### PR TITLE
fix: trim delimiters from bare chat links

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
@@ -108,6 +108,39 @@ private val imageAttachmentMarkerPattern = Regex(
 private const val MESSAGE_RENDER_CHUNK_CHARS = 4_000
 private const val MIN_EMBEDDED_PAYLOAD_CHARS = 512
 private val webUrlPrefixes = listOf("https://", "http://")
+private val pairedWebUrlDelimiters = listOf(
+    '(' to ')',
+    '[' to ']',
+    '{' to '}',
+    '<' to '>',
+)
+
+private fun trimBareWebUrlEnd(text: String, start: Int, scannedEnd: Int): Int {
+    val delimiterBalances = pairedWebUrlDelimiters.associate { (_, close) -> close to 0 }.toMutableMap()
+    for (index in start until scannedEnd) {
+        val character = text[index]
+        pairedWebUrlDelimiters.forEach { (open, close) ->
+            when (character) {
+                open -> delimiterBalances[close] = delimiterBalances.getValue(close) - 1
+                close -> delimiterBalances[close] = delimiterBalances.getValue(close) + 1
+            }
+        }
+    }
+
+    var end = scannedEnd
+    while (end > start) {
+        val trailing = text[end - 1]
+        when {
+            trailing in ".,;:!?\"'" -> end -= 1
+            delimiterBalances.getOrDefault(trailing, 0) > 0 -> {
+                delimiterBalances[trailing] = delimiterBalances.getValue(trailing) - 1
+                end -= 1
+            }
+            else -> return end
+        }
+    }
+    return end
+}
 
 private fun splitMarkdownTableRow(line: String): List<String>? {
     val trimmed = line.trim()
@@ -418,7 +451,7 @@ private fun parseMarkdownInlines(text: String, inherited: InlineState = InlineSt
         if (inherited.link == null && webUrlPrefix != null) {
             var end = index + webUrlPrefix.length
             while (end < text.length && !text[end].isWhitespace()) end += 1
-            while (end > index && text[end - 1] in ".,;:!?") end -= 1
+            end = trimBareWebUrlEnd(text, index, end)
             if (end > index + webUrlPrefix.length) {
                 flushPlain()
                 val url = text.substring(index, end)

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
@@ -195,6 +195,28 @@ class MessageMarkdownTest {
     }
 
     @Test
+    fun trimsUnmatchedPairedDelimitersFromBareUrls() {
+        val block = parseMessageMarkdown(
+            "See (https://example.com/docs), \"https://example.com/quoted\", " +
+                "[https://example.com/square], {https://example.com/curly}, " +
+                "<https://example.com/angle>, and " +
+                "https://en.wikipedia.org/wiki/Function_(mathematics).",
+        ).single() as MarkdownTextBlock
+
+        assertEquals(
+            listOf(
+                "https://example.com/docs",
+                "https://example.com/quoted",
+                "https://example.com/square",
+                "https://example.com/curly",
+                "https://example.com/angle",
+                "https://en.wikipedia.org/wiki/Function_(mathematics)",
+            ),
+            block.inlines.mapNotNull { it.link },
+        )
+    }
+
+    @Test
     fun preservesUnmatchedInlineMarkersAndTreatsStreamingFenceAsCode() {
         val unmatched = parseMessageMarkdown("Keep **unfinished and `partial")
             .single() as MarkdownTextBlock


### PR DESCRIPTION
## Summary
- trim unmatched closing parentheses, brackets, braces, angle brackets, and quotes from bare chat URLs
- preserve balanced delimiters that are genuinely part of a URL
- add regression coverage for each delimiter and a balanced Wikipedia-style URL

## Context
Follow-up to #2, which merged immediately before the review finding was posted. Addresses [discussion_r3786684379](https://github.com/unsupportedpastels/hermes-android/pull/2#discussion_r3786684379).

## Test plan
- [x] `./gradlew testDebugUnitTest lintDebug assembleDebug`
- [x] `git diff --check`