### PR TITLE
feat(android): add device voice input

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -23,6 +23,8 @@ Host-file contents are downloaded only after an explicit preview, play, save, or
 
 HAM sends data only to the Hermes server origin you configure in the app. HAM does **not** operate a shared hosted backend and does not include analytics, advertising, tracking, or telemetry SDKs.
 
+When you explicitly choose **Voice input**, HAM opens an installed Android speech-recognition activity. That service may capture and process audio under its own privacy policy; HAM receives only the recognized text and does not store the recording.
+
 Your chosen server’s operator and configuration determine how server-side data is processed, retained, logged, and secured. Review that server’s policies before connecting, especially if it is operated by someone else.
 
 ## Android permissions
@@ -31,7 +33,7 @@ Your chosen server’s operator and configuration determine how server-side data
 - **Notifications** — optional alerts for completed turns and requests requiring your attention.
 - **Foreground service / data sync** — maintain truthful, visible status while an active HAM-started turn is running.
 
-HAM does not request location, contacts, camera, microphone, or storage-wide file permissions. Attachments use Android’s user-mediated document picker.
+HAM does not request location, contacts, camera, microphone, or storage-wide file permissions. Attachments use Android’s user-mediated document picker. Voice input is provided by an installed Android speech service, which may request microphone access in its own interface.
 
 ## Security
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,12 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
+    <queries>
+        <intent>
+            <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
@@ -127,6 +127,7 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Psychology
 import androidx.compose.material.icons.outlined.Speed
 import androidx.compose.runtime.Composable
@@ -257,6 +258,8 @@ import com.unsupportedpastels.hermesandroid.session.toggleBulkSelection
 import com.unsupportedpastels.hermesandroid.share.SharePayload
 import com.unsupportedpastels.hermesandroid.theme.HermesAndroidTheme
 import com.unsupportedpastels.hermesandroid.theme.LocalHermesSemanticColors
+import com.unsupportedpastels.hermesandroid.voice.DeviceVoiceInputContract
+import com.unsupportedpastels.hermesandroid.voice.VoiceInputPolicy
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
@@ -849,6 +852,7 @@ fun HermesApp(
                     SessionDetailScreen(
                         session = session,
                         chat = chat,
+                        voiceInputScopeKey = draftKey,
                         draft = drafts[draftKey].orEmpty(),
                         onDraftChanged = { updated ->
                             drafts[draftKey] = updated
@@ -4120,6 +4124,7 @@ internal fun isTranscriptAtTrueEnd(
 private fun SessionDetailScreen(
     session: SessionSummary,
     chat: ChatSessionSnapshot,
+    voiceInputScopeKey: String,
     draft: String,
     onDraftChanged: (String) -> Unit,
     canSend: Boolean,
@@ -4183,6 +4188,18 @@ private fun SessionDetailScreen(
         workspacePath == null
     var attachmentError by remember(session.id) { mutableStateOf<String?>(null) }
     var pendingSend by remember(session.id) { mutableStateOf<Pair<String, Int>?>(null) }
+    var pendingVoiceInputScopeKey by rememberSaveable { mutableStateOf<String?>(null) }
+    val currentVoiceInputScopeKey by rememberUpdatedState(voiceInputScopeKey)
+    val currentDraft by rememberUpdatedState(draft)
+    val currentOnDraftChanged by rememberUpdatedState(onDraftChanged)
+    val voiceInputAvailable = remember(context) { DeviceVoiceInputContract.isAvailable(context) }
+    val voiceInputLauncher = rememberLauncherForActivityResult(DeviceVoiceInputContract()) { recognized ->
+        val targetScopeKey = pendingVoiceInputScopeKey
+        pendingVoiceInputScopeKey = null
+        if (recognized != null && targetScopeKey == currentVoiceInputScopeKey) {
+            currentOnDraftChanged(VoiceInputPolicy.mergeDraft(currentDraft, recognized))
+        }
+    }
     val attachmentPicker = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenMultipleDocuments(),
     ) { uris ->
@@ -4654,6 +4671,24 @@ private fun SessionDetailScreen(
                                     showHostFiles = true
                                 },
                             )
+                            if (voiceInputAvailable) {
+                                DropdownMenuItem(
+                                    text = { Text("Voice input") },
+                                    leadingIcon = {
+                                        Icon(Icons.Outlined.Mic, contentDescription = null)
+                                    },
+                                    onClick = {
+                                        attachmentMenuOpen = false
+                                        attachmentError = null
+                                        pendingVoiceInputScopeKey = voiceInputScopeKey
+                                        runCatching { voiceInputLauncher.launch(Unit) }
+                                            .onFailure {
+                                                pendingVoiceInputScopeKey = null
+                                                attachmentError = "Voice input is unavailable"
+                                            }
+                                    },
+                                )
+                            }
                         }
                     }
                     BasicTextField(

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
@@ -852,7 +852,11 @@ fun HermesApp(
                     SessionDetailScreen(
                         session = session,
                         chat = chat,
-                        voiceInputScopeKey = draftKey,
+                        voiceInputScopeKey = VoiceInputPolicy.scopeKey(
+                            serverOrigin = serverOrigin?.value,
+                            profile = snapshot.selectedProfile,
+                            durableSessionId = session.id.value,
+                        ),
                         draft = drafts[draftKey].orEmpty(),
                         onDraftChanged = { updated ->
                             drafts[draftKey] = updated

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceVoiceInputContract.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceVoiceInputContract.kt
@@ -1,0 +1,32 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.speech.RecognizerIntent
+import androidx.activity.result.contract.ActivityResultContract
+
+internal class DeviceVoiceInputContract : ActivityResultContract<Unit, String?>() {
+    override fun createIntent(context: Context, input: Unit): Intent = recognitionIntent()
+
+    override fun parseResult(resultCode: Int, intent: Intent?): String? {
+        if (resultCode != Activity.RESULT_OK) return null
+        return VoiceInputPolicy.bestResult(
+            intent?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS),
+        )
+    }
+
+    companion object {
+        fun isAvailable(context: Context): Boolean =
+            recognitionIntent().resolveActivity(context.packageManager) != null
+
+        private fun recognitionIntent(): Intent =
+            Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                putExtra(
+                    RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                    RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
+                )
+                putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 3)
+            }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicy.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicy.kt
@@ -3,7 +3,18 @@ package com.unsupportedpastels.hermesandroid.voice
 internal object VoiceInputPolicy {
     const val MAX_RESULT_CHARS = 4_096
 
-    fun bestResult(results: List<String>?): String? = null
+    fun bestResult(results: List<String>?): String? = results
+        ?.asSequence()
+        ?.map { it.trim() }
+        ?.firstOrNull(String::isNotEmpty)
+        ?.take(MAX_RESULT_CHARS)
 
-    fun mergeDraft(current: String, recognized: String): String = current
+    fun mergeDraft(current: String, recognized: String): String {
+        val bounded = recognized.trim().take(MAX_RESULT_CHARS)
+        return when {
+            bounded.isEmpty() -> current
+            current.isEmpty() || current.last().isWhitespace() -> current + bounded
+            else -> "$current $bounded"
+        }
+    }
 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicy.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicy.kt
@@ -1,0 +1,9 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+internal object VoiceInputPolicy {
+    const val MAX_RESULT_CHARS = 4_096
+
+    fun bestResult(results: List<String>?): String? = null
+
+    fun mergeDraft(current: String, recognized: String): String = current
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicy.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicy.kt
@@ -3,6 +3,13 @@ package com.unsupportedpastels.hermesandroid.voice
 internal object VoiceInputPolicy {
     const val MAX_RESULT_CHARS = 4_096
 
+    fun scopeKey(
+        serverOrigin: String?,
+        profile: String,
+        durableSessionId: String,
+    ): String = listOf(serverOrigin.orEmpty(), profile, durableSessionId)
+        .joinToString("|") { value -> "${value.length}:$value" }
+
     fun bestResult(results: List<String>?): String? = results
         ?.asSequence()
         ?.map { it.trim() }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/VoiceInputUiTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/VoiceInputUiTest.kt
@@ -1,0 +1,145 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.ResolveInfo
+import android.speech.RecognizerIntent
+import androidx.activity.compose.LocalActivityResultRegistryOwner
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNode
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.core.app.ActivityOptionsCompat
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.unsupportedpastels.hermesandroid.app.DurableSessionId
+import com.unsupportedpastels.hermesandroid.app.SessionSummary
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import com.unsupportedpastels.hermesandroid.connection.ServerSettingsState
+import com.unsupportedpastels.hermesandroid.gateway.AuthenticationState
+import com.unsupportedpastels.hermesandroid.gateway.ConnectionState
+import com.unsupportedpastels.hermesandroid.gateway.HermesGatewaySnapshot
+import com.unsupportedpastels.hermesandroid.navigation.SessionDetailRoute
+import com.unsupportedpastels.hermesandroid.theme.HermesAndroidTheme
+import com.unsupportedpastels.hermesandroid.voice.DeviceVoiceInputContract
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class VoiceInputUiTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun staleProfileResultIsDiscardedWhileCurrentResultUpdatesDraft() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        shadowOf(context.packageManager).addResolveInfoForIntent(
+            DeviceVoiceInputContract().createIntent(context, Unit),
+            ResolveInfo().apply {
+                activityInfo = ActivityInfo().apply {
+                    packageName = "test.speech.service"
+                    name = "SpeechActivity"
+                }
+            },
+        )
+        val registry = RecordingActivityResultRegistry()
+        val registryOwner = object : ActivityResultRegistryOwner {
+            override val activityResultRegistry: ActivityResultRegistry = registry
+        }
+        val sessionId = DurableSessionId("voice-session")
+        var snapshot by mutableStateOf(
+            HermesGatewaySnapshot(
+                connectionState = ConnectionState.Connected,
+                authenticationState = AuthenticationState.Authenticated,
+                durableSessions = listOf(SessionSummary(sessionId, "Voice session")),
+                selectedProfile = "default",
+            ),
+        )
+
+        composeRule.setContent {
+            CompositionLocalProvider(LocalActivityResultRegistryOwner provides registryOwner) {
+                HermesAndroidTheme {
+                    HermesApp(
+                        snapshot = snapshot,
+                        initialRoute = SessionDetailRoute(sessionId),
+                        serverSettingsState = ServerSettingsState.Ready(
+                            ServerOrigin.parse("https://hermes.example"),
+                        ),
+                    )
+                }
+            }
+        }
+
+        launchVoiceInput()
+        composeRule.runOnIdle {
+            snapshot = snapshot.copy(selectedProfile = "work")
+        }
+        composeRule.runOnIdle {
+            registry.dispatchRecognition("stale default-profile text")
+        }
+        assertComposerText("")
+
+        launchVoiceInput()
+        composeRule.runOnIdle {
+            registry.dispatchRecognition("current work-profile text")
+        }
+        assertComposerText("current work-profile text")
+    }
+
+    private fun launchVoiceInput() {
+        composeRule.onNodeWithContentDescription("Attach files").performClick()
+        composeRule.onNodeWithText("Voice input").performClick()
+    }
+
+    private fun assertComposerText(expected: String) {
+        val composer = hasAnyAncestor(hasTestTag("Message composer"))
+        val text = composeRule.onNode(hasSetTextAction().and(composer))
+            .fetchSemanticsNode()
+            .config[SemanticsProperties.InputText]
+            .text
+        assertEquals(expected, text)
+    }
+
+    private class RecordingActivityResultRegistry : ActivityResultRegistry() {
+        private var requestCode: Int? = null
+
+        override fun <I, O> onLaunch(
+            requestCode: Int,
+            contract: ActivityResultContract<I, O>,
+            input: I,
+            options: ActivityOptionsCompat?,
+        ) {
+            this.requestCode = requestCode
+        }
+
+        fun dispatchRecognition(text: String) {
+            dispatchResult(
+                checkNotNull(requestCode) { "Voice input was not launched" },
+                Activity.RESULT_OK,
+                Intent().putStringArrayListExtra(
+                    RecognizerIntent.EXTRA_RESULTS,
+                    arrayListOf(text),
+                ),
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/VoiceInputUiTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/VoiceInputUiTest.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.v2.createComposeRule
-import androidx.compose.ui.test.onNode
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DeviceVoiceInputContractTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DeviceVoiceInputContractTest.kt
@@ -1,0 +1,81 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import android.speech.RecognizerIntent
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class DeviceVoiceInputContractTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val contract = DeviceVoiceInputContract()
+
+    @Test
+    fun createsGenericFreeFormRecognitionIntent() {
+        val intent = contract.createIntent(context, Unit)
+
+        assertEquals(RecognizerIntent.ACTION_RECOGNIZE_SPEECH, intent.action)
+        assertEquals(
+            RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
+            intent.getStringExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL),
+        )
+        assertEquals(3, intent.getIntExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 0))
+        assertNull(intent.component)
+        assertNull(intent.`package`)
+    }
+
+    @Test
+    fun returnsTextOnlyForSuccessfulRecognition() {
+        val result = Intent().putStringArrayListExtra(
+            RecognizerIntent.EXTRA_RESULTS,
+            arrayListOf("  draft from speech  "),
+        )
+
+        assertEquals("draft from speech", contract.parseResult(Activity.RESULT_OK, result))
+        assertNull(contract.parseResult(Activity.RESULT_CANCELED, result))
+        assertNull(contract.parseResult(Activity.RESULT_OK, null))
+    }
+
+    @Test
+    fun reportsAvailabilityOnlyWhenADeviceHandlerExists() {
+        assertFalse(DeviceVoiceInputContract.isAvailable(context))
+
+        shadowOf(context.packageManager).addResolveInfoForIntent(
+            contract.createIntent(context, Unit),
+            ResolveInfo().apply {
+                activityInfo = ActivityInfo().apply {
+                    packageName = "test.speech.service"
+                    name = "SpeechActivity"
+                }
+            },
+        )
+
+        assertTrue(DeviceVoiceInputContract.isAvailable(context))
+    }
+
+    @Test
+    fun appDoesNotRequestMicrophonePermission() {
+        @Suppress("DEPRECATION")
+        val permissions = context.packageManager.getPackageInfo(
+            context.packageName,
+            PackageManager.GET_PERMISSIONS,
+        ).requestedPermissions.orEmpty()
+
+        assertFalse(Manifest.permission.RECORD_AUDIO in permissions)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicyTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicyTest.kt
@@ -1,0 +1,34 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class VoiceInputPolicyTest {
+    @Test
+    fun selectsFirstNonBlankResultAndTrimsIt() {
+        assertEquals(
+            "Send the release notes",
+            VoiceInputPolicy.bestResult(listOf("   ", "  Send the release notes  ", "ignored")),
+        )
+        assertNull(VoiceInputPolicy.bestResult(null))
+        assertNull(VoiceInputPolicy.bestResult(listOf("", "  ")))
+    }
+
+    @Test
+    fun boundsUntrustedRecognizerText() {
+        val result = VoiceInputPolicy.bestResult(
+            listOf("a".repeat(VoiceInputPolicy.MAX_RESULT_CHARS + 32)),
+        )
+
+        assertEquals(VoiceInputPolicy.MAX_RESULT_CHARS, result?.length)
+    }
+
+    @Test
+    fun appendsRecognitionWithoutOverwritingTheDraft() {
+        assertEquals("new words", VoiceInputPolicy.mergeDraft("", "new words"))
+        assertEquals("existing new words", VoiceInputPolicy.mergeDraft("existing", "new words"))
+        assertEquals("existing\nnew words", VoiceInputPolicy.mergeDraft("existing\n", "new words"))
+        assertEquals("existing", VoiceInputPolicy.mergeDraft("existing", "   "))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicyTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicyTest.kt
@@ -1,10 +1,25 @@
 package com.unsupportedpastels.hermesandroid.voice
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 class VoiceInputPolicyTest {
+    @Test
+    fun scopesPendingResultsByOriginProfileAndDurableSession() {
+        val baseline = VoiceInputPolicy.scopeKey("https://one.example", "default", "session-1")
+
+        assertEquals(baseline, VoiceInputPolicy.scopeKey("https://one.example", "default", "session-1"))
+        assertNotEquals(baseline, VoiceInputPolicy.scopeKey("https://two.example", "default", "session-1"))
+        assertNotEquals(baseline, VoiceInputPolicy.scopeKey("https://one.example", "work", "session-1"))
+        assertNotEquals(baseline, VoiceInputPolicy.scopeKey("https://one.example", "default", "session-2"))
+        assertNotEquals(
+            VoiceInputPolicy.scopeKey("https://one.example", "a|1:b", "session-1"),
+            VoiceInputPolicy.scopeKey("https://one.example|a", "b", "1:session-1"),
+        )
+    }
+
     @Test
     fun selectsFirstNonBlankResultAndTrimsIt() {
         assertEquals(


### PR DESCRIPTION
## Summary

Add optional device-provided voice input to the chat composer.

- Show **Voice input** in the existing attachment menu only when Android can resolve a speech-recognition activity.
- Append the first non-blank result to the current draft without replacing existing text.
- Bound recognized input to 4,096 characters.
- Bind pending results to the active server origin, profile, and durable session so stale results are discarded after navigation or connection-scope changes.

## Hermes compatibility

This is entirely client-side and uses Android's standard `ACTION_RECOGNIZE_SPEECH` activity-result contract. It does not require a custom Hermes route, plugin, dashboard extension, worker, or fork.

HAM does not request `RECORD_AUDIO` and does not persist raw audio. The installed Android speech service handles capture and recognition in its own interface; HAM reads only the returned recognition strings. The privacy policy now documents that boundary.

## Verification

- [x] `./gradlew testDebugUnitTest lintDebug assembleDebug`
- [x] `./gradlew validateDebugScreenshotTest`
- [x] One combined Android CI job covers tests, lint, build, and screenshot validation.
- [x] No adaptive layout or screenshot reference changes.
- [x] No credentials, cookies, tickets, server addresses, prompts, transcripts, attachments, signing material, or generated build output added.

RED evidence: [combined Android CI run 31994412460](https://github.com/snowzlmbot/Hermes-Agent-Mobile-HAM/actions/runs/31994412460) failed only the three intentionally stubbed voice-policy tests (569 passed, 3 failed).

GREEN evidence: [combined Android CI run 31996656516](https://github.com/snowzlmbot/Hermes-Agent-Mobile-HAM/actions/runs/31996656516) validates a commit whose Git tree matches this PR head. The upstream fork-PR check still awaits maintainer approval.

## Screenshots

No screenshot reference change. The action is added inside the existing attachment menu and does not alter the compact composer layout.

## Risk and rollback

Device speech-service availability and recognition quality vary by installed provider. Unsupported devices do not show the action. Reverting this PR removes the action, activity-result contract, manifest visibility query, policy, tests, and privacy note without changing stored data or the Hermes protocol.