### PR TITLE
fix: preserve apostrophes in bare chat links

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
@@ -115,8 +115,19 @@ private val pairedWebUrlDelimiters = listOf(
     '<' to '>',
 )
 
+private fun surroundingWebUrlQuote(text: String, start: Int): Char? {
+    var precedingIndex = start - 1
+    while (
+        precedingIndex >= 0 &&
+        pairedWebUrlDelimiters.any { (open, _) -> text[precedingIndex] == open }
+    ) {
+        precedingIndex -= 1
+    }
+    return text.getOrNull(precedingIndex)?.takeIf { it == '\'' || it == '"' }
+}
+
 private fun trimBareWebUrlEnd(text: String, start: Int, scannedEnd: Int): Int {
-    val surroundingQuote = text.getOrNull(start - 1)?.takeIf { it == '\'' || it == '"' }
+    val surroundingQuote = surroundingWebUrlQuote(text, start)
     val delimiterBalances = pairedWebUrlDelimiters.associate { (_, close) -> close to 0 }.toMutableMap()
     for (index in start until scannedEnd) {
         val character = text[index]

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
@@ -116,6 +116,7 @@ private val pairedWebUrlDelimiters = listOf(
 )
 
 private fun trimBareWebUrlEnd(text: String, start: Int, scannedEnd: Int): Int {
+    val surroundingQuote = text.getOrNull(start - 1)?.takeIf { it == '\'' || it == '"' }
     val delimiterBalances = pairedWebUrlDelimiters.associate { (_, close) -> close to 0 }.toMutableMap()
     for (index in start until scannedEnd) {
         val character = text[index]
@@ -131,7 +132,8 @@ private fun trimBareWebUrlEnd(text: String, start: Int, scannedEnd: Int): Int {
     while (end > start) {
         val trailing = text[end - 1]
         when {
-            trailing in ".,;:!?\"'" -> end -= 1
+            trailing in ".,;:!?" -> end -= 1
+            trailing == surroundingQuote -> end -= 1
             delimiterBalances.getOrDefault(trailing, 0) > 0 -> {
                 delimiterBalances[trailing] = delimiterBalances.getValue(trailing) - 1
                 end -= 1

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
@@ -198,19 +198,23 @@ class MessageMarkdownTest {
     fun trimsUnmatchedPairedDelimitersFromBareUrls() {
         val block = parseMessageMarkdown(
             "See (https://example.com/docs), \"https://example.com/quoted\", " +
+                "'https://example.com/single-quoted', " +
                 "[https://example.com/square], {https://example.com/curly}, " +
                 "<https://example.com/angle>, and " +
-                "https://en.wikipedia.org/wiki/Function_(mathematics).",
+                "https://en.wikipedia.org/wiki/Function_(mathematics), plus " +
+                "https://example.com/wiki/Readers'.",
         ).single() as MarkdownTextBlock
 
         assertEquals(
             listOf(
                 "https://example.com/docs",
                 "https://example.com/quoted",
+                "https://example.com/single-quoted",
                 "https://example.com/square",
                 "https://example.com/curly",
                 "https://example.com/angle",
                 "https://en.wikipedia.org/wiki/Function_(mathematics)",
+                "https://example.com/wiki/Readers'",
             ),
             block.inlines.mapNotNull { it.link },
         )

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
@@ -199,6 +199,7 @@ class MessageMarkdownTest {
         val block = parseMessageMarkdown(
             "See (https://example.com/docs), \"https://example.com/quoted\", " +
                 "'https://example.com/single-quoted', " +
+                "\"(https://example.com/nested)\", " +
                 "[https://example.com/square], {https://example.com/curly}, " +
                 "<https://example.com/angle>, and " +
                 "https://en.wikipedia.org/wiki/Function_(mathematics), plus " +
@@ -210,6 +211,7 @@ class MessageMarkdownTest {
                 "https://example.com/docs",
                 "https://example.com/quoted",
                 "https://example.com/single-quoted",
+                "https://example.com/nested",
                 "https://example.com/square",
                 "https://example.com/curly",
                 "https://example.com/angle",


### PR DESCRIPTION
## Summary
- preserve valid trailing apostrophes in bare URL paths
- trim single or double quotes only when they actually surround the URL
- retain the existing delimiter and balanced-parenthesis behavior

## Context
Follow-up to #3, which merged immediately before its review finding was posted. Addresses [discussion_r3786719610](https://github.com/unsupportedpastels/hermes-android/pull/3#discussion_r3786719610).

## Test plan
- [x] focused RED/GREEN URL delimiter regression
- [x] `./gradlew testDebugUnitTest lintDebug assembleDebug`
- [x] `git diff --check`