### PR TITLE
chore: group Dependabot version updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,21 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      gradle-non-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      actions:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Groups Dependabot version-update PRs so routine dependency bumps arrive as one weekly PR per ecosystem instead of one PR per package:

- **Gradle**: minor and patch updates are grouped (`gradle-non-major`); major updates still open individual PRs for separate review.
- **GitHub Actions**: all action version bumps are grouped into a single PR.

Security-driven updates are unaffected — those are handled by the repo's "Grouped security updates" setting.

## Hermes compatibility

N/A — repository configuration only (`.github/dependabot.yml`); no app or server-facing changes.

## Verification

- [ ] `./gradlew testDebugUnitTest lintDebug assembleDebug` — N/A, no code changes
- [ ] `./gradlew validateDebugScreenshotTest` (when UI/reference changes apply) — N/A
- [ ] I checked compact, medium, and expanded layouts (when adaptive UI changes apply). — N/A
- [x] I did not add credentials, cookies, tickets, server addresses, prompts, transcripts, attachments, signing material, or generated build output.

## Screenshots

N/A — no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)