### PR TITLE
fix(chat): correlate approval responses by request ID

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -1761,7 +1761,7 @@ class HermesConnectionViewModel(
                     HermesChatResponseStatus.Unknown,
                     -> RunInteractionLifecycle.Failed
                 }
-                publishApprovalResponse(operation, lifecycle)
+                publishApprovalResponse(operation, lifecycle, response.nextApproval)
                 if (lifecycle == RunInteractionLifecycle.Failed) {
                     publishApprovalError(operation)
                 }
@@ -3754,6 +3754,7 @@ class HermesConnectionViewModel(
     private fun publishApprovalResponse(
         operation: ControllerOperation,
         lifecycle: RunInteractionLifecycle,
+        nextApproval: HermesChatEvent.ApprovalRequest? = null,
     ) {
         synchronized(controllerLock) {
             if (!isCurrentControllerOperation(operation)) return
@@ -3766,15 +3767,24 @@ class HermesConnectionViewModel(
                 current.choices != operation.advertisedChoices ||
                 current.lifecycle != RunInteractionLifecycle.Responding
             ) return
+            val transitionedRunState = chat.runState.transitionApprovalLifecycle(
+                operation.runtimeSessionId,
+                operation.requestId,
+                lifecycle,
+            )
+            val nextRunState = if (
+                lifecycle != RunInteractionLifecycle.Failed &&
+                nextApproval?.sessionId == operation.runtimeSessionId
+            ) {
+                transitionedRunState.reduce(nextApproval)
+            } else {
+                transitionedRunState
+            }
             mutableSnapshots.value = snapshot.copy(
                 chatSessions = snapshot.chatSessions + (
                     operation.durableSessionId to chat.copy(
                         error = null,
-                        runState = chat.runState.transitionApprovalLifecycle(
-                            operation.runtimeSessionId,
-                            operation.requestId,
-                            lifecycle,
-                        ),
+                        runState = nextRunState,
                     )
                     ),
             )

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -1746,9 +1746,10 @@ class HermesConnectionViewModel(
         return viewModelScope.launch {
             try {
                 val response = operation.session.respondToApproval(
-                    operation.runtimeSessionId,
-                    choice,
-                    all,
+                    runtimeSessionId = operation.runtimeSessionId,
+                    choice = choice,
+                    all = all,
+                    requestId = operation.requestId,
                 )
                 currentCoroutineContext().ensureActive()
                 val lifecycle = when (response.status) {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
@@ -484,6 +484,7 @@ interface HermesChatSession {
         runtimeSessionId: RuntimeSessionId,
         choice: String,
         all: Boolean = false,
+        requestId: String? = null,
     ): HermesChatResponse = throw HermesChatProtocolException("Approval response is not available")
 
     suspend fun interruptSession(
@@ -823,11 +824,20 @@ class HermesChatConnection internal constructor(
         runtimeSessionId: RuntimeSessionId,
         choice: String,
         all: Boolean,
+        requestId: String?,
     ): HermesChatResponse {
         val boundedChoice = boundedRpcInput(choice, HERMES_CHAT_MAX_EVENT_CHOICE_CHARS, "approval choice")
         val sessionKey = boundedRpcInput(runtimeSessionId.value, HERMES_CHAT_MAX_EVENT_ID_CHARS, "runtime session ID")
+        val boundedRequestId = requestId?.let {
+            boundedRpcInput(it, HERMES_CHAT_MAX_EVENT_ID_CHARS, "request ID")
+        }
         synchronized(interactionLock) {
-            val pending = pendingApprovals[sessionKey]?.peekFirst()
+            val queue = pendingApprovals[sessionKey]
+            val pending = if (boundedRequestId == null) {
+                queue?.peekFirst()
+            } else {
+                queue?.firstOrNull { it.requestId == boundedRequestId }
+            }
                 ?: throw HermesChatProtocolException("No pending approval choices for this session")
             if (boundedChoice !in pending.choices) {
                 throw HermesChatProtocolException("Approval choice was not advertised")
@@ -835,13 +845,19 @@ class HermesChatConnection internal constructor(
         }
         val params = buildJsonObject {
             put("session_id", sessionKey)
+            boundedRequestId?.let { put("request_id", it) }
             put("choice", boundedChoice)
             put("all", all)
         }
         val response = parseInteractionResponse(request("approval.respond", params))
         synchronized(interactionLock) {
             val queue = pendingApprovals[sessionKey]
-            if (queue != null && queue.isNotEmpty()) queue.removeFirst()
+            when {
+                queue == null -> Unit
+                all -> queue.clear()
+                boundedRequestId != null -> queue.removeIf { it.requestId == boundedRequestId }
+                queue.isNotEmpty() -> queue.removeFirst()
+            }
             if (queue == null || queue.isEmpty()) pendingApprovals.remove(sessionKey)
         }
         return response
@@ -862,6 +878,7 @@ class HermesChatConnection internal constructor(
     private fun parseInteractionResponse(result: JsonObject): HermesChatResponse {
         val wireStatus = result.stringValue("status")
             ?: result.booleanValue("resolved")?.let { resolved -> if (resolved) "ok" else "expired" }
+            ?: result.longValue("resolved")?.let { resolved -> if (resolved > 0) "ok" else "expired" }
             ?: throw HermesChatProtocolException("Hermes interaction response was incomplete")
         return HermesChatResponse(HermesChatResponseStatus.fromWire(wireStatus))
     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
@@ -164,6 +164,7 @@ enum class HermesChatResponseStatus {
 
 data class HermesChatResponse(
     val status: HermesChatResponseStatus,
+    val nextApproval: HermesChatEvent.ApprovalRequest? = null,
 )
 
 /**
@@ -579,8 +580,19 @@ class HermesChatGateway(
 
 private data class PendingApproval(
     val requestId: String?,
+    val command: String?,
+    val description: String?,
     val choices: List<String>,
-)
+) {
+    fun toEvent(sessionId: RuntimeSessionId): HermesChatEvent.ApprovalRequest =
+        HermesChatEvent.ApprovalRequest(
+            sessionId = sessionId,
+            requestId = requestId,
+            command = command,
+            description = description,
+            choices = choices,
+        )
+}
 
 class HermesChatConnection internal constructor(
     private val socket: HermesChatSocket,
@@ -834,7 +846,7 @@ class HermesChatConnection internal constructor(
         synchronized(interactionLock) {
             val queue = pendingApprovals[sessionKey]
             val pending = if (boundedRequestId == null) {
-                queue?.peekFirst()
+                queue?.peekLast()
             } else {
                 queue?.firstOrNull { it.requestId == boundedRequestId }
             }
@@ -850,17 +862,25 @@ class HermesChatConnection internal constructor(
             put("all", all)
         }
         val response = parseInteractionResponse(request("approval.respond", params))
-        synchronized(interactionLock) {
+        val nextApproval = synchronized(interactionLock) {
             val queue = pendingApprovals[sessionKey]
-            when {
-                queue == null -> Unit
-                all -> queue.clear()
-                boundedRequestId != null -> queue.removeIf { it.requestId == boundedRequestId }
-                queue.isNotEmpty() -> queue.removeFirst()
+            if (response.status in setOf(
+                    HermesChatResponseStatus.Ok,
+                    HermesChatResponseStatus.Resolved,
+                    HermesChatResponseStatus.Expired,
+                )
+            ) {
+                when {
+                    queue == null -> Unit
+                    all -> queue.clear()
+                    boundedRequestId != null -> queue.removeIf { it.requestId == boundedRequestId }
+                    queue.isNotEmpty() -> queue.removeLast()
+                }
             }
             if (queue == null || queue.isEmpty()) pendingApprovals.remove(sessionKey)
+            queue?.peekLast()?.toEvent(runtimeSessionId)
         }
-        return response
+        return response.copy(nextApproval = nextApproval)
     }
 
     override suspend fun interruptSession(
@@ -1354,7 +1374,14 @@ class HermesChatConnection internal constructor(
                     )
                     synchronized(interactionLock) {
                         pendingApprovals.getOrPut(sessionId.value) { ArrayDeque() }
-                            .addLast(PendingApproval(approval.requestId, choices))
+                            .addLast(
+                                PendingApproval(
+                                    requestId = approval.requestId,
+                                    command = approval.command,
+                                    description = approval.description,
+                                    choices = choices,
+                                ),
+                            )
                     }
                     approval
                 }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
@@ -1294,6 +1294,7 @@ class HermesChatIntegrationTest {
             listOf(Triple(session.runtimeSessionId, "allow", true)),
             session.approvalCalls,
         )
+        assertEquals(listOf("approval-1"), session.approvalRequestIds)
         assertEquals(
             RunInteractionLifecycle.Responding,
             viewModel.snapshots.value.chatSessions.getValue(durableId).runState.approval?.lifecycle,
@@ -2741,6 +2742,7 @@ private class ControllerChatSession(
     override val events: Flow<HermesChatEvent> = channel.receiveAsFlow()
     val clarificationCalls = mutableListOf<Pair<String, String>>()
     val approvalCalls = mutableListOf<Triple<RuntimeSessionId, String, Boolean>>()
+    val approvalRequestIds = mutableListOf<String?>()
     val interruptCalls = mutableListOf<RuntimeSessionId>()
     val steerCalls = mutableListOf<Pair<RuntimeSessionId, String>>()
     val usageCalls = mutableListOf<RuntimeSessionId>()
@@ -2792,8 +2794,10 @@ private class ControllerChatSession(
         runtimeSessionId: RuntimeSessionId,
         choice: String,
         all: Boolean,
+        requestId: String?,
     ): HermesChatResponse {
         approvalCalls += Triple(runtimeSessionId, choice, all)
+        approvalRequestIds += requestId
         return if (approvalNonCooperative) {
             withContext(NonCancellable) { approvalResponse.await() }
         } else {

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
@@ -1311,6 +1311,50 @@ class HermesChatIntegrationTest {
     }
 
     @Test
+    fun approvalControllerPromotesTheNextQueuedApprovalAfterResolvingTheLatest() = runTest(dispatcher) {
+        val session = ControllerChatSession()
+        val viewModel = chatViewModel(session)
+        advanceUntilIdle()
+
+        viewModel.openSession(durableId)
+        advanceUntilIdle()
+        val firstApproval = HermesChatEvent.ApprovalRequest(
+            sessionId = session.runtimeSessionId,
+            requestId = "approval-1",
+            command = "first command",
+            description = "First approval",
+            choices = listOf("once", "deny"),
+        )
+        session.emit(firstApproval)
+        session.emit(
+            HermesChatEvent.ApprovalRequest(
+                sessionId = session.runtimeSessionId,
+                requestId = "approval-2",
+                command = "second command",
+                description = "Second approval",
+                choices = listOf("session", "deny"),
+            ),
+        )
+        advanceUntilIdle()
+
+        val response = viewModel.respondToApproval(durableId, "session")
+        runCurrent()
+        session.approvalResponse.complete(
+            HermesChatResponse(
+                status = HermesChatResponseStatus.Ok,
+                nextApproval = firstApproval,
+            ),
+        )
+        response.join()
+
+        val promoted = viewModel.snapshots.value.chatSessions.getValue(durableId).runState.approval
+        assertEquals("approval-1", promoted?.requestId)
+        assertEquals("First approval", promoted?.descriptionPreview)
+        assertEquals(listOf("once", "deny"), promoted?.choices)
+        assertEquals(RunInteractionLifecycle.Pending, promoted?.lifecycle)
+    }
+
+    @Test
     fun stopControllerTargetsSendingRuntimeOnceAndTerminalizesLiveInteractionsWithoutClosingSocket() = runTest(dispatcher) {
         val session = ControllerChatSession()
         val viewModel = chatViewModel(session)

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayTest.kt
@@ -871,6 +871,53 @@ class HermesChatGatewayTest {
     }
 
     @Test
+    fun approvalResponseTargetsTheDisplayedQueuedRequestById() = runTest {
+        val socket = ScriptedSocket()
+        socket.onSend = { frame ->
+            val request = Json.parseToJsonElement(frame).jsonObject
+            socket.offer(
+                """{"jsonrpc":"2.0","id":${request["id"]!!.jsonPrimitive.content},"result":{"resolved":1}}""",
+            )
+        }
+        val connection = HermesChatGateway(
+            origin = ServerOrigin.parse("https://hermes.example"),
+            accessToken = "opaque-access",
+            ticketClient = RecordingTicketClient("ticket-1"),
+            socketFactory = RecordingSocketFactory(socket),
+            parentScope = backgroundScope,
+        ).connect()
+
+        socket.offer(
+            """{"jsonrpc":"2.0","method":"event","params":{"type":"approval.request","session_id":"runtime-1","payload":{"request_id":"approval-1","choices":["once","deny"],"description":"first"}}}""",
+        )
+        socket.offer(
+            """{"jsonrpc":"2.0","method":"event","params":{"type":"approval.request","session_id":"runtime-1","payload":{"request_id":"approval-2","choices":["session","deny"],"description":"second"}}}""",
+        )
+        val approvals = connection.events.take(2).toList()
+        assertEquals("approval-2", (approvals.last() as HermesChatEvent.ApprovalRequest).requestId)
+
+        val response = connection.respondToApproval(
+            runtimeSessionId = RuntimeSessionId("runtime-1"),
+            requestId = "approval-2",
+            choice = "session",
+            all = false,
+        )
+
+        val request = Json.parseToJsonElement(socket.sentFrames.single()).jsonObject
+        assertEquals(
+            mapOf(
+                "session_id" to "runtime-1",
+                "request_id" to "approval-2",
+                "choice" to "session",
+                "all" to "false",
+            ),
+            request["params"]!!.jsonObject.mapValues { it.value.jsonPrimitive.content },
+        )
+        assertEquals(HermesChatResponseStatus.Ok, response.status)
+        connection.close()
+    }
+
+    @Test
     fun rejectsOversizedRuntimeIdentityBeforeInterruptRequestIsSent() = runTest {
         val socket = ScriptedSocket()
         socket.onSend = { frame ->

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayTest.kt
@@ -914,6 +914,9 @@ class HermesChatGatewayTest {
             request["params"]!!.jsonObject.mapValues { it.value.jsonPrimitive.content },
         )
         assertEquals(HermesChatResponseStatus.Ok, response.status)
+        assertEquals("approval-1", response.nextApproval?.requestId)
+        assertEquals("first", response.nextApproval?.description)
+        assertEquals(listOf("once", "deny"), response.nextApproval?.choices)
         connection.close()
     }
 


### PR DESCRIPTION
## Summary
- target approval responses at the exact queued request shown in the UI
- accept the gateway's numeric `resolved` response shape
- clear only the matched approval, or the full queue for approve-all
- carry the approval request ID through the ViewModel

## Test plan
- [x] focused queued-approval gateway regression test
- [x] focused approval controller integration test
- [x] `./gradlew testDebugUnitTest lintDebug assembleDebug validateDebugScreenshotTest`
- [x] `git diff --check`