### PR TITLE
feat(android): add hands-free voice conversation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+# Contributors
+
+- [@snowzlmbot](https://github.com/snowzlmbot) — originated the device voice-input idea carried forward from [PR #26](https://github.com/unsupportedpastels/Hermes-Agent-Mobile-HAM/pull/26).

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -32,6 +32,8 @@ Host-file contents are downloaded only after an explicit preview, play, save, or
 
 HAM sends data only to the Hermes server origin you configure in the app. HAM does **not** operate a shared hosted backend and does not include analytics, advertising, tracking, or telemetry SDKs.
 
+When you explicitly choose **Voice input**, HAM opens an installed Android speech-recognition activity. That service may capture and process audio under its own privacy policy; HAM receives only the recognized text and does not store the recording.
+
 Your chosen server’s operator and configuration determine how server-side data is processed, retained, logged, and secured. Review that server’s policies before connecting, especially if it is operated by someone else.
 
 ## Android permissions
@@ -42,7 +44,7 @@ Your chosen server’s operator and configuration determine how server-side data
 - **Microphone (`RECORD_AUDIO`)** — voice dictation, voice conversations, and barge-in; requested only when you first start a voice feature, used only while one is active.
 - **Foreground service / microphone and wake lock** — only for the opt-in screen-off voice continuation described above.
 
-HAM does not request location, contacts, camera, or storage-wide file permissions. Attachments use Android’s user-mediated document picker.
+HAM does not request location, contacts, camera, or storage-wide file permissions. Attachments use Android’s user-mediated document picker. Device Voice input uses an installed Android speech service, which may request microphone access in its own interface; server-backed dictation and voice conversation use HAM’s explicitly requested `RECORD_AUDIO` permission described above.
 
 ## Security
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -19,6 +19,15 @@ Transcript tails are not stored unless you opt in under Settings. Opted-in trans
 
 Host-file contents are downloaded only after an explicit preview, play, save, or share action. Save uses Android's user-selected document destination. Share creates a bounded temporary file in app-private cache and exposes only that file through a one-time Android content-URI grant; Android may later evict the cache file.
 
+## Voice
+
+- **Microphone audio.** When you start dictation or a voice conversation, HAM records audio and sends it to your configured Hermes server for transcription (`/api/audio/transcribe`). That server may forward the audio to its configured speech-to-text provider. Recording happens only after you explicitly start it and stops on release, silence, the server-configured cap, or leaving the app.
+- **Spoken replies.** Text you ask HAM to read aloud (or that auto-speak reads, when the server's `voice.auto_tts` is enabled) is sent to your configured Hermes server for synthesis (`/api/audio/speak` and `/api/audio/speak-stream`), which may forward it to its configured text-to-speech provider.
+- **No voice persistence.** Microphone recordings, transcripts in flight, and generated speech audio live in memory or short-lived app-cache temporary files that are deleted when playback or transcription finishes. They are never written to the offline transcript cache, saved state, logs, notifications, or any analytics (HAM has none).
+- **Lifecycle default.** Voice capture and playback stop when you switch sessions or profiles, log out, lock the device, or leave the app.
+- **Screen-off continuation (opt-in).** If you enable "Continue voice with screen off" in Settings, an already-started voice conversation keeps running behind a non-dismissable notification with a Stop action, using Android's microphone foreground service; Android's microphone indicator stays visible, and a partial wake lock keeps capture and network alive. The notification shows only the loop phase (Listening/Thinking/Speaking), never transcript text. After the process is killed, voice never restarts on its own.
+- **Server-side processing** of voice audio and speech text — including provider choice, logging, and retention — is controlled by your server's operator and configuration.
+
 ## Where data goes
 
 HAM sends data only to the Hermes server origin you configure in the app. HAM does **not** operate a shared hosted backend and does not include analytics, advertising, tracking, or telemetry SDKs.
@@ -28,10 +37,12 @@ Your chosen server’s operator and configuration determine how server-side data
 ## Android permissions
 
 - **Internet** — connect to your configured Hermes server.
-- **Notifications** — optional alerts for completed turns and requests requiring your attention.
+- **Notifications** — optional alerts for completed turns and requests requiring your attention, plus the persistent voice-conversation status notification.
 - **Foreground service / data sync** — maintain truthful, visible status while an active HAM-started turn is running.
+- **Microphone (`RECORD_AUDIO`)** — voice dictation, voice conversations, and barge-in; requested only when you first start a voice feature, used only while one is active.
+- **Foreground service / microphone and wake lock** — only for the opt-in screen-off voice continuation described above.
 
-HAM does not request location, contacts, camera, microphone, or storage-wide file permissions. Attachments use Android’s user-mediated document picker.
+HAM does not request location, contacts, camera, or storage-wide file permissions. Attachments use Android’s user-mediated document picker.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - Supports native Nous OAuth with system-browser PKCE, origin-scoped encrypted credentials, refresh, and reconnect/reconciliation.
 - Adapts cleanly across compact phones, Fold cover screens, unfolded layouts, split screen, freeform windows, and DeX.
 - Preserves a HAM-started live turn when you navigate away; it does not take over or close another client’s runtime.
+- Speaks and listens through your server's audited voice stack: tap/hold dictation into the draft, per-message read-aloud, streaming speech that overlaps generation, a hands-free voice conversation with spoken stop phrases and barge-in, and server-backed voice settings (`voice.auto_tts`, ElevenLabs voice). Voice controls appear only when the connected server exposes the official `/api/audio/…` routes, audio is never persisted on the device, and the microphone permission is requested only when you first use voice.
 
 ## Designed for foldables and tablets
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,10 @@ The cache never stores access or refresh tokens, WebSocket tickets, transient ru
 
 Managed artifact downloads remain bounded by the client transport. Explicit sharing writes only the selected artifact to app-private cache and grants read access through a non-exported `FileProvider` content URI. HAM does not execute or render HTML/SVG artifacts in a WebView.
 
+## Voice
+
+Voice features use only released Hermes routes (`/api/audio/transcribe`, `/api/audio/speak`, `/api/audio/speak-stream`, `/api/audio/elevenlabs/voices`) over the same authenticated origin-scoped transport; the streaming speech WebSocket authenticates with a fresh single-use ticket per connection, never a bearer token in a URL. Servers without the audio routes simply hide voice controls. Microphone recordings and synthesized audio are held in memory or short-lived app-cache temporary files, deleted on completion, and are excluded from the offline cache, logs, and error messages (errors are bounded category messages without audio data URLs, prompt text, config bodies, or tickets). The opt-in screen-off voice service is non-exported, uses `foregroundServiceType="microphone"`, always shows a stoppable notification without transcript content, and never starts or restarts from the background.
+
 ## Scope
 
 HAM is a native client for released Hermes interfaces. Reports affecting Hermes Agent itself, a server deployment, or another upstream dependency may need coordinated disclosure with that project or vendor. We will acknowledge valid reports, assess the client impact, and coordinate a fix where appropriate.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,12 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <queries>
+        <intent>
+            <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,15 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <!-- Voice dictation and read-aloud: mic capture is used only while the user
+         is actively recording; audio is sent to the user's Hermes server. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <!-- Opt-in screen-off voice conversation: microphone foreground service with
+         a persistent, stoppable notification, plus a bounded partial wake lock
+         for capture/network continuity. Never started from the background. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:allowBackup="false"
@@ -43,6 +52,10 @@
             android:name=".notifications.HermesTurnNotificationService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+        <service
+            android:name=".voice.VoiceConversationService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.files"

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
@@ -14,7 +14,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.core.net.toUri
 import com.unsupportedpastels.hermesandroid.app.ComposerAttachment
@@ -23,6 +26,12 @@ import com.unsupportedpastels.hermesandroid.app.ProjectId
 import com.unsupportedpastels.hermesandroid.connection.HermesConnectionViewModel
 import com.unsupportedpastels.hermesandroid.connection.HermesAppForeground
 import com.unsupportedpastels.hermesandroid.connection.HermesWindowFocus
+import com.unsupportedpastels.hermesandroid.voice.ComposerDictation
+import com.unsupportedpastels.hermesandroid.voice.ComposerVoiceConversation
+import com.unsupportedpastels.hermesandroid.voice.MessageReadAloud
+import com.unsupportedpastels.hermesandroid.voice.VoiceCapabilities
+import com.unsupportedpastels.hermesandroid.voice.VoiceServerConfig
+import com.unsupportedpastels.hermesandroid.voice.VoiceSettings
 import com.unsupportedpastels.hermesandroid.connection.ModelPickerState
 import com.unsupportedpastels.hermesandroid.gateway.ModelSwitchResult
 import com.unsupportedpastels.hermesandroid.connection.ServerSettingsState
@@ -183,6 +192,8 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+private const val VOICE_SCREEN_OFF_PREF = "screen_off_continuation"
+
 @Composable
 internal fun HermesAppHost(
     viewModel: ServerSettingsViewModel,
@@ -245,6 +256,69 @@ internal fun HermesAppHost(
     val persistedProjectDockStateFlow = paneLayoutPreferencesViewModel?.projectDockState
         ?: remember { MutableStateFlow<ProjectDockState?>(null) }
     val persistedProjectDockState by persistedProjectDockStateFlow.collectAsStateWithLifecycle()
+
+    val voiceCapabilitiesFlow = connectionViewModel?.voiceCapabilities
+        ?: remember { MutableStateFlow(VoiceCapabilities.NONE) }
+    val voiceCapabilities by voiceCapabilitiesFlow.collectAsStateWithLifecycle()
+    val voiceServerConfigFlow = connectionViewModel?.voiceServerConfig
+        ?: remember { MutableStateFlow(VoiceServerConfig.DEFAULT) }
+    val voiceServerConfig by voiceServerConfigFlow.collectAsStateWithLifecycle()
+
+    // Re-probe voice contracts whenever the connection or selected profile
+    // changes; refreshVoiceCapabilities is fail-closed so an unauthenticated or
+    // older server simply leaves the mic hidden.
+    LaunchedEffect(connectionViewModel, snapshot.authenticationState, snapshot.selectedProfile) {
+        connectionViewModel?.refreshVoiceCapabilities()
+    }
+
+    val voiceViewModel = connectionViewModel
+    // Remembered so lambda-carrying bundles stay reference-stable across
+    // recompositions — downstream composables key remember/effects on them.
+    val composerDictation = remember(voiceViewModel, voiceCapabilities, voiceServerConfig) {
+        if (voiceCapabilities.canDictateViaServer && voiceViewModel != null) {
+            ComposerDictation(serverConfig = voiceServerConfig) { dataUrl, mimeType ->
+                resultPreservingCancellation { voiceViewModel.transcribeDictation(dataUrl, mimeType) }
+            }
+        } else {
+            null
+        }
+    }
+    val messageReadAloud = remember(voiceViewModel, voiceCapabilities) {
+        if (voiceCapabilities.canReadAloud && voiceViewModel != null) {
+            MessageReadAloud { text ->
+                resultPreservingCancellation { voiceViewModel.synthesizeSpeech(text) }
+            }
+        } else {
+            null
+        }
+    }
+    // Client-side opt-in for screen-off voice continuation; the voice loop
+    // itself and all audio stay in-memory only.
+    val appContext = LocalContext.current.applicationContext
+    val voicePreferences = remember(appContext) {
+        appContext.getSharedPreferences("voice", android.content.Context.MODE_PRIVATE)
+    }
+    var voiceScreenOffContinuation by remember(voicePreferences) {
+        mutableStateOf(voicePreferences.getBoolean(VOICE_SCREEN_OFF_PREF, false))
+    }
+
+    // The hands-free loop needs both STT (transcribe) and TTS (speak) contracts.
+    val composerVoiceConversation = remember(voiceViewModel, voiceCapabilities, voiceServerConfig) {
+        if (voiceCapabilities.canDictateViaServer && voiceCapabilities.canReadAloud && voiceViewModel != null) {
+            ComposerVoiceConversation(
+                serverConfig = voiceServerConfig,
+                transcribe = { dataUrl, mimeType ->
+                    resultPreservingCancellation { voiceViewModel.transcribeDictation(dataUrl, mimeType) }
+                },
+                openStream = { voiceViewModel.openSpeechStream() },
+                synthesize = { text ->
+                    resultPreservingCancellation { voiceViewModel.synthesizeSpeech(text) }
+                },
+            )
+        } else {
+            null
+        }
+    }
 
     HermesApp(
         snapshot = snapshot,
@@ -344,6 +418,33 @@ internal fun HermesAppHost(
                 ?: Result.failure(IllegalStateException("Bulk session deletion unavailable"))
         },
         onSearchTranscripts = { query -> connectionViewModel?.searchTranscripts(query) },
+        dictation = composerDictation,
+        readAloud = messageReadAloud,
+        voiceConversation = composerVoiceConversation,
+        onSendVoiceMessage = { sessionId, text, interrupted ->
+            connectionViewModel?.sendMessage(sessionId, text, interrupted)
+        },
+        voiceSettings = if (voiceCapabilities.audioRoutesPresent && voiceViewModel != null) {
+            VoiceSettings(
+                capabilities = voiceCapabilities,
+                config = voiceServerConfig,
+                setAutoTts = { enabled -> voiceViewModel.setVoiceAutoTts(enabled) },
+                setElevenLabsVoice = { voiceId -> voiceViewModel.setElevenLabsVoice(voiceId) },
+                loadVoices = { voiceViewModel.loadElevenLabsVoices() },
+                screenOffContinuationEnabled = voiceScreenOffContinuation,
+                setScreenOffContinuation = { enabled ->
+                    voiceScreenOffContinuation = enabled
+                    voicePreferences
+                        .edit()
+                        .putBoolean(VOICE_SCREEN_OFF_PREF, enabled)
+                        .apply()
+                },
+            )
+        } else {
+            null
+        },
+        autoSpeakEnabled = voiceCapabilities.canReadAloud && voiceServerConfig.autoTts,
+        voiceScreenOffContinuation = voiceScreenOffContinuation,
         onSendMessage = onSendMessage,
         onReasoningSelected = onReasoningSelected,
         onFastSelected = onFastSelected,

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
@@ -26,7 +26,6 @@ import com.unsupportedpastels.hermesandroid.app.ProjectId
 import com.unsupportedpastels.hermesandroid.connection.HermesConnectionViewModel
 import com.unsupportedpastels.hermesandroid.connection.HermesAppForeground
 import com.unsupportedpastels.hermesandroid.connection.HermesWindowFocus
-import com.unsupportedpastels.hermesandroid.voice.ComposerDictation
 import com.unsupportedpastels.hermesandroid.voice.ComposerVoiceConversation
 import com.unsupportedpastels.hermesandroid.voice.MessageReadAloud
 import com.unsupportedpastels.hermesandroid.voice.VoiceCapabilities
@@ -272,17 +271,6 @@ internal fun HermesAppHost(
     }
 
     val voiceViewModel = connectionViewModel
-    // Remembered so lambda-carrying bundles stay reference-stable across
-    // recompositions — downstream composables key remember/effects on them.
-    val composerDictation = remember(voiceViewModel, voiceCapabilities, voiceServerConfig) {
-        if (voiceCapabilities.canDictateViaServer && voiceViewModel != null) {
-            ComposerDictation(serverConfig = voiceServerConfig) { dataUrl, mimeType ->
-                resultPreservingCancellation { voiceViewModel.transcribeDictation(dataUrl, mimeType) }
-            }
-        } else {
-            null
-        }
-    }
     val messageReadAloud = remember(voiceViewModel, voiceCapabilities) {
         if (voiceCapabilities.canReadAloud && voiceViewModel != null) {
             MessageReadAloud { text ->
@@ -418,7 +406,6 @@ internal fun HermesAppHost(
                 ?: Result.failure(IllegalStateException("Bulk session deletion unavailable"))
         },
         onSearchTranscripts = { query -> connectionViewModel?.searchTranscripts(query) },
-        dictation = composerDictation,
         readAloud = messageReadAloud,
         voiceConversation = composerVoiceConversation,
         onSendVoiceMessage = { sessionId, text, interrupted ->

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
@@ -29,12 +29,14 @@ import com.unsupportedpastels.hermesandroid.connection.HermesWindowFocus
 import com.unsupportedpastels.hermesandroid.voice.ComposerVoiceConversation
 import com.unsupportedpastels.hermesandroid.voice.MessageReadAloud
 import com.unsupportedpastels.hermesandroid.voice.VoiceCapabilities
+import com.unsupportedpastels.hermesandroid.voice.VoiceInputPolicy
 import com.unsupportedpastels.hermesandroid.voice.VoiceServerConfig
 import com.unsupportedpastels.hermesandroid.voice.VoiceSettings
 import com.unsupportedpastels.hermesandroid.connection.ModelPickerState
 import com.unsupportedpastels.hermesandroid.gateway.ModelSwitchResult
 import com.unsupportedpastels.hermesandroid.connection.ServerSettingsState
 import com.unsupportedpastels.hermesandroid.connection.ServerSettingsViewModel
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
 import com.unsupportedpastels.hermesandroid.connection.launchBrowserAndAwaitReturn
 import com.unsupportedpastels.hermesandroid.connection.SlashCompletionState
 import com.unsupportedpastels.hermesandroid.gateway.HermesGatewaySnapshot
@@ -193,6 +195,9 @@ class MainActivity : ComponentActivity() {
 
 private const val VOICE_SCREEN_OFF_PREF = "screen_off_continuation"
 
+internal fun voiceScreenOffPreferenceKey(origin: ServerOrigin?): String =
+    "$VOICE_SCREEN_OFF_PREF:${origin?.value ?: "unconfigured"}"
+
 @Composable
 internal fun HermesAppHost(
     viewModel: ServerSettingsViewModel,
@@ -286,13 +291,18 @@ internal fun HermesAppHost(
     val voicePreferences = remember(appContext) {
         appContext.getSharedPreferences("voice", android.content.Context.MODE_PRIVATE)
     }
-    var voiceScreenOffContinuation by remember(voicePreferences) {
-        mutableStateOf(voicePreferences.getBoolean(VOICE_SCREEN_OFF_PREF, false))
+    val screenOffConsentKey = voiceScreenOffPreferenceKey(currentServerOrigin)
+    var voiceScreenOffContinuation by remember(voicePreferences, screenOffConsentKey) {
+        mutableStateOf(voicePreferences.getBoolean(screenOffConsentKey, false))
     }
 
     // The hands-free loop needs both STT (transcribe) and TTS (speak) contracts.
     val composerVoiceConversation = remember(voiceViewModel, voiceCapabilities, voiceServerConfig) {
-        if (voiceCapabilities.canDictateViaServer && voiceCapabilities.canReadAloud && voiceViewModel != null) {
+        if (VoiceInputPolicy.canUseServerConversation(
+                voiceCapabilities,
+                voiceServerConfig,
+            ) && voiceViewModel != null
+        ) {
             ComposerVoiceConversation(
                 serverConfig = voiceServerConfig,
                 transcribe = { dataUrl, mimeType ->
@@ -423,7 +433,7 @@ internal fun HermesAppHost(
                     voiceScreenOffContinuation = enabled
                     voicePreferences
                         .edit()
-                        .putBoolean(VOICE_SCREEN_OFF_PREF, enabled)
+                        .putBoolean(screenOffConsentKey, enabled)
                         .apply()
                 },
             )

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
@@ -31,8 +31,18 @@ import com.unsupportedpastels.hermesandroid.files.MAX_HOST_FILE_ENTRIES
 import com.unsupportedpastels.hermesandroid.files.validCanonicalHostFilePath
 import com.unsupportedpastels.hermesandroid.files.validHostFileMimeType
 import com.unsupportedpastels.hermesandroid.files.validHostFileName
+import com.unsupportedpastels.hermesandroid.voice.ElevenLabsVoice
+import com.unsupportedpastels.hermesandroid.voice.SpeechAudio
+import com.unsupportedpastels.hermesandroid.voice.decodeAudioDataUrl
+import com.unsupportedpastels.hermesandroid.voice.TranscriptionResult
+import com.unsupportedpastels.hermesandroid.voice.VoiceAudioTimeouts
+import com.unsupportedpastels.hermesandroid.voice.VoiceCapabilities
+import com.unsupportedpastels.hermesandroid.voice.VoiceCapabilityPolicy
+import com.unsupportedpastels.hermesandroid.voice.VoiceServerConfig
+import com.unsupportedpastels.hermesandroid.voice.audioRequestTimeout
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
@@ -274,7 +284,10 @@ private class HermesResponseBodyTooLargeException :
 
 private const val MAX_RESPONSE_BODY_BYTES = 64 * 1024
 private const val MAX_TRANSCRIPT_BODY_BYTES = 1024 * 1024
+// Base64 TTS audio for a finalized message can exceed the 1 MiB transcript cap.
+private const val MAX_SPEECH_RESPONSE_BODY_BYTES = 8 * 1024 * 1024
 private const val MAX_CRON_RESPONSE_BODY_BYTES = 128 * 1024
+private const val MAX_ELEVENLABS_VOICES = 200
 private const val MAX_MODEL_OPTIONS_RESPONSE_BODY_BYTES = 1024 * 1024
 private const val MAX_TRANSCRIPT_REASONING_CHARS = 1024 * 1024
 private val TRANSCRIPT_PAGE_LIMITS = intArrayOf(100, 50, 25, 10, 5, 1)
@@ -288,12 +301,16 @@ private const val MAX_HOST_FILE_READ_BODY_BYTES = 1024 * 1024
 
 internal fun HttpClientConfig<*>.configureHermesHttpClient() {
     followRedirects = false
+    // Installed with no defaults so ordinary chat/REST requests keep their
+    // engine-level timeout behaviour. Long-running `/api/audio/…` calls opt into
+    // extended windows per-request via HttpRequestBuilder.audioRequestTimeout().
+    install(HttpTimeout)
 }
 
 internal suspend fun HttpResponse.readBodyTextBounded(
     maxBytes: Int = MAX_RESPONSE_BODY_BYTES,
 ): String {
-    require(maxBytes in 1..MAX_TRANSCRIPT_BODY_BYTES)
+    require(maxBytes in 1..MAX_SPEECH_RESPONSE_BODY_BYTES)
     val channel = bodyAsChannel()
     return try {
         val source = channel.readRemaining(maxBytes + 1L)
@@ -328,6 +345,74 @@ interface HermesConnectionClient {
         serverOrigin: ServerOrigin,
         profile: String,
     ): OperationalStatus = throw UnsupportedOperationException()
+
+    /**
+     * Fail-closed probe of the `/api/audio/…` route family. Returns
+     * [VoiceCapabilities.NONE] when the routes are absent (older server) or the
+     * probe fails, so every voice affordance hides rather than errors.
+     */
+    suspend fun probeVoiceCapabilities(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+    ): VoiceCapabilities = VoiceCapabilities.NONE
+
+    /**
+     * Read the server-authoritative `voice` config section. Falls back to
+     * [VoiceServerConfig.DEFAULT] on any transport or shape error.
+     */
+    suspend fun loadVoiceServerConfig(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+    ): VoiceServerConfig = VoiceServerConfig.DEFAULT
+
+    /**
+     * Transcribe a recorded utterance via `POST /api/audio/transcribe`. [dataUrl]
+     * must be a `data:<audio-mime>;base64,<...>` URL. A blank transcript means the
+     * server detected silence — a normal result, not an error.
+     */
+    suspend fun transcribeAudio(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+        dataUrl: String,
+        mimeType: String?,
+    ): TranscriptionResult = throw UnsupportedOperationException()
+
+    /**
+     * Synthesize [text] to speech via `POST /api/audio/speak`, returning decoded
+     * audio bytes ready for playback. This is the REST fallback for read-aloud;
+     * the streaming path is `/api/audio/speak-stream`.
+     */
+    suspend fun speakText(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+        text: String,
+    ): SpeechAudio = throw UnsupportedOperationException()
+
+    /**
+     * Deep-merge [config] into the server's profile-scoped config via
+     * `PUT /api/config` (the released server merges incoming over disk, so only
+     * the changed nested fields are sent). Returns true on success.
+     */
+    suspend fun updateServerConfig(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+        config: JsonObject,
+    ): Boolean = throw UnsupportedOperationException()
+
+    /**
+     * List configured ElevenLabs voices for the picker. Empty when the route
+     * reports `available:false` or the response is malformed.
+     */
+    suspend fun listElevenLabsVoices(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+    ): List<ElevenLabsVoice> = emptyList()
 
     suspend fun authenticate(
         serverOrigin: ServerOrigin,
@@ -493,6 +578,154 @@ class HttpHermesConnectionClient(
     private val client: HttpClient,
 ) : HermesConnectionClient {
     private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun probeVoiceCapabilities(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+    ): VoiceCapabilities = try {
+        val response = client.get("${serverOrigin.value}/api/audio/elevenlabs/voices") {
+            bearerAuth(accessToken)
+            parameter("profile", profile.take(64))
+        }
+        val body = response.readBodyTextBounded()
+        if (!response.status.isSuccess()) {
+            VoiceCapabilityPolicy.fromVoicesProbe(response.status.value, elevenLabsAvailable = false)
+        } else {
+            val available = (json.parseToJsonElement(body) as? JsonObject)
+                ?.get("available")?.jsonPrimitive?.booleanOrNull ?: false
+            VoiceCapabilityPolicy.fromVoicesProbe(response.status.value, elevenLabsAvailable = available)
+        }
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Exception) {
+        VoiceCapabilities.NONE
+    }
+
+    override suspend fun loadVoiceServerConfig(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+    ): VoiceServerConfig = try {
+        val response = client.get("${serverOrigin.value}/api/config") {
+            bearerAuth(accessToken)
+            parameter("profile", profile.take(64))
+        }
+        val body = response.readBodyTextBounded()
+        if (!response.status.isSuccess()) {
+            VoiceServerConfig.DEFAULT
+        } else {
+            VoiceServerConfig.fromConfigRoot(json.parseToJsonElement(body) as? JsonObject)
+        }
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Exception) {
+        VoiceServerConfig.DEFAULT
+    }
+
+    override suspend fun transcribeAudio(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+        dataUrl: String,
+        mimeType: String?,
+    ): TranscriptionResult {
+        val response = client.post("${serverOrigin.value}/api/audio/transcribe") {
+            bearerAuth(accessToken)
+            parameter("profile", profile.take(64))
+            contentType(ContentType.Application.Json)
+            setBody(
+                buildJsonObject {
+                    put("data_url", dataUrl)
+                    mimeType?.takeIf { it.isNotBlank() }?.let { put("mime_type", it) }
+                }.toString(),
+            )
+            audioRequestTimeout(VoiceAudioTimeouts.TRANSCRIBE_REQUEST_MILLIS)
+        }
+        val body = response.readBodyTextBounded()
+        if (!response.status.isSuccess()) {
+            throw HermesConnectionException(
+                "Hermes transcription returned HTTP ${response.status.value}",
+            )
+        }
+        val root = json.parseToJsonElement(body) as? JsonObject
+            ?: throw HermesConnectionException("Hermes transcription response was invalid")
+        return TranscriptionResult(
+            transcript = root["transcript"]?.jsonPrimitive?.contentOrNull.orEmpty().trim(),
+            provider = root["provider"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+
+    override suspend fun speakText(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+        text: String,
+    ): SpeechAudio {
+        val response = client.post("${serverOrigin.value}/api/audio/speak") {
+            bearerAuth(accessToken)
+            parameter("profile", profile.take(64))
+            contentType(ContentType.Application.Json)
+            setBody(buildJsonObject { put("text", text) }.toString())
+            audioRequestTimeout(VoiceAudioTimeouts.SPEAK_REQUEST_MILLIS)
+        }
+        val body = response.readBodyTextBounded(MAX_SPEECH_RESPONSE_BODY_BYTES)
+        if (!response.status.isSuccess()) {
+            throw HermesConnectionException(
+                "Hermes speech synthesis returned HTTP ${response.status.value}",
+            )
+        }
+        val root = json.parseToJsonElement(body) as? JsonObject
+            ?: throw HermesConnectionException("Hermes speech response was invalid")
+        val dataUrl = root["data_url"]?.jsonPrimitive?.contentOrNull
+            ?: throw HermesConnectionException("Hermes speech response had no audio")
+        return decodeAudioDataUrl(dataUrl)
+            ?: throw HermesConnectionException("Hermes speech audio was not decodable")
+    }
+
+    override suspend fun updateServerConfig(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+        config: JsonObject,
+    ): Boolean {
+        val response = client.put("${serverOrigin.value}/api/config") {
+            bearerAuth(accessToken)
+            parameter("profile", profile.take(64))
+            contentType(ContentType.Application.Json)
+            setBody(buildJsonObject { put("config", config) }.toString())
+        }
+        if (!response.status.isSuccess()) return false
+        val body = response.readBodyTextBounded()
+        return (json.parseToJsonElement(body) as? JsonObject)
+            ?.get("ok")?.jsonPrimitive?.booleanOrNull == true
+    }
+
+    override suspend fun listElevenLabsVoices(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+    ): List<ElevenLabsVoice> {
+        val response = client.get("${serverOrigin.value}/api/audio/elevenlabs/voices") {
+            bearerAuth(accessToken)
+            parameter("profile", profile.take(64))
+        }
+        if (!response.status.isSuccess()) return emptyList()
+        val body = response.readBodyTextBounded(MAX_TRANSCRIPT_BODY_BYTES)
+        val root = json.parseToJsonElement(body) as? JsonObject ?: return emptyList()
+        if (root["available"]?.jsonPrimitive?.booleanOrNull != true) return emptyList()
+        val voices = root["voices"] as? JsonArray ?: return emptyList()
+        return voices.mapNotNull { element ->
+            val voice = element as? JsonObject ?: return@mapNotNull null
+            val id = voice["voice_id"]?.jsonPrimitive?.contentOrNull
+                ?.takeIf(String::isNotBlank)?.take(128) ?: return@mapNotNull null
+            ElevenLabsVoice(
+                voiceId = id,
+                name = voice["name"]?.jsonPrimitive?.contentOrNull.orEmpty().take(128),
+                label = voice["label"]?.jsonPrimitive?.contentOrNull.orEmpty().take(256),
+            )
+        }.take(MAX_ELEVENLABS_VOICES)
+    }
 
     override suspend fun updateSession(
         serverOrigin: ServerOrigin,

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -65,6 +65,15 @@ import com.unsupportedpastels.hermesandroid.gateway.ModelSelection
 import com.unsupportedpastels.hermesandroid.gateway.ModelSwitchResult
 import com.unsupportedpastels.hermesandroid.gateway.OperationalSnapshot
 import com.unsupportedpastels.hermesandroid.gateway.OperationalStatusState
+import com.unsupportedpastels.hermesandroid.voice.ElevenLabsVoice
+import com.unsupportedpastels.hermesandroid.voice.KtorSpeechWebSocketFactory
+import com.unsupportedpastels.hermesandroid.voice.SpeechAudio
+import com.unsupportedpastels.hermesandroid.voice.SpeechStreamConnector
+import com.unsupportedpastels.hermesandroid.voice.SpeechStreamSocket
+import com.unsupportedpastels.hermesandroid.voice.StreamingSpeechTransport
+import com.unsupportedpastels.hermesandroid.voice.TranscriptionResult
+import com.unsupportedpastels.hermesandroid.voice.VoiceCapabilities
+import com.unsupportedpastels.hermesandroid.voice.VoiceServerConfig
 import com.unsupportedpastels.hermesandroid.gateway.lastGoodOrNull
 import com.unsupportedpastels.hermesandroid.gateway.ResumedChatSession
 import com.unsupportedpastels.hermesandroid.gateway.RuntimeSessionId
@@ -117,8 +126,10 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 
 private const val TOKEN_REFRESH_SKEW_SECONDS = 30L
 private const val MAX_CHAT_RECOVERIES_PER_OPERATION = 2
@@ -309,6 +320,7 @@ class HermesConnectionViewModel(
     private val appForegroundStates: StateFlow<Boolean> = MutableStateFlow(true),
     private val notifications: TurnNotificationController = NoOpTurnNotificationController,
     private val sessionFilterRepository: SessionFilterRepository? = null,
+    private val speechStreamConnector: SpeechStreamConnector? = null,
 ) : ViewModel() {
     private val mutableSnapshots = MutableStateFlow(HermesGatewaySnapshot())
     val snapshots: StateFlow<HermesGatewaySnapshot> = mutableSnapshots.asStateFlow()
@@ -391,6 +403,14 @@ class HermesConnectionViewModel(
         MutableStateFlow<Map<DurableSessionId, List<ComposerAttachment>>>(emptyMap())
     val attachments: StateFlow<Map<DurableSessionId, List<ComposerAttachment>>> =
         mutableAttachments.asStateFlow()
+
+    /** Which `/api/audio/…` contracts the connected server advertises (fail-closed). */
+    private val mutableVoiceCapabilities = MutableStateFlow(VoiceCapabilities.NONE)
+    val voiceCapabilities: StateFlow<VoiceCapabilities> = mutableVoiceCapabilities.asStateFlow()
+
+    /** Server-authoritative `voice` config (recording cap, silence, stop phrases). */
+    private val mutableVoiceServerConfig = MutableStateFlow(VoiceServerConfig.DEFAULT)
+    val voiceServerConfig: StateFlow<VoiceServerConfig> = mutableVoiceServerConfig.asStateFlow()
 
     /** Maps local draft IDs to the canonical durable IDs returned by session.create. */
     private val serverDurableIds = mutableMapOf<DurableSessionId, DurableSessionId>()
@@ -882,6 +902,126 @@ class HermesConnectionViewModel(
         }
         return result
     }
+
+    /**
+     * Refresh which `/api/audio/…` contracts the connected server advertises and
+     * its authoritative `voice` config. Fail-closed: any transport error leaves
+     * capabilities at [VoiceCapabilities.NONE], so the mic stays hidden.
+     */
+    suspend fun refreshVoiceCapabilities() {
+        val probe = runCatching {
+            withHermesRestOperation { origin, token ->
+                val profile = mutableSnapshots.value.selectedProfile
+                val caps = client.probeVoiceCapabilities(origin, token.orEmpty(), profile)
+                val config = client.loadVoiceServerConfig(origin, token.orEmpty(), profile)
+                caps to config
+            }
+        }.getOrNull()
+        if (probe == null) {
+            mutableVoiceCapabilities.value = VoiceCapabilities.NONE
+            return
+        }
+        mutableVoiceCapabilities.value = probe.first
+        mutableVoiceServerConfig.value = probe.second
+    }
+
+    /**
+     * Write `voice.auto_tts` through profile-scoped `PUT /api/config` (server
+     * deep-merges). Optimistic local update; rolled back on failure. Returns
+     * whether the server accepted the write.
+     */
+    suspend fun setVoiceAutoTts(enabled: Boolean): Boolean {
+        val previous = mutableVoiceServerConfig.value
+        mutableVoiceServerConfig.value = previous.copy(autoTts = enabled)
+        val accepted = runCatching {
+            withHermesRestOperation { origin, token ->
+                client.updateServerConfig(
+                    origin,
+                    token.orEmpty(),
+                    mutableSnapshots.value.selectedProfile,
+                    buildJsonObject {
+                        put("voice", buildJsonObject { put("auto_tts", enabled) })
+                    },
+                )
+            }
+        }.getOrDefault(false)
+        if (!accepted) mutableVoiceServerConfig.value = previous
+        return accepted
+    }
+
+    /** Write `tts.elevenlabs.voice_id`; optimistic with rollback like auto-TTS. */
+    suspend fun setElevenLabsVoice(voiceId: String): Boolean {
+        val trimmed = voiceId.trim().take(128)
+        if (trimmed.isEmpty()) return false
+        val previous = mutableVoiceServerConfig.value
+        mutableVoiceServerConfig.value = previous.copy(elevenLabsVoiceId = trimmed)
+        val accepted = runCatching {
+            withHermesRestOperation { origin, token ->
+                client.updateServerConfig(
+                    origin,
+                    token.orEmpty(),
+                    mutableSnapshots.value.selectedProfile,
+                    buildJsonObject {
+                        put(
+                            "tts",
+                            buildJsonObject {
+                                put("elevenlabs", buildJsonObject { put("voice_id", trimmed) })
+                            },
+                        )
+                    },
+                )
+            }
+        }.getOrDefault(false)
+        if (!accepted) mutableVoiceServerConfig.value = previous
+        return accepted
+    }
+
+    /** ElevenLabs voices for the settings picker; empty on any failure. */
+    suspend fun loadElevenLabsVoices(): List<ElevenLabsVoice> = runCatching {
+        withHermesRestOperation { origin, token ->
+            client.listElevenLabsVoices(
+                origin,
+                token.orEmpty(),
+                mutableSnapshots.value.selectedProfile,
+            )
+        }
+    }.getOrDefault(emptyList())
+
+    /** Transcribe a dictation recording via the server's audited STT chain. */
+    suspend fun transcribeDictation(dataUrl: String, mimeType: String?): TranscriptionResult =
+        withHermesRestOperation { origin, token ->
+            client.transcribeAudio(
+                origin,
+                token.orEmpty(),
+                mutableSnapshots.value.selectedProfile,
+                dataUrl,
+                mimeType,
+            )
+        }
+
+    /**
+     * Open a fresh-ticket streaming-speech socket to `/api/audio/speak-stream`
+     * for the active origin/profile. Each call mints a new single-use ticket;
+     * the chat socket is untouched. Null when streaming is unavailable.
+     */
+    suspend fun openSpeechStream(): SpeechStreamSocket? {
+        val connector = speechStreamConnector ?: return null
+        if (!mutableVoiceCapabilities.value.canStreamSpeech) return null
+        return withHermesRestOperation { origin, token ->
+            connector.connect(origin, token.orEmpty(), mutableSnapshots.value.selectedProfile)
+        }
+    }
+
+    /** Synthesize [text] to speech via the server's TTS chain (read-aloud REST path). */
+    suspend fun synthesizeSpeech(text: String): SpeechAudio =
+        withHermesRestOperation { origin, token ->
+            client.speakText(
+                origin,
+                token.orEmpty(),
+                mutableSnapshots.value.selectedProfile,
+                text,
+            )
+        }
 
     private fun isCurrentRestOperation(
         serverOrigin: ServerOrigin,
@@ -2321,7 +2461,15 @@ class HermesConnectionViewModel(
         return job
     }
 
-    fun sendMessage(durableSessionId: DurableSessionId, rawText: String): Job {
+    /**
+     * [interrupted] marks a voice barge-in follow-up; it is forwarded to
+     * `prompt.submit` for exactly this one submission.
+     */
+    fun sendMessage(
+        durableSessionId: DurableSessionId,
+        rawText: String,
+        interrupted: Boolean = false,
+    ): Job {
         val text = rawText.trim()
         val hasAttachments = mutableAttachments.value[durableSessionId].orEmpty().isNotEmpty()
         if (text.isEmpty() && !hasAttachments) return viewModelScope.launch { }
@@ -2404,7 +2552,7 @@ class HermesConnectionViewModel(
                 }
                 promptStaged = true
                 yield()
-                session.submitPrompt(runtimeId, submittedText)
+                session.submitPrompt(runtimeId, submittedText, interrupted)
                 // A prompt can launch background processes, so refresh the activity
                 // stack only after the turn is accepted: the pre-submit snapshot
                 // cannot contain processes created by this turn.
@@ -5534,6 +5682,10 @@ class HermesConnectionViewModel(
                 appForegroundStates = HermesAppForeground.states,
                 notifications = AndroidTurnNotificationController(context),
                 sessionFilterRepository = DataStoreSessionFilterRepository(context),
+                speechStreamConnector = StreamingSpeechTransport(
+                    ticketClient = KtorWsTicketClient(httpClient),
+                    socketFactory = KtorSpeechWebSocketFactory(httpClient),
+                ),
             ) as T
         }
     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -1483,9 +1483,14 @@ class HermesConnectionViewModel(
                 }
                 currentCoroutineContext().ensureActive()
                 if (!isCurrentProjectLoad(serverOrigin, originGeneration)) return@launch
-                if (durableSessions != mutableSnapshots.value.durableSessions) {
+                val mergedHomeSessions = mergeServerSessionsPreservingDrafts(
+                    serverSessions = durableSessions,
+                    currentSessions = mutableSnapshots.value.durableSessions,
+                    pendingDrafts = pendingDraftSessions,
+                )
+                if (mergedHomeSessions != mutableSnapshots.value.durableSessions) {
                     mutableSnapshots.value = mutableSnapshots.value.copy(
-                        durableSessions = durableSessions,
+                        durableSessions = mergedHomeSessions,
                     )
                 }
                 startProjectTreeLoad(
@@ -1663,7 +1668,13 @@ class HermesConnectionViewModel(
                     mutableSnapshots.value = currentSnapshot.copy(
                         profiles = profiles,
                         selectedProfile = selected,
-                        durableSessions = profileSessions ?: currentSnapshot.durableSessions,
+                        durableSessions = profileSessions?.let { sessions ->
+                            mergeServerSessionsPreservingDrafts(
+                                serverSessions = sessions,
+                                currentSessions = currentSnapshot.durableSessions,
+                                pendingDrafts = pendingDraftSessions,
+                            )
+                        } ?: currentSnapshot.durableSessions,
                         defaultModelOptions = options,
                         currentModelInfo = currentInfo?.takeIf { it.profile == selected },
                         profileReasoningEffort = profileReasoningEffort,
@@ -1725,7 +1736,13 @@ class HermesConnectionViewModel(
             ) {
                 lastDurableSessionsFetchKey = key
                 activeSessionArchivedFilter = archivedOnly
-                mutableSnapshots.value = mutableSnapshots.value.copy(durableSessions = sessions)
+                mutableSnapshots.value = mutableSnapshots.value.copy(
+                    durableSessions = mergeServerSessionsPreservingDrafts(
+                        serverSessions = sessions,
+                        currentSessions = mutableSnapshots.value.durableSessions,
+                        pendingDrafts = pendingDraftSessions,
+                    ),
+                )
             }
         }
     }
@@ -1926,7 +1943,13 @@ class HermesConnectionViewModel(
         check(generation == expectedGeneration && activeOrigin == origin &&
             mutableSnapshots.value.selectedProfile == profile
         ) { "Server scope changed while refreshing sessions" }
-        mutableSnapshots.value = mutableSnapshots.value.copy(durableSessions = durableSessions)
+        mutableSnapshots.value = mutableSnapshots.value.copy(
+            durableSessions = mergeServerSessionsPreservingDrafts(
+                serverSessions = durableSessions,
+                currentSessions = mutableSnapshots.value.durableSessions,
+                pendingDrafts = pendingDraftSessions,
+            ),
+        )
         startProjectTreeLoad(
             serverOrigin = origin,
             originGeneration = expectedGeneration,

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/SessionListMerge.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/SessionListMerge.kt
@@ -1,0 +1,28 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import com.unsupportedpastels.hermesandroid.app.DurableSessionId
+import com.unsupportedpastels.hermesandroid.app.SessionSummary
+
+/**
+ * Replaces the durable session list with a server-fetched list while keeping
+ * local draft sessions ("New chat" entries that only exist on this client)
+ * visible. Without this, a background session-list refresh that lands while a
+ * draft is open removes the draft from the snapshot and the open detail route
+ * degrades to "Session is no longer available".
+ *
+ * Drafts are kept only while they are still pending (not yet promoted to a
+ * server session) and not already represented in the server list.
+ */
+internal fun mergeServerSessionsPreservingDrafts(
+    serverSessions: List<SessionSummary>,
+    currentSessions: List<SessionSummary>,
+    pendingDrafts: Set<DurableSessionId>,
+): List<SessionSummary> {
+    if (pendingDrafts.isEmpty()) return serverSessions
+    val serverIds = serverSessions.mapTo(mutableSetOf(), SessionSummary::id)
+    val preservedDrafts = currentSessions.filter { session ->
+        session.isLocalDraft && session.id in pendingDrafts && session.id !in serverIds
+    }
+    if (preservedDrafts.isEmpty()) return serverSessions
+    return preservedDrafts + serverSessions
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
@@ -497,6 +497,19 @@ interface HermesChatSession {
         text: String,
     ): PromptSubmission
 
+    /**
+     * Submits a prompt with the voice barge-in annotation. The released gateway
+     * latches `params.interrupted` so the turn's model message carries the
+     * interruption note; it is sent only when true, so older servers see an
+     * unchanged request. Implementations without the live transport just drop
+     * the flag.
+     */
+    suspend fun submitPrompt(
+        runtimeSessionId: RuntimeSessionId,
+        text: String,
+        interrupted: Boolean,
+    ): PromptSubmission = submitPrompt(runtimeSessionId, text)
+
     /** Adds bounded steering text to the currently running turn. */
     suspend fun steer(runtimeSessionId: RuntimeSessionId, text: String): SessionSteerResult =
         throw HermesChatMethodNotFoundException("session.steer")
@@ -825,10 +838,17 @@ class HermesChatConnection internal constructor(
     override suspend fun submitPrompt(
         runtimeSessionId: RuntimeSessionId,
         text: String,
+    ): PromptSubmission = submitPrompt(runtimeSessionId, text, interrupted = false)
+
+    override suspend fun submitPrompt(
+        runtimeSessionId: RuntimeSessionId,
+        text: String,
+        interrupted: Boolean,
     ): PromptSubmission {
         val params = buildJsonObject {
             put("session_id", runtimeSessionId.value)
             put("text", text)
+            if (interrupted) put("interrupted", true)
         }
         val result = request("prompt.submit", params)
         val status = result.stringValue("status")

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
@@ -31,6 +31,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -130,6 +132,7 @@ import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Psychology
 import androidx.compose.material.icons.outlined.Speed
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -215,6 +218,19 @@ import com.unsupportedpastels.hermesandroid.artifacts.Artifact
 import com.unsupportedpastels.hermesandroid.artifacts.ArtifactExtractor
 import com.unsupportedpastels.hermesandroid.artifacts.ArtifactOrigin
 import com.unsupportedpastels.hermesandroid.artifacts.ArtifactType
+import com.unsupportedpastels.hermesandroid.voice.AutoSpeakEffect
+import com.unsupportedpastels.hermesandroid.voice.ComposerDictation
+import com.unsupportedpastels.hermesandroid.voice.ComposerVoiceConversation
+import com.unsupportedpastels.hermesandroid.voice.VoiceSettings
+import com.unsupportedpastels.hermesandroid.voice.VoiceSettingsSection
+import com.unsupportedpastels.hermesandroid.voice.DictationMicButton
+import com.unsupportedpastels.hermesandroid.voice.MessageReadAloud
+import com.unsupportedpastels.hermesandroid.voice.MessageSpeakerButton
+import com.unsupportedpastels.hermesandroid.voice.VoiceConversationBar
+import com.unsupportedpastels.hermesandroid.voice.VoiceConversationState
+import com.unsupportedpastels.hermesandroid.voice.VoiceConversationToggleButton
+import com.unsupportedpastels.hermesandroid.voice.rememberReadAloudSession
+import com.unsupportedpastels.hermesandroid.voice.rememberVoiceConversationHost
 import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
 import com.unsupportedpastels.hermesandroid.connection.ServerCatalog
 import com.unsupportedpastels.hermesandroid.connection.ServerCatalogEntry
@@ -367,6 +383,13 @@ fun HermesApp(
         Result.failure(UnsupportedOperationException("Bulk session deletion unavailable"))
     },
     onSearchTranscripts: (String) -> Unit = {},
+    dictation: ComposerDictation? = null,
+    readAloud: MessageReadAloud? = null,
+    voiceConversation: ComposerVoiceConversation? = null,
+    voiceSettings: VoiceSettings? = null,
+    autoSpeakEnabled: Boolean = false,
+    voiceScreenOffContinuation: Boolean = false,
+    onSendVoiceMessage: (DurableSessionId, String, Boolean) -> Unit = { _, _, _ -> },
     onSendMessage: (DurableSessionId, String) -> Unit = { _, _ -> },
     onReasoningSelected: (DurableSessionId, String) -> Unit = { _, _ -> },
     onFastSelected: (DurableSessionId, Boolean) -> Unit = { _, _ -> },
@@ -849,6 +872,16 @@ fun HermesApp(
                     SessionDetailScreen(
                         session = session,
                         chat = chat,
+                        dictation = dictation,
+                        readAloud = readAloud,
+                        voiceConversation = voiceConversation,
+                        // Voice turns are attachment-free and skip staged host
+                        // references — the spoken words are the whole prompt.
+                        onVoiceSubmit = { text, interrupted ->
+                            onSendVoiceMessage(session.id, text, interrupted)
+                        },
+                        autoSpeakEnabled = autoSpeakEnabled,
+                        voiceScreenOffContinuation = voiceScreenOffContinuation,
                         draft = drafts[draftKey].orEmpty(),
                         onDraftChanged = { updated ->
                             drafts[draftKey] = updated
@@ -966,6 +999,7 @@ fun HermesApp(
                     onLoadManagementSettings = onLoadManagementSettings,
                     onSetProfileDefaultModel = onSetProfileDefaultModel,
                     onSetProfileReasoningEffort = onSetProfileReasoningEffort,
+                    voiceSettings = voiceSettings,
                     onRefreshCronJobs = onRefreshCronJobs,
                     onCronJobAction = onCronJobAction,
                     onRunCronJob = onRunCronJob,
@@ -3593,6 +3627,7 @@ internal fun ServerSettingsScreen(
     onRunCronJob: (String) -> Unit = {},
     onToggleCronJobRuns: (String) -> Unit = {},
     onLogout: suspend () -> Unit = {},
+    voiceSettings: VoiceSettings? = null,
 ) {
     var value by rememberSaveable(serverOrigin?.value) {
         mutableStateOf(serverOrigin?.value.orEmpty())
@@ -3994,6 +4029,9 @@ internal fun ServerSettingsScreen(
                             Text(error, color = MaterialTheme.colorScheme.error)
                         }
                     }
+                    voiceSettings?.let { settings ->
+                        VoiceSettingsSection(settings)
+                    }
                     Text("Offline cache", style = MaterialTheme.typography.titleMedium)
                     Text(
                         "Session metadata is cached by default. Transcript tails are encrypted and opt-in.",
@@ -4120,6 +4158,12 @@ internal fun isTranscriptAtTrueEnd(
 private fun SessionDetailScreen(
     session: SessionSummary,
     chat: ChatSessionSnapshot,
+    dictation: ComposerDictation? = null,
+    readAloud: MessageReadAloud? = null,
+    voiceConversation: ComposerVoiceConversation? = null,
+    onVoiceSubmit: (String, Boolean) -> Unit = { _, _ -> },
+    autoSpeakEnabled: Boolean = false,
+    voiceScreenOffContinuation: Boolean = false,
     draft: String,
     onDraftChanged: (String) -> Unit,
     canSend: Boolean,
@@ -4166,6 +4210,7 @@ private fun SessionDetailScreen(
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
     val transcriptScope = rememberCoroutineScope()
+    val readAloudSession = rememberReadAloudSession(readAloud, session.id.value)
     var showSessionInsights by remember(session.id) { mutableStateOf(false) }
     var showHostFiles by remember(session.id) { mutableStateOf(false) }
     var showArtifacts by remember(session.id) { mutableStateOf(false) }
@@ -4469,6 +4514,18 @@ private fun SessionDetailScreen(
                                                 onLoadManagedImage(path).getOrThrow()
                                             },
                                         )
+                                        if (
+                                            readAloudSession != null &&
+                                            message.role == ChatMessageRole.Assistant &&
+                                            renderedText.isNotBlank()
+                                        ) {
+                                            MessageSpeakerButton(
+                                                session = readAloudSession,
+                                                messageKey = "message:$messageIndex",
+                                                text = renderedText,
+                                                enabled = true,
+                                            )
+                                        }
                                     }
                                 }
                             }
@@ -4575,6 +4632,31 @@ private fun SessionDetailScreen(
             }
             val composerEnabled = (!chat.isSending || steeringAvailable) && !chat.isLoading
             val attachmentsEnabled = canSend && composerEnabled && !steeringAvailable
+            val voiceHost = rememberVoiceConversationHost(
+                conversation = voiceConversation,
+                sessionId = session.id.value,
+                chat = chat,
+                onSubmit = onVoiceSubmit,
+                // Barge-in cuts the running turn through the same seam as the
+                // composer Stop button.
+                onStopTurn = onStop,
+                screenOffContinuation = voiceScreenOffContinuation,
+            )
+            val voiceConversationState = voiceHost?.controller?.state?.collectAsState()?.value
+            val voiceActive = voiceConversationState != null &&
+                voiceConversationState != VoiceConversationState.Idle
+            if (voiceHost != null) {
+                VoiceConversationBar(host = voiceHost)
+            }
+            // Server-configured auto-speak of new finalized replies; the active
+            // voice conversation owns speech and suppresses it.
+            AutoSpeakEffect(
+                readAloudSession = readAloudSession,
+                chat = chat,
+                enabled = autoSpeakEnabled,
+                suppressed = voiceActive,
+                sessionId = session.id.value,
+            )
             if (attachments.isNotEmpty() || hostReferences.isNotEmpty()) {
                 Row(
                     modifier = Modifier
@@ -4656,9 +4738,24 @@ private fun SessionDetailScreen(
                             )
                         }
                     }
+                    var draftFieldValue by remember {
+                        mutableStateOf(TextFieldValue(draft, TextRange(draft.length)))
+                    }
+                    // Keep the caret after externally-inserted text (dictation, slash
+                    // completion, clear-on-send) rather than leaving it at the start.
+                    if (draftFieldValue.text != draft) {
+                        draftFieldValue = draftFieldValue.copy(
+                            text = draft,
+                            selection = TextRange(draft.length),
+                        )
+                    }
                     BasicTextField(
-                        value = draft,
-                        onValueChange = onDraftChanged,
+                        value = draftFieldValue,
+                        onValueChange = { newValue ->
+                            val textChanged = newValue.text != draftFieldValue.text
+                            draftFieldValue = newValue
+                            if (textChanged) onDraftChanged(newValue.text)
+                        },
                         enabled = composerEnabled,
                         modifier = Modifier
                             .weight(1f)
@@ -4692,6 +4789,24 @@ private fun SessionDetailScreen(
                             }
                         },
                     )
+                    if (dictation != null) {
+                        DictationMicButton(
+                            dictation = dictation,
+                            // One microphone owner: dictation yields while the
+                            // voice conversation loop is running.
+                            enabled = composerEnabled && !voiceActive,
+                            onAppendTranscript = { transcript ->
+                                val base = draft.trimEnd()
+                                onDraftChanged(if (base.isEmpty()) transcript else "$base $transcript")
+                            },
+                        )
+                    }
+                    if (voiceHost != null) {
+                        VoiceConversationToggleButton(
+                            host = voiceHost,
+                            enabled = canSend && composerEnabled,
+                        )
+                    }
                     if (showStop) {
                         if (steeringAvailable) {
                             Button(

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
@@ -129,6 +129,7 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Psychology
 import androidx.compose.material.icons.outlined.Speed
 import androidx.compose.runtime.Composable
@@ -219,11 +220,9 @@ import com.unsupportedpastels.hermesandroid.artifacts.ArtifactExtractor
 import com.unsupportedpastels.hermesandroid.artifacts.ArtifactOrigin
 import com.unsupportedpastels.hermesandroid.artifacts.ArtifactType
 import com.unsupportedpastels.hermesandroid.voice.AutoSpeakEffect
-import com.unsupportedpastels.hermesandroid.voice.ComposerDictation
 import com.unsupportedpastels.hermesandroid.voice.ComposerVoiceConversation
 import com.unsupportedpastels.hermesandroid.voice.VoiceSettings
 import com.unsupportedpastels.hermesandroid.voice.VoiceSettingsSection
-import com.unsupportedpastels.hermesandroid.voice.DictationMicButton
 import com.unsupportedpastels.hermesandroid.voice.MessageReadAloud
 import com.unsupportedpastels.hermesandroid.voice.MessageSpeakerButton
 import com.unsupportedpastels.hermesandroid.voice.VoiceConversationBar
@@ -231,6 +230,8 @@ import com.unsupportedpastels.hermesandroid.voice.VoiceConversationState
 import com.unsupportedpastels.hermesandroid.voice.VoiceConversationToggleButton
 import com.unsupportedpastels.hermesandroid.voice.rememberReadAloudSession
 import com.unsupportedpastels.hermesandroid.voice.rememberVoiceConversationHost
+import com.unsupportedpastels.hermesandroid.voice.DeviceSpeechRecognizerController
+import com.unsupportedpastels.hermesandroid.voice.DeviceSpeechInputButton
 import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
 import com.unsupportedpastels.hermesandroid.connection.ServerCatalog
 import com.unsupportedpastels.hermesandroid.connection.ServerCatalogEntry
@@ -273,6 +274,7 @@ import com.unsupportedpastels.hermesandroid.session.toggleBulkSelection
 import com.unsupportedpastels.hermesandroid.share.SharePayload
 import com.unsupportedpastels.hermesandroid.theme.HermesAndroidTheme
 import com.unsupportedpastels.hermesandroid.theme.LocalHermesSemanticColors
+import com.unsupportedpastels.hermesandroid.voice.VoiceInputPolicy
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
@@ -383,7 +385,6 @@ fun HermesApp(
         Result.failure(UnsupportedOperationException("Bulk session deletion unavailable"))
     },
     onSearchTranscripts: (String) -> Unit = {},
-    dictation: ComposerDictation? = null,
     readAloud: MessageReadAloud? = null,
     voiceConversation: ComposerVoiceConversation? = null,
     voiceSettings: VoiceSettings? = null,
@@ -872,7 +873,6 @@ fun HermesApp(
                     SessionDetailScreen(
                         session = session,
                         chat = chat,
-                        dictation = dictation,
                         readAloud = readAloud,
                         voiceConversation = voiceConversation,
                         // Voice turns are attachment-free and skip staged host
@@ -882,6 +882,11 @@ fun HermesApp(
                         },
                         autoSpeakEnabled = autoSpeakEnabled,
                         voiceScreenOffContinuation = voiceScreenOffContinuation,
+                        voiceInputScopeKey = VoiceInputPolicy.scopeKey(
+                            serverOrigin = serverOrigin?.value,
+                            profile = snapshot.selectedProfile,
+                            durableSessionId = session.id.value,
+                        ),
                         draft = drafts[draftKey].orEmpty(),
                         onDraftChanged = { updated ->
                             drafts[draftKey] = updated
@@ -4158,12 +4163,12 @@ internal fun isTranscriptAtTrueEnd(
 private fun SessionDetailScreen(
     session: SessionSummary,
     chat: ChatSessionSnapshot,
-    dictation: ComposerDictation? = null,
     readAloud: MessageReadAloud? = null,
     voiceConversation: ComposerVoiceConversation? = null,
     onVoiceSubmit: (String, Boolean) -> Unit = { _, _ -> },
     autoSpeakEnabled: Boolean = false,
     voiceScreenOffContinuation: Boolean = false,
+    voiceInputScopeKey: String,
     draft: String,
     onDraftChanged: (String) -> Unit,
     canSend: Boolean,
@@ -4228,6 +4233,21 @@ private fun SessionDetailScreen(
         workspacePath == null
     var attachmentError by remember(session.id) { mutableStateOf<String?>(null) }
     var pendingSend by remember(session.id) { mutableStateOf<Pair<String, Int>?>(null) }
+    val currentDraft by rememberUpdatedState(draft)
+    val currentOnDraftChanged by rememberUpdatedState(onDraftChanged)
+    val deviceSpeechController = remember(context) {
+        DeviceSpeechRecognizerController(context)
+    }
+    val voiceInputAvailable = remember(context) {
+        DeviceSpeechRecognizerController.isAvailable(context)
+    }
+    LaunchedEffect(voiceInputScopeKey) {
+        deviceSpeechController.cancel()
+    }
+    DisposableEffect(session.id, deviceSpeechController) {
+        onDispose { deviceSpeechController.cancel() }
+    }
+
     val attachmentPicker = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenMultipleDocuments(),
     ) { uris ->
@@ -4789,23 +4809,30 @@ private fun SessionDetailScreen(
                             }
                         },
                     )
-                    if (dictation != null) {
-                        DictationMicButton(
-                            dictation = dictation,
-                            // One microphone owner: dictation yields while the
-                            // voice conversation loop is running.
+                    // Group the two voice controls tighter than the composer's
+                    // 4.dp spacing: each 40.dp button pads ~8.dp around its glyph,
+                    // so negative spacing pulls the glyphs closer without
+                    // overlapping their touch targets' visual centers.
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy((-10).dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        DeviceSpeechInputButton(
+                            controller = deviceSpeechController,
+                            available = voiceInputAvailable,
                             enabled = composerEnabled && !voiceActive,
-                            onAppendTranscript = { transcript ->
-                                val base = draft.trimEnd()
-                                onDraftChanged(if (base.isEmpty()) transcript else "$base $transcript")
-                            },
+                            currentDraft = currentDraft,
+                            onDraftChanged = currentOnDraftChanged,
+                            onError = { message -> attachmentError = message },
+                            modifier = Modifier.size(40.dp),
                         )
-                    }
-                    if (voiceHost != null) {
-                        VoiceConversationToggleButton(
-                            host = voiceHost,
-                            enabled = canSend && composerEnabled,
-                        )
+                        if (voiceHost != null) {
+                            VoiceConversationToggleButton(
+                                host = voiceHost,
+                                enabled = canSend && composerEnabled,
+                                modifier = Modifier.size(40.dp),
+                            )
+                        }
                     }
                     if (showStop) {
                         if (steeringAvailable) {
@@ -4853,6 +4880,7 @@ private fun SessionDetailScreen(
                     } else {
                         FilledIconButton(
                             onClick = {
+                                deviceSpeechController.finish()
                                 val message = draft.trim()
                                 val reasoningEffort = reasoningEffortCommand(message)
                                 keyboardController?.hide()

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/AndroidDictationEngine.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/AndroidDictationEngine.kt
@@ -1,0 +1,139 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.content.Context
+import android.media.MediaRecorder
+import android.os.Build
+import java.io.File
+import java.util.Base64
+
+/** A finished recording, ready to POST to `/api/audio/transcribe`. */
+data class DictationRecording(val dataUrl: String, val mimeType: String)
+
+/**
+ * Captures a single dictation utterance. Implementations are Android-backed
+ * ([MediaRecorderDictationRecorder]); the polling/silence/elapsed logic that
+ * drives [DictationController] lives in the composable host so it stays testable.
+ */
+interface DictationRecorder {
+    /** MIME type the encoded recording will carry. */
+    val mimeType: String
+
+    /** Begin capture. Returns false if the recorder could not start. */
+    fun start(): Boolean
+
+    /** Peak amplitude since the previous sample, normalised to 0..1. */
+    fun sampleLevel(): Float
+
+    /** Peak amplitude since the previous sample on the raw 0..32767 scale (for silence checks). */
+    fun sampleAmplitude(): Int
+
+    /** Stop capture and encode the recording, or null if nothing was captured. */
+    fun stopAndEncode(): DictationRecording?
+
+    /** Discard the in-progress recording and release resources. */
+    fun cancel()
+}
+
+/**
+ * Build a `data:<mime>;base64,<...>` URL from raw audio bytes. Pure (JVM
+ * Base64) so it is unit-testable without a device.
+ */
+fun encodeAudioDataUrl(bytes: ByteArray, mimeType: String): String {
+    val encoded = Base64.getEncoder().encodeToString(bytes)
+    return "data:$mimeType;base64,$encoded"
+}
+
+private const val MAX_AMPLITUDE = 32_767f
+
+/**
+ * [MediaRecorder]-backed recorder producing an AAC/MPEG-4 (`audio/mp4`) clip in
+ * the app cache. Mirrors [com.unsupportedpastels.hermesandroid.ui] audio
+ * conventions: a dedicated cache subdir and best-effort temp-file cleanup.
+ */
+class MediaRecorderDictationRecorder(
+    private val context: Context,
+) : DictationRecorder {
+    override val mimeType: String = "audio/mp4"
+
+    private var recorder: MediaRecorder? = null
+    private var outputFile: File? = null
+
+    @Suppress("DEPRECATION")
+    private fun newRecorder(): MediaRecorder =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            MediaRecorder(context)
+        } else {
+            MediaRecorder()
+        }
+
+    override fun start(): Boolean {
+        cancel()
+        return try {
+            val directory = File(context.cacheDir, "dictation").apply { mkdirs() }
+            val file = File.createTempFile("dictation-", ".m4a", directory)
+            val recorder = newRecorder().apply {
+                setAudioSource(MediaRecorder.AudioSource.VOICE_COMMUNICATION)
+                setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+                setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+                setAudioEncodingBitRate(96_000)
+                setAudioSamplingRate(44_100)
+                setOutputFile(file.absolutePath)
+                prepare()
+                start()
+            }
+            this.recorder = recorder
+            this.outputFile = file
+            true
+        } catch (_: Exception) {
+            cancel()
+            false
+        }
+    }
+
+    override fun sampleAmplitude(): Int =
+        try {
+            recorder?.maxAmplitude ?: 0
+        } catch (_: Exception) {
+            0
+        }
+
+    override fun sampleLevel(): Float = (sampleAmplitude() / MAX_AMPLITUDE).coerceIn(0f, 1f)
+
+    override fun stopAndEncode(): DictationRecording? {
+        val recorder = this.recorder
+        val file = this.outputFile
+        this.recorder = null
+        this.outputFile = null
+        return try {
+            recorder?.apply {
+                stop()
+                release()
+            }
+            val bytes = file?.takeIf { it.exists() }?.readBytes()
+            if (bytes == null || bytes.isEmpty()) {
+                null
+            } else {
+                DictationRecording(encodeAudioDataUrl(bytes, mimeType), mimeType)
+            }
+        } catch (_: Exception) {
+            null
+        } finally {
+            file?.delete()
+        }
+    }
+
+    override fun cancel() {
+        try {
+            recorder?.apply {
+                runCatching { stop() }
+                release()
+            }
+        } catch (_: Exception) {
+            // A recorder that never started throws on stop(); release is best-effort.
+        } finally {
+            recorder = null
+            outputFile?.delete()
+            outputFile = null
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/AudioRecordBargeRecorder.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/AudioRecordBargeRecorder.kt
@@ -1,0 +1,241 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.Manifest
+import android.content.Context
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
+import android.media.audiofx.AcousticEchoCanceler
+import android.media.audiofx.NoiseSuppressor
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.abs
+
+/**
+ * Device capability/result for the capture session used by full-duplex barge
+ * monitoring. A VOICE_COMMUNICATION source can select a platform preprocessor,
+ * but only the attached effect/session state proves that AEC is active.
+ */
+data class VoiceAudioProcessingStatus(
+    val audioSessionId: Int,
+    val acousticEchoCancelerAvailable: Boolean,
+    val acousticEchoCancelerEnabled: Boolean,
+    val noiseSuppressorAvailable: Boolean,
+    val noiseSuppressorEnabled: Boolean,
+)
+
+/**
+ * AudioRecord-backed barge recorder with explicit platform AEC/NS attachment.
+ * The recorder continuously drains PCM on a reader thread so amplitude samples
+ * and the final WAV clip come from the same post-processed capture path.
+ */
+class AudioRecordBargeRecorder(
+    private val context: Context,
+    private val sampleRateHz: Int = DEFAULT_SAMPLE_RATE_HZ,
+    private val onDiagnostics: (String) -> Unit = {},
+) : DictationRecorder {
+    override val mimeType: String = "audio/wav"
+
+    @Volatile
+    var processingStatus: VoiceAudioProcessingStatus? = null
+        private set
+
+    private var audioRecord: AudioRecord? = null
+    private var echoCanceler: AcousticEchoCanceler? = null
+    private var noiseSuppressor: NoiseSuppressor? = null
+    private var readerThread: Thread? = null
+    private val running = AtomicBoolean(false)
+    private val peakAmplitude = AtomicInteger(0)
+    private val pcm = ByteArrayOutputStream()
+
+    override fun start(): Boolean {
+        cancel()
+        synchronized(pcm) { pcm.reset() }
+        peakAmplitude.set(0)
+
+        if (context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) !=
+            android.content.pm.PackageManager.PERMISSION_GRANTED
+        ) {
+            onDiagnostics("audio:aec-recorder-unavailable reason=permission-denied")
+            return false
+        }
+
+        val channelConfig = AudioFormat.CHANNEL_IN_MONO
+        val audioFormat = AudioFormat.ENCODING_PCM_16BIT
+        val minimumBuffer = AudioRecord.getMinBufferSize(sampleRateHz, channelConfig, audioFormat)
+        if (minimumBuffer <= 0) {
+            onDiagnostics("audio:aec-recorder-unavailable reason=invalid-buffer")
+            return false
+        }
+
+        val record = try {
+            AudioRecord.Builder()
+                .setAudioSource(MediaRecorder.AudioSource.VOICE_COMMUNICATION)
+                .setAudioFormat(
+                    AudioFormat.Builder()
+                        .setEncoding(audioFormat)
+                        .setSampleRate(sampleRateHz)
+                        .setChannelMask(channelConfig)
+                        .build(),
+                )
+                .setBufferSizeInBytes((minimumBuffer * 2).coerceAtLeast(sampleRateHz / 2))
+                .build()
+        } catch (_: Exception) {
+            onDiagnostics("audio:aec-recorder-unavailable reason=construct-failed")
+            return false
+        }
+
+        if (record.state != AudioRecord.STATE_INITIALIZED) {
+            record.release()
+            onDiagnostics("audio:aec-recorder-unavailable reason=not-initialized")
+            return false
+        }
+
+        val sessionId = record.audioSessionId
+        val aecAvailable = AcousticEchoCanceler.isAvailable()
+        val nsAvailable = NoiseSuppressor.isAvailable()
+        val aec = if (aecAvailable) runCatching {
+            AcousticEchoCanceler.create(sessionId)
+        }.getOrNull() else null
+        val ns = if (nsAvailable) runCatching {
+            NoiseSuppressor.create(sessionId)
+        }.getOrNull() else null
+
+        val aecEnabled = aec?.let { runCatching { it.enabled = true }.isSuccess && it.enabled } == true
+        val nsEnabled = ns?.let { runCatching { it.enabled = true }.isSuccess && it.enabled } == true
+        processingStatus = VoiceAudioProcessingStatus(
+            audioSessionId = sessionId,
+            acousticEchoCancelerAvailable = aecAvailable,
+            acousticEchoCancelerEnabled = aecEnabled,
+            noiseSuppressorAvailable = nsAvailable,
+            noiseSuppressorEnabled = nsEnabled,
+        )
+        onDiagnostics(
+            "audio:aec-status session=$sessionId " +
+                "aecAvailable=$aecAvailable aecEnabled=$aecEnabled " +
+                "nsAvailable=$nsAvailable nsEnabled=$nsEnabled",
+        )
+
+        return try {
+            record.startRecording()
+            if (record.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
+                throw IllegalStateException("recording-not-started")
+            }
+            audioRecord = record
+            echoCanceler = aec
+            noiseSuppressor = ns
+            running.set(true)
+            readerThread = Thread({ readLoop(record) }, "hermes-aec-capture").apply {
+                isDaemon = true
+                start()
+            }
+            onDiagnostics("audio:aec-capture-started rate=$sampleRateHz")
+            true
+        } catch (_: Exception) {
+            runCatching { ns?.release() }
+            runCatching { aec?.release() }
+            runCatching { record.release() }
+            processingStatus = null
+            onDiagnostics("audio:aec-recorder-unavailable reason=start-failed")
+            false
+        }
+    }
+
+    override fun sampleAmplitude(): Int = peakAmplitude.getAndSet(0)
+
+    override fun sampleLevel(): Float =
+        (sampleAmplitude() / MAX_AMPLITUDE).coerceIn(0f, 1f)
+
+    override fun stopAndEncode(): DictationRecording? {
+        stopCapture()
+        val pcmBytes = synchronized(pcm) { pcm.toByteArray() }
+        if (pcmBytes.isEmpty()) return null
+        return DictationRecording(
+            dataUrl = encodeAudioDataUrl(pcm16MonoToWav(pcmBytes, sampleRateHz), mimeType),
+            mimeType = mimeType,
+        )
+    }
+
+    override fun cancel() {
+        stopCapture()
+        synchronized(pcm) { pcm.reset() }
+        peakAmplitude.set(0)
+    }
+
+    private fun readLoop(record: AudioRecord) {
+        val buffer = ByteArray(BUFFER_BYTES)
+        while (running.get()) {
+            val count = try {
+                record.read(buffer, 0, buffer.size, AudioRecord.READ_BLOCKING)
+            } catch (_: Exception) {
+                break
+            }
+            if (count <= 0) continue
+            synchronized(pcm) { pcm.write(buffer, 0, count) }
+            val peak = pcmPeakAmplitude(buffer, count)
+            if (peak > 0) peakAmplitude.getAndUpdate { current -> maxOf(current, peak) }
+        }
+    }
+
+    private fun stopCapture() {
+        running.set(false)
+        audioRecord?.let { runCatching { it.stop() } }
+        readerThread?.let { thread ->
+            runCatching { thread.join(READER_JOIN_TIMEOUT_MILLIS) }
+        }
+        readerThread = null
+        runCatching { noiseSuppressor?.release() }
+        runCatching { echoCanceler?.release() }
+        noiseSuppressor = null
+        echoCanceler = null
+        audioRecord?.let { runCatching { it.release() } }
+        audioRecord = null
+    }
+
+    private companion object {
+        const val DEFAULT_SAMPLE_RATE_HZ = 16_000
+        const val BUFFER_BYTES = 3_200
+        const val READER_JOIN_TIMEOUT_MILLIS = 250L
+        const val MAX_AMPLITUDE = 32_767f
+    }
+}
+
+private fun pcmPeakAmplitude(bytes: ByteArray, length: Int): Int {
+    var peak = 0
+    var index = 0
+    while (index + 1 < length) {
+        val unsigned = (bytes[index].toInt() and 0xff) or
+            ((bytes[index + 1].toInt() and 0xff) shl 8)
+        val signed = if (unsigned > Short.MAX_VALUE) unsigned - (1 shl 16) else unsigned
+        peak = maxOf(peak, abs(signed))
+        index += 2
+    }
+    return peak
+}
+
+/** Wrap little-endian mono PCM16 bytes in a bounded RIFF/WAV container. */
+internal fun pcm16MonoToWav(pcm: ByteArray, sampleRateHz: Int): ByteArray {
+    val byteRate = sampleRateHz * 2
+    return ByteBuffer.allocate(44 + pcm.size)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .apply {
+            put("RIFF".toByteArray())
+            putInt(36 + pcm.size)
+            put("WAVE".toByteArray())
+            put("fmt ".toByteArray())
+            putInt(16)
+            putShort(1)
+            putShort(1)
+            putInt(sampleRateHz)
+            putInt(byteRate)
+            putShort(2)
+            putShort(16)
+            put("data".toByteArray())
+            putInt(pcm.size)
+            put(pcm)
+        }
+        .array()
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/AudioTrackSpeechSink.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/AudioTrackSpeechSink.kt
@@ -1,0 +1,116 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Streams mono int16 PCM from `/api/audio/speak-stream` through an [AudioTrack]
+ * in streaming mode. Created lazily on the server's start frame (which carries
+ * the sample rate); writes are blocking on [ioDispatcher]; an odd trailing byte
+ * is carried into the next frame so 16-bit samples never split across writes.
+ */
+class AudioTrackSpeechSink(
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val trackFactory: (sampleRateHz: Int) -> AudioTrack = ::defaultTrack,
+) : PcmSpeechSink {
+    private var track: AudioTrack? = null
+    private var carriedByte: Byte? = null
+
+    override fun start(sampleRateHz: Int, channels: Int): Boolean {
+        if (channels != 1) return false
+        stop()
+        return try {
+            val created = trackFactory(sampleRateHz)
+            if (created.state != AudioTrack.STATE_INITIALIZED) {
+                created.release()
+                return false
+            }
+            created.play()
+            track = created
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    override suspend fun write(pcm: ByteArray) {
+        val activeTrack = track ?: return
+        // Re-attach a carried odd byte so samples stay 16-bit aligned.
+        val carried = carriedByte
+        val aligned: ByteArray
+        if (carried != null) {
+            aligned = ByteArray(pcm.size + 1)
+            aligned[0] = carried
+            pcm.copyInto(aligned, 1)
+            carriedByte = null
+        } else {
+            aligned = pcm
+        }
+        val writable = aligned.size and 1.inv()
+        if (writable < aligned.size) carriedByte = aligned[aligned.size - 1]
+        if (writable == 0) return
+        withContext(ioDispatcher) {
+            var offset = 0
+            while (offset < writable) {
+                val written = activeTrack.write(aligned, offset, writable - offset)
+                if (written <= 0) break
+                offset += written
+            }
+        }
+    }
+
+    override suspend fun finish() {
+        val activeTrack = track ?: return
+        withContext(ioDispatcher) {
+            try {
+                activeTrack.stop()
+            } catch (_: Exception) {
+            }
+            activeTrack.release()
+        }
+        track = null
+        carriedByte = null
+    }
+
+    override fun stop() {
+        track?.let {
+            runCatching { it.pause() }
+            runCatching { it.flush() }
+            runCatching { it.stop() }
+            it.release()
+        }
+        track = null
+        carriedByte = null
+    }
+
+    private companion object {
+        fun defaultTrack(sampleRateHz: Int): AudioTrack {
+            val minBuffer = AudioTrack.getMinBufferSize(
+                sampleRateHz,
+                AudioFormat.CHANNEL_OUT_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+            ).coerceAtLeast(sampleRateHz / 2)
+            return AudioTrack.Builder()
+                .setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .build(),
+                )
+                .setAudioFormat(
+                    AudioFormat.Builder()
+                        .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                        .setSampleRate(sampleRateHz)
+                        .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                        .build(),
+                )
+                .setTransferMode(AudioTrack.MODE_STREAM)
+                .setBufferSizeInBytes(minBuffer * 2)
+                .build()
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/AutoSpeak.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/AutoSpeak.kt
@@ -1,0 +1,107 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import com.unsupportedpastels.hermesandroid.gateway.ChatSessionSnapshot
+import kotlinx.coroutines.flow.combine
+
+/** A finalized reply eligible for auto-speak. */
+data class AutoSpeakTarget(val index: Int, val text: String)
+
+/**
+ * Decides which finalized assistant reply auto-speak reads next, mirroring
+ * Desktop's use-auto-speak-replies: history is never read, only replies that
+ * finalize while the policy is watching, each at most once, backlog collapsed
+ * to the newest eligible reply.
+ *
+ * "History" is defined defensively, because transcript loading and session
+ * resume can replace the message list at any moment: the first view observed,
+ * any view whose list SHRANK, and any view that grew by more than a single
+ * turn plausibly could (a bulk transcript load) all re-mark everything present
+ * as already spoken. Only a reply that appears through ordinary incremental
+ * growth is ever read aloud.
+ */
+class AutoSpeakPolicy {
+    private var lastSeenCount = -1
+    private var lastSpokenIndex = Int.MAX_VALUE
+
+    /** Everything currently visible becomes history. */
+    fun markAllSpoken(view: VoiceReplyView) {
+        lastSpokenIndex = view.finalAssistantIndex
+        lastSeenCount = view.messageCount
+    }
+
+    /** Newest eligible finalized reply, or null when there is nothing new. */
+    fun nextToSpeak(view: VoiceReplyView): AutoSpeakTarget? {
+        val firstObservation = lastSeenCount < 0
+        val listReplaced = view.messageCount < lastSeenCount
+        val bulkGrowth = !firstObservation &&
+            view.messageCount - lastSeenCount > MAX_INCREMENTAL_GROWTH
+        if (firstObservation || listReplaced || bulkGrowth) {
+            markAllSpoken(view)
+            return null
+        }
+        lastSeenCount = view.messageCount
+        val index = view.finalAssistantIndex
+        val text = view.finalAssistantText ?: return null
+        if (index <= lastSpokenIndex) return null
+        return AutoSpeakTarget(index, text)
+    }
+
+    fun markSpoken(index: Int) {
+        if (lastSpokenIndex == Int.MAX_VALUE || index > lastSpokenIndex) {
+            lastSpokenIndex = index
+        }
+    }
+
+    private companion object {
+        /** One turn adds a handful of rows incrementally; a whole transcript
+         * arriving at once adds many — treat that as a load, not new replies. */
+        const val MAX_INCREMENTAL_GROWTH = 4
+    }
+}
+
+/**
+ * Speaks new finalized replies in the currently open session through the shared
+ * [ReadAloudSession] (so auto-speak, manual speaker buttons, and artifact audio
+ * stay mutually exclusive). Holds while any clip owns playback and re-checks
+ * when it goes idle; [suppressed] (an active voice conversation) pauses it —
+ * conversation playback owns speech.
+ */
+@Composable
+fun AutoSpeakEffect(
+    readAloudSession: ReadAloudSession?,
+    chat: ChatSessionSnapshot,
+    enabled: Boolean,
+    suppressed: Boolean,
+    sessionId: String,
+) {
+    if (readAloudSession == null || !enabled) return
+    val chatState = rememberUpdatedState(chat)
+    // A new policy per session entry: its first observation (and any transcript
+    // reload it sees) marks everything present as history, never read aloud.
+    val policy = remember(sessionId) { AutoSpeakPolicy() }
+    val suppressedState = rememberUpdatedState(suppressed)
+    LaunchedEffect(policy, readAloudSession) {
+        combine(
+            snapshotFlow { chatState.value.isLoading to chatState.value.toVoiceReplyView() },
+            readAloudSession.controller.state,
+        ) { view, playback -> view to playback }
+            .collect { (loadingAndView, playback) ->
+                val (loading, view) = loadingAndView
+                if (loading) {
+                    // History still arriving — everything visible stays history.
+                    policy.markAllSpoken(view)
+                    return@collect
+                }
+                if (suppressedState.value) return@collect
+                if (playback != SpeechPlaybackState.Idle) return@collect
+                val target = policy.nextToSpeak(view) ?: return@collect
+                policy.markSpoken(target.index)
+                readAloudSession.toggle("auto:$sessionId:${target.index}", target.text)
+            }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/BargeInDetector.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/BargeInDetector.kt
@@ -1,0 +1,130 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+/** Server-configured trip point: the silence floor scaled by
+ * `voice.barge_in_threshold_multiplier`. On Android's peak-amplitude scale this
+ * is a lower bound only — [BargeInDetector] raises it above the measured
+ * ambient floor, mirroring Desktop's quiet-floor calibration. */
+fun VoiceServerConfig.bargeTriggerAmplitude(): Int =
+    (silenceThreshold * bargeInThresholdMultiplier).toInt()
+        .coerceIn(minOf(silenceThreshold + 1, 32_767), 32_767)
+
+/**
+ * Deterministic amplitude-based barge-in detector. The grace window after the
+ * monitor starts (server `voice.barge_in_grace_seconds`, covering TTS onset
+ * bleed) doubles as ambient calibration: the effective trip point is the
+ * loudest of the server-configured trigger, 3× the calibrated ambient peak,
+ * and an absolute speech minimum — bounded so real speech always stays
+ * detectable. A trigger then requires [requiredConsecutiveSamples] consecutive
+ * samples at or above that trip point, so a cough or bump doesn't cut the
+ * reply. Pure and clock-free: the caller feeds (elapsedMillis, amplitude).
+ */
+class BargeInDetector(
+    private val configuredTriggerAmplitude: Int,
+    private val graceMillis: Long,
+    private val requiredConsecutiveSamples: Int = DEFAULT_REQUIRED_CONSECUTIVE_SAMPLES,
+) {
+    private var consecutive = 0
+    private var triggered = false
+
+    /** Loudest sample seen during the grace/calibration window. */
+    var ambientPeakAmplitude: Int = 0
+        private set
+
+    val effectiveTriggerAmplitude: Int
+        get() = maxOf(
+            configuredTriggerAmplitude,
+            ambientPeakAmplitude * 3,
+            MIN_TRIGGER_AMPLITUDE,
+        ).coerceAtMost(MAX_TRIGGER_AMPLITUDE)
+
+    private var playbackStartedAtMillis = -1L
+    private var playbackBleedPeak = 0
+
+    /** While TTS is audible the phone's own speaker bleeds into the mic far
+     * above room tone. Mirroring Desktop's voice-barge-in.ts: the first
+     * [PLAYBACK_GRACE_MILLIS] of each playback are a no-trigger window that
+     * doubles as bleed calibration, and the trip point is the loudest of the
+     * playback minimum (0.14 of full scale), 1.5× the measured bleed peak, and
+     * the ambient trigger — capped at the ceiling (0.37) so genuinely loud
+     * user speech still barges through. */
+    val playbackTriggerAmplitude: Int
+        get() = maxOf(
+            effectiveTriggerAmplitude,
+            PLAYBACK_MIN_TRIGGER,
+            (playbackBleedPeak * 3) / 2,
+        ).coerceAtMost(PLAYBACK_CEILING)
+
+    /** Post-trigger silence floor for utterance end-pointing. */
+    val silenceFloorAmplitude: Int
+        get() = maxOf((ambientPeakAmplitude * 7) / 4, MIN_SILENCE_FLOOR)
+            .coerceAtMost(MAX_SILENCE_FLOOR)
+
+    /**
+     * Feed one sample; returns true exactly once, at the trigger moment.
+     * [playbackActive] = TTS is audible right now: the trip point rises to the
+     * playback clamp and the sustained-speech requirement lengthens, so the
+     * reply's own audio cannot cut the reply.
+     */
+    fun onSample(elapsedMillis: Long, amplitude: Int, playbackActive: Boolean = false): Boolean {
+        if (triggered) return false
+        if (elapsedMillis < graceMillis) {
+            if (amplitude > ambientPeakAmplitude) ambientPeakAmplitude = amplitude
+            consecutive = 0
+            return false
+        }
+        if (playbackActive) {
+            if (playbackStartedAtMillis < 0) playbackStartedAtMillis = elapsedMillis
+            // Playback grace: no triggering while the speaker's own onset
+            // bleeds into the mic; the window calibrates the bleed level.
+            if (elapsedMillis - playbackStartedAtMillis < PLAYBACK_GRACE_MILLIS) {
+                if (amplitude > playbackBleedPeak) playbackBleedPeak = amplitude
+                consecutive = 0
+                return false
+            }
+        } else {
+            playbackStartedAtMillis = -1L
+        }
+        val trigger = if (playbackActive) playbackTriggerAmplitude else effectiveTriggerAmplitude
+        val required = if (playbackActive) {
+            PLAYBACK_REQUIRED_CONSECUTIVE_SAMPLES
+        } else {
+            requiredConsecutiveSamples
+        }
+        if (amplitude >= trigger) {
+            consecutive++
+            if (consecutive >= required) {
+                triggered = true
+                return true
+            }
+        } else {
+            consecutive = 0
+        }
+        return false
+    }
+
+    companion object {
+        /** At the 100 ms sampling cadence this is ~300 ms of sustained speech. */
+        const val DEFAULT_REQUIRED_CONSECUTIVE_SAMPLES = 3
+
+        /** Below this peak it isn't speech on any real device. */
+        private const val MIN_TRIGGER_AMPLITUDE = 2_500
+
+        /** Even loud playback bleed must leave genuine speech detectable. */
+        private const val MAX_TRIGGER_AMPLITUDE = 30_000
+
+        /** Desktop's playback-phase minimum (0.14 × 32767). */
+        private const val PLAYBACK_MIN_TRIGGER = 4_600
+
+        /** Desktop's playback-phase ceiling (0.37 × 32767). */
+        private const val PLAYBACK_CEILING = 12_200
+
+        /** ~500 ms of sustained speech before cutting audible playback. */
+        private const val PLAYBACK_REQUIRED_CONSECUTIVE_SAMPLES = 5
+
+        /** Desktop's playback grace: no triggers while bleed calibrates. */
+        private const val PLAYBACK_GRACE_MILLIS = 500L
+
+        private const val MIN_SILENCE_FLOOR = 400
+        private const val MAX_SILENCE_FLOOR = 6_000
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechInputButton.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechInputButton.kt
@@ -1,0 +1,55 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.Stop
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+/** Composer mic for app-owned, pause-tolerant device speech recognition. */
+@Composable
+fun DeviceSpeechInputButton(
+    controller: DeviceSpeechRecognizerController,
+    available: Boolean,
+    enabled: Boolean,
+    currentDraft: String,
+    onDraftChanged: (String) -> Unit,
+    onError: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by controller.state.collectAsState()
+    val active = state != DeviceSpeechRecognizerState.Idle
+    val description = if (active) "Stop voice input" else "Voice input"
+
+    IconButton(
+        onClick = {
+            if (active) {
+                controller.finish()
+            } else if (!controller.start(currentDraft, onDraftChanged, onError)) {
+                onError("Voice input is unavailable")
+            }
+        },
+        enabled = enabled && (available || active),
+        modifier = modifier.semantics { contentDescription = description },
+    ) {
+        Icon(
+            imageVector = if (active) Icons.Outlined.Stop else Icons.Outlined.Mic,
+            contentDescription = null,
+            tint = if (active) {
+                MaterialTheme.colorScheme.primary
+            } else if (available && enabled) {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            } else {
+                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechRecognizerController.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechRecognizerController.kt
@@ -1,0 +1,209 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.content.Context
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** Visible lifecycle of the app-owned native recognizer. */
+enum class DeviceSpeechRecognizerState {
+    Idle,
+    Listening,
+    Restarting,
+}
+
+/**
+ * App-owned wrapper around the installed Android recognition service. Unlike
+ * ACTION_RECOGNIZE_SPEECH, this keeps control of the recognition session and
+ * restarts it after provider endpointing, preserving the accumulated draft.
+ */
+class DeviceSpeechRecognizerController(
+    private val context: Context,
+) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val _state = MutableStateFlow(DeviceSpeechRecognizerState.Idle)
+    val state: StateFlow<DeviceSpeechRecognizerState> = _state.asStateFlow()
+
+    private var recognizer: SpeechRecognizer? = null
+    private var generation = 0L
+    private var baseDraft = ""
+    private var committedDraft = ""
+    private var onDraftChanged: ((String) -> Unit)? = null
+    private var onError: ((String) -> Unit)? = null
+
+    val isActive: Boolean
+        get() = _state.value != DeviceSpeechRecognizerState.Idle
+
+    fun start(
+        currentDraft: String,
+        onDraftChanged: (String) -> Unit,
+        onError: (String) -> Unit,
+    ): Boolean {
+        stop(keepDraft = false)
+        if (!isAvailable(context)) return false
+
+        baseDraft = currentDraft
+        committedDraft = currentDraft
+        this.onDraftChanged = onDraftChanged
+        this.onError = onError
+        generation++
+        val token = generation
+        recognizer = runCatching {
+            SpeechRecognizer.createSpeechRecognizer(context).apply {
+                setRecognitionListener(Listener(token))
+            }
+        }.getOrNull()
+        if (recognizer == null) {
+            clearCallbacks()
+            return false
+        }
+        _state.value = DeviceSpeechRecognizerState.Listening
+        startListening(token)
+        return true
+    }
+
+    /** Finish and keep all recognized text currently in the draft. */
+    fun finish() {
+        stop(keepDraft = true)
+    }
+
+    /** Cancel and restore the draft as it was before recognition started. */
+    fun cancel() {
+        stop(keepDraft = false)
+    }
+
+    private fun startListening(token: Long) {
+        if (!isCurrent(token)) return
+        try {
+            recognizer?.startListening(recognitionIntent())
+            _state.value = DeviceSpeechRecognizerState.Listening
+        } catch (_: Exception) {
+            scheduleRestart(token)
+        }
+    }
+
+    private fun scheduleRestart(token: Long) {
+        if (!isCurrent(token)) return
+        _state.value = DeviceSpeechRecognizerState.Restarting
+        mainHandler.postDelayed(
+            { startListening(token) },
+            RESTART_DELAY_MILLIS,
+        )
+    }
+
+    private fun handlePartial(token: Long, results: BundleText?) {
+        if (!isCurrent(token)) return
+        val text = results?.text ?: return
+        onDraftChanged?.invoke(VoiceInputPolicy.mergeDraft(committedDraft, text))
+    }
+
+    private fun handleFinal(token: Long, results: BundleText?) {
+        if (!isCurrent(token)) return
+        val text = results?.text
+        if (!text.isNullOrBlank()) {
+            committedDraft = VoiceInputPolicy.mergeDraft(committedDraft, text)
+            onDraftChanged?.invoke(committedDraft)
+        }
+        // Google endpointing can close a recognition segment after a short
+        // pause. Restart while preserving committedDraft instead of ending the
+        // user’s conversational input.
+        scheduleRestart(token)
+    }
+
+    private fun handleError(token: Long, error: Int) {
+        if (!isCurrent(token)) return
+        if (error == SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS ||
+            error == SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED ||
+            error == SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE
+        ) {
+            onError?.invoke("Voice input is unavailable")
+            stop(keepDraft = true)
+        } else {
+            // No-match, speech-timeout, client, and provider endpoint errors
+            // are recoverable while the user keeps the voice-input surface open.
+            scheduleRestart(token)
+        }
+    }
+
+    private fun stop(keepDraft: Boolean) {
+        generation++
+        mainHandler.removeCallbacksAndMessages(null)
+        recognizer?.let {
+            runCatching { it.cancel() }
+            it.destroy()
+        }
+        recognizer = null
+        if (!keepDraft) onDraftChanged?.invoke(baseDraft)
+        clearCallbacks()
+        _state.value = DeviceSpeechRecognizerState.Idle
+    }
+
+    private fun clearCallbacks() {
+        onDraftChanged = null
+        onError = null
+        baseDraft = ""
+        committedDraft = ""
+    }
+
+    private fun isCurrent(token: Long): Boolean = token == generation && recognizer != null
+
+    private fun recognitionIntent(): Intent =
+        Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(
+                RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
+            )
+            putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 3)
+            putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+        }
+
+    private inner class Listener(private val token: Long) : RecognitionListener {
+        override fun onReadyForSpeech(params: android.os.Bundle?) {
+            if (isCurrent(token)) _state.value = DeviceSpeechRecognizerState.Listening
+        }
+
+        override fun onBeginningOfSpeech() = Unit
+
+        override fun onRmsChanged(rmsdB: Float) = Unit
+
+        override fun onBufferReceived(buffer: ByteArray?) = Unit
+
+        override fun onEndOfSpeech() = Unit
+
+        override fun onError(error: Int) {
+            handleError(token, error)
+        }
+
+        override fun onResults(results: android.os.Bundle?) {
+            handleFinal(token, results?.let(::BundleText))
+        }
+
+        override fun onPartialResults(partialResults: android.os.Bundle?) {
+            handlePartial(token, partialResults?.let(::BundleText))
+        }
+
+        override fun onEvent(eventType: Int, params: android.os.Bundle?) = Unit
+    }
+
+    private data class BundleText(val text: String?) {
+        constructor(bundle: android.os.Bundle) : this(
+            bundle.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+                ?.firstOrNull()
+                ?.trim()
+                ?.takeIf(String::isNotEmpty),
+        )
+    }
+
+    companion object {
+        private const val RESTART_DELAY_MILLIS = 150L
+
+        fun isAvailable(context: Context): Boolean =
+            SpeechRecognizer.isRecognitionAvailable(context)
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechRecognizerController.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechRecognizerController.kt
@@ -204,6 +204,6 @@ class DeviceSpeechRecognizerController(
         private const val RESTART_DELAY_MILLIS = 150L
 
         fun isAvailable(context: Context): Boolean =
-            SpeechRecognizer.isRecognitionAvailable(context)
+            runCatching { SpeechRecognizer.isRecognitionAvailable(context) }.getOrDefault(false)
     }
 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DictationController.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DictationController.kt
@@ -1,0 +1,102 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** Why a dictation attempt ended without producing a transcript. */
+enum class DictationFailure {
+    PermissionDenied,
+    Unavailable,
+    NoSpeech,
+    RecordingFailed,
+    TranscriptionFailed,
+}
+
+/**
+ * Phase of a single dictation attempt. The controller only tracks phase — it
+ * never holds or sends the transcript. Recognised text flows straight from the
+ * engine/transport into the composer draft, so dictation can *never* auto-send.
+ */
+sealed interface DictationState {
+    data object Idle : DictationState
+
+    data class Recording(val elapsedMillis: Long, val level: Float) : DictationState
+
+    data object Transcribing : DictationState
+
+    data class Failed(val reason: DictationFailure) : DictationState
+}
+
+/**
+ * Pure state machine for hold-to-dictate / tap-to-dictate. Bounded by
+ * [maxRecordingMillis] (server `voice.max_recording_seconds`); the engine feeds
+ * elapsed/level samples and a silence signal, and the controller reports when
+ * the cap is hit so the caller stops the mic. No Android dependencies — the
+ * `AudioRecord`/`SpeechRecognizer` engine lives behind a separate seam.
+ */
+class DictationController(
+    val maxRecordingMillis: Long =
+        VoiceServerConfig.DEFAULT.maxRecordingSeconds.toLong() * 1_000L,
+) {
+    private val _state = MutableStateFlow<DictationState>(DictationState.Idle)
+    val state: StateFlow<DictationState> = _state.asStateFlow()
+
+    val isActive: Boolean
+        get() = _state.value is DictationState.Recording || _state.value is DictationState.Transcribing
+
+    /** Begin recording. Allowed only from Idle or a dismissed Failed state. */
+    fun beginRecording(): Boolean {
+        return when (_state.value) {
+            is DictationState.Idle, is DictationState.Failed -> {
+                _state.value = DictationState.Recording(elapsedMillis = 0L, level = 0f)
+                true
+            }
+            else -> false
+        }
+    }
+
+    fun onAudioLevel(level: Float) {
+        val recording = _state.value as? DictationState.Recording ?: return
+        _state.value = recording.copy(level = level.coerceIn(0f, 1f))
+    }
+
+    /**
+     * Report elapsed recording time. Returns true when the recording cap is
+     * reached so the caller stops capture and moves to transcription.
+     */
+    fun onElapsed(millis: Long): Boolean {
+        val recording = _state.value as? DictationState.Recording ?: return false
+        _state.value = recording.copy(elapsedMillis = millis.coerceAtLeast(0L))
+        return millis >= maxRecordingMillis
+    }
+
+    /** Recording finished (user released, silence auto-stop, or cap hit). */
+    fun finishRecording(): Boolean {
+        if (_state.value !is DictationState.Recording) return false
+        _state.value = DictationState.Transcribing
+        return true
+    }
+
+    /** Transcription completed — return to Idle regardless of whether text was empty. */
+    fun onTranscriptionComplete() {
+        if (_state.value is DictationState.Transcribing) {
+            _state.value = DictationState.Idle
+        }
+    }
+
+    /** Abort the current attempt from any phase (slide-to-cancel, hard stop). */
+    fun cancel() {
+        _state.value = DictationState.Idle
+    }
+
+    fun fail(reason: DictationFailure) {
+        _state.value = DictationState.Failed(reason)
+    }
+
+    fun dismissError() {
+        if (_state.value is DictationState.Failed) {
+            _state.value = DictationState.Idle
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DictationMic.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DictationMic.kt
@@ -1,0 +1,305 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.Stop
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Everything the composer needs to offer dictation. Null when the connected
+ * server has no audio routes, so the mic simply does not render (fail-closed).
+ * [serverConfig] carries the authoritative recording cap and silence tuning.
+ */
+data class ComposerDictation(
+    val serverConfig: VoiceServerConfig,
+    val transcribe: suspend (dataUrl: String, mimeType: String?) -> Result<TranscriptionResult>,
+)
+
+private const val POLL_INTERVAL_MILLIS = 100L
+
+/** Dictation is user-driven, so give them longer before declaring no speech. */
+private const val DICTATION_NO_SPEECH_TIMEOUT_MILLIS = 15_000L
+
+private fun hasRecordAudioPermission(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+        PackageManager.PERMISSION_GRANTED
+
+/**
+ * Tap-to-toggle dictation mic. Tap starts recording; tapping again (or silence /
+ * the server recording cap) stops and transcribes; long-press cancels. The
+ * transcript is appended to the composer draft via [onAppendTranscript] — it is
+ * never sent automatically. Recording/level/elapsed polling, silence auto-stop,
+ * and the RECORD_AUDIO grant all live here; the [DictationController] state
+ * machine and [DictationRecorder] engine are tested independently.
+ */
+@Composable
+fun DictationMicButton(
+    dictation: ComposerDictation,
+    enabled: Boolean,
+    onAppendTranscript: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    onError: (DictationFailure) -> Unit = {},
+    recorderFactory: (Context) -> DictationRecorder = { MediaRecorderDictationRecorder(it) },
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val controller = remember { DictationController(dictation.serverConfig.maxRecordingSeconds.toLong() * 1_000L) }
+    val recorder = remember { recorderFactory(context) }
+    val state by controller.state.collectAsState()
+
+    val currentAppend by rememberUpdatedState(onAppendTranscript)
+    val currentTranscribe by rememberUpdatedState(dictation.transcribe)
+    val currentOnError by rememberUpdatedState(onError)
+    val silenceThreshold = dictation.serverConfig.silenceThreshold
+    val silenceMillis = (dictation.serverConfig.silenceDurationSeconds * 1_000).toLong()
+
+    suspend fun finishAndTranscribe() {
+        if (!controller.finishRecording()) return
+        val recording = withContext(Dispatchers.IO) { recorder.stopAndEncode() }
+        if (recording == null) {
+            controller.fail(DictationFailure.NoSpeech)
+            currentOnError(DictationFailure.NoSpeech)
+            return
+        }
+        currentTranscribe(recording.dataUrl, recording.mimeType)
+            .onSuccess { result ->
+                if (result.isEmpty) {
+                    controller.fail(DictationFailure.NoSpeech)
+                    currentOnError(DictationFailure.NoSpeech)
+                } else {
+                    currentAppend(result.transcript)
+                    controller.onTranscriptionComplete()
+                }
+            }
+            .onFailure {
+                controller.fail(DictationFailure.TranscriptionFailed)
+                currentOnError(DictationFailure.TranscriptionFailed)
+            }
+    }
+
+    fun startRecording() {
+        if (!controller.beginRecording()) return
+        if (!recorder.start()) {
+            controller.fail(DictationFailure.RecordingFailed)
+            currentOnError(DictationFailure.RecordingFailed)
+        }
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) {
+            startRecording()
+        } else {
+            controller.fail(DictationFailure.PermissionDenied)
+            currentOnError(DictationFailure.PermissionDenied)
+        }
+    }
+
+    // Drive elapsed/level/silence while recording; stop on cap or speech-then-
+    // silence (ambient-calibrated — see SilenceAutoStop). A hands-free tap that
+    // never hears speech resolves to NoSpeech instead of uploading room tone.
+    val isRecording = state is DictationState.Recording
+    LaunchedEffect(isRecording) {
+        if (!isRecording) return@LaunchedEffect
+        val startedAt = System.currentTimeMillis()
+        val autoStop = SilenceAutoStop(
+            configuredThreshold = silenceThreshold,
+            silenceMillis = silenceMillis,
+            maxMillis = controller.maxRecordingMillis,
+            noSpeechTimeoutMillis = DICTATION_NO_SPEECH_TIMEOUT_MILLIS,
+        )
+        while (isActive) {
+            delay(POLL_INTERVAL_MILLIS)
+            val amplitude = recorder.sampleAmplitude()
+            controller.onAudioLevel(amplitude / 32_767f)
+            val elapsed = System.currentTimeMillis() - startedAt
+            controller.onElapsed(elapsed)
+            when (autoStop.feed(elapsed, amplitude)) {
+                SilenceAutoStopDecision.Continue -> Unit
+                SilenceAutoStopDecision.Stop -> {
+                    finishAndTranscribe()
+                    break
+                }
+                SilenceAutoStopDecision.StopEmpty -> {
+                    recorder.cancel()
+                    controller.fail(DictationFailure.NoSpeech)
+                    currentOnError(DictationFailure.NoSpeech)
+                    break
+                }
+            }
+        }
+    }
+
+    // Privacy default: leaving the foreground (including device lock) discards
+    // any in-progress recording; the visible draft text is untouched.
+    val lifecycleOwner = androidx.compose.ui.platform.LocalLifecycleOwner.current
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_STOP) {
+                recorder.cancel()
+                controller.cancel()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    val level = (state as? DictationState.Recording)?.level ?: 0f
+    val pulse by animateFloatAsState(targetValue = 1f + level * 0.25f, label = "dictationPulse")
+
+    val description = when (state) {
+        is DictationState.Recording -> "Stop dictation and insert"
+        is DictationState.Transcribing -> "Transcribing"
+        else -> "Dictate message"
+    }
+    val stateText = when (val current = state) {
+        is DictationState.Recording -> "Recording"
+        is DictationState.Transcribing -> "Transcribing"
+        is DictationState.Failed -> current.reason.name
+        DictationState.Idle -> "Idle"
+    }
+
+    fun beginCapture() {
+        controller.dismissError()
+        if (hasRecordAudioPermission(context)) {
+            startRecording()
+        } else {
+            permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+        }
+    }
+
+    // Quick tap toggles a hands-free recording (also the TalkBack activation path).
+    val tap: () -> Unit = tap@{
+        if (!enabled) return@tap
+        when (state) {
+            is DictationState.Recording -> scope.launch { finishAndTranscribe() }
+            is DictationState.Transcribing -> Unit
+            else -> beginCapture()
+        }
+    }
+    // Press-and-hold to talk: start on the long-press threshold, stop on release.
+    val holdStart: () -> Unit = holdStart@{
+        if (!enabled) return@holdStart
+        if (state is DictationState.Idle || state is DictationState.Failed) beginCapture()
+    }
+    val holdRelease: () -> Unit = {
+        if (state is DictationState.Recording) scope.launch { finishAndTranscribe() }
+    }
+    val holdCancel: () -> Unit = {
+        recorder.cancel()
+        controller.cancel()
+    }
+
+    val latestState by rememberUpdatedState(state)
+    val latestEnabled by rememberUpdatedState(enabled)
+    val currentTap by rememberUpdatedState(tap)
+    val currentHoldStart by rememberUpdatedState(holdStart)
+    val currentHoldRelease by rememberUpdatedState(holdRelease)
+    val currentHoldCancel by rememberUpdatedState(holdCancel)
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Box(
+        modifier = modifier
+            .size(44.dp)
+            .indication(interactionSource, ripple(bounded = false, radius = 22.dp))
+            .semantics {
+                contentDescription = description
+                stateDescription = stateText
+                onClick { currentTap(); true }
+            }
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    if (!latestEnabled || latestState is DictationState.Transcribing) {
+                        return@awaitEachGesture
+                    }
+                    val press = PressInteraction.Press(down.position)
+                    interactionSource.tryEmit(press)
+                    val releasedEarly = withTimeoutOrNull(viewConfiguration.longPressTimeoutMillis) {
+                        waitForUpOrCancellation()
+                    }
+                    if (releasedEarly != null) {
+                        // Released before the long-press threshold — treat as a tap.
+                        interactionSource.tryEmit(PressInteraction.Release(press))
+                        currentTap()
+                    } else {
+                        // Held past the threshold — record while held, stop on release.
+                        currentHoldStart()
+                        val up = waitForUpOrCancellation()
+                        interactionSource.tryEmit(PressInteraction.Release(press))
+                        if (up != null) currentHoldRelease() else currentHoldCancel()
+                    }
+                }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        when (state) {
+            is DictationState.Transcribing ->
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                )
+            is DictationState.Recording ->
+                Icon(
+                    imageVector = Icons.Outlined.Stop,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.graphicsLayer { scaleX = pulse; scaleY = pulse },
+                )
+            else ->
+                Icon(
+                    imageVector = Icons.Outlined.Mic,
+                    contentDescription = null,
+                    tint = if (enabled) {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    } else {
+                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                    },
+                    modifier = Modifier.alpha(if (enabled) 1f else 0.6f),
+                )
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DictationMic.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DictationMic.kt
@@ -184,7 +184,11 @@ fun DictationMicButton(
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+        onDispose {
+            recorder.cancel()
+            controller.cancel()
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
     }
 
     val level = (state as? DictationState.Recording)?.level ?: 0f

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DictationProviderPolicy.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DictationProviderPolicy.kt
@@ -1,0 +1,51 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+/** Which engine produces the transcript. */
+enum class DictationProvider {
+    /** Upload audio to `POST /api/audio/transcribe` — the server's audited STT chain. */
+    Server,
+
+    /** Android `SpeechRecognizer` — instant partials, works offline / when server STT is unconfigured. */
+    OnDevice,
+}
+
+/** User's provider choice; `Automatic` prefers the server for provider-model fidelity. */
+enum class DictationProviderPreference {
+    Automatic,
+    Server,
+    OnDevice,
+}
+
+/**
+ * Chooses the dictation engine from the user's preference and what's actually
+ * available — mirroring Hermex's `orderedProviders`. Returns a fallback-ordered
+ * list (first = preferred); an empty list means dictation is unavailable and the
+ * mic affordance hides.
+ *
+ * `Automatic` keeps Server first: it uses the same provider chain as the rest of
+ * the agent, so a dictated turn transcribes identically to a desktop one. On-device
+ * is the offline/unconfigured fallback and the accessibility-friendly live-partial
+ * option users can opt into.
+ */
+object DictationProviderPolicy {
+    fun orderedProviders(
+        preference: DictationProviderPreference,
+        serverAvailable: Boolean,
+        onDeviceSupported: Boolean,
+    ): List<DictationProvider> {
+        val server = if (serverAvailable) listOf(DictationProvider.Server) else emptyList()
+        val onDevice = if (onDeviceSupported) listOf(DictationProvider.OnDevice) else emptyList()
+        return when (preference) {
+            DictationProviderPreference.OnDevice -> onDevice + server
+            DictationProviderPreference.Server -> server + onDevice
+            DictationProviderPreference.Automatic -> server + onDevice
+        }
+    }
+
+    fun preferred(
+        preference: DictationProviderPreference,
+        serverAvailable: Boolean,
+        onDeviceSupported: Boolean,
+    ): DictationProvider? =
+        orderedProviders(preference, serverAvailable, onDeviceSupported).firstOrNull()
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/ReadAloud.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/ReadAloud.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 /**
@@ -46,6 +47,18 @@ class ReadAloudSession(
     private val engine: SpeechEngine,
     private val synthesize: suspend (String) -> Result<SpeechAudio>,
 ) {
+    private var requestGeneration = 0L
+    private var synthesisJob: Job? = null
+
+    private fun invalidateRequest() {
+        requestGeneration++
+        synthesisJob?.cancel()
+        synthesisJob = null
+    }
+
+    private fun isCurrent(messageKey: String, generation: Long): Boolean =
+        requestGeneration == generation && controller.isActiveFor(messageKey)
+
     /** Start speaking [text] for [messageKey], or stop if it is already the active one. */
     fun toggle(messageKey: String, text: String) {
         if (controller.isActiveFor(messageKey)) {
@@ -54,24 +67,45 @@ class ReadAloudSession(
         }
         val speechText = sanitizeTextForSpeech(text)
         if (speechText.isBlank()) return
+        invalidateRequest()
         engine.stop()
         controller.beginPreparing(messageKey)
-        scope.launch {
-            synthesize(speechText)
-                .onSuccess { audio ->
-                    if (!controller.isActiveFor(messageKey)) return@onSuccess
-                    engine.play(
-                        audio = audio,
-                        onStarted = { controller.markPlaying(messageKey) },
-                        onFinished = { controller.complete() },
-                        onError = { controller.fail(messageKey, SpeechPlaybackFailure.Playback) },
-                    )
-                }
-                .onFailure { controller.fail(messageKey, SpeechPlaybackFailure.Synthesis) }
+        val generation = requestGeneration
+        synthesisJob = scope.launch {
+            try {
+                synthesize(speechText)
+                    .onSuccess { audio ->
+                        if (!isCurrent(messageKey, generation)) return@onSuccess
+                        engine.play(
+                            audio = audio,
+                            onStarted = {
+                                if (isCurrent(messageKey, generation)) {
+                                    controller.markPlaying(messageKey)
+                                }
+                            },
+                            onFinished = {
+                                if (isCurrent(messageKey, generation)) controller.complete()
+                            },
+                            onError = {
+                                if (isCurrent(messageKey, generation)) {
+                                    controller.fail(messageKey, SpeechPlaybackFailure.Playback)
+                                }
+                            },
+                        )
+                    }
+                    .onFailure {
+                        if (isCurrent(messageKey, generation)) {
+                            controller.fail(messageKey, SpeechPlaybackFailure.Synthesis)
+                        }
+                    }
+            } finally {
+                if (requestGeneration == generation) synthesisJob = null
+            }
         }
     }
 
     fun stop() {
+        invalidateRequest()
         engine.stop()
         controller.stop()
     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/ReadAloud.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/ReadAloud.kt
@@ -1,0 +1,174 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.content.Context
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Stop
+import androidx.compose.material.icons.outlined.VolumeUp
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * What the composer needs to read messages aloud. Null when the connected server
+ * has no audio routes, so speaker buttons do not render (fail-closed).
+ */
+data class MessageReadAloud(
+    val synthesize: suspend (text: String) -> Result<SpeechAudio>,
+)
+
+/**
+ * Shared read-aloud coordination for one session: a single [SpeechPlaybackController]
+ * and [SpeechEngine] so only one message speaks at a time. Text is sanitized for
+ * speech before synthesis; tool/system/secret content should never reach here.
+ */
+class ReadAloudSession(
+    val controller: SpeechPlaybackController,
+    private val scope: CoroutineScope,
+    private val engine: SpeechEngine,
+    private val synthesize: suspend (String) -> Result<SpeechAudio>,
+) {
+    /** Start speaking [text] for [messageKey], or stop if it is already the active one. */
+    fun toggle(messageKey: String, text: String) {
+        if (controller.isActiveFor(messageKey)) {
+            stop()
+            return
+        }
+        val speechText = sanitizeTextForSpeech(text)
+        if (speechText.isBlank()) return
+        engine.stop()
+        controller.beginPreparing(messageKey)
+        scope.launch {
+            synthesize(speechText)
+                .onSuccess { audio ->
+                    if (!controller.isActiveFor(messageKey)) return@onSuccess
+                    engine.play(
+                        audio = audio,
+                        onStarted = { controller.markPlaying(messageKey) },
+                        onFinished = { controller.complete() },
+                        onError = { controller.fail(messageKey, SpeechPlaybackFailure.Playback) },
+                    )
+                }
+                .onFailure { controller.fail(messageKey, SpeechPlaybackFailure.Synthesis) }
+        }
+    }
+
+    fun stop() {
+        engine.stop()
+        controller.stop()
+    }
+}
+
+/**
+ * Remembers a [ReadAloudSession] bound to [sessionId]. Playback stops when the
+ * session changes, when the composable leaves composition, and when the activity
+ * is stopped.
+ */
+@Composable
+fun rememberReadAloudSession(
+    readAloud: MessageReadAloud?,
+    sessionId: String,
+    engineFactory: (Context) -> SpeechEngine = { MediaPlayerSpeechEngine(it) },
+): ReadAloudSession? {
+    if (readAloud == null) return null
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val engine = remember { engineFactory(context) }
+    val controller = remember { SpeechPlaybackController() }
+    val session = remember(readAloud) {
+        ReadAloudSession(controller, scope, engine, readAloud.synthesize)
+    }
+
+    // Stop when switching sessions.
+    DisposableEffect(sessionId) {
+        onDispose { session.stop() }
+    }
+    // Release when leaving composition.
+    DisposableEffect(Unit) {
+        onDispose { engine.release() }
+    }
+    // Stop when the activity is stopped.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP) {
+                session.stop()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    return session
+}
+
+/**
+ * Per-message speaker toggle. Shows play when idle, a spinner while synthesizing,
+ * and stop while this message plays; disabled while a *different* message is
+ * speaking so only one plays at a time.
+ */
+@Composable
+fun MessageSpeakerButton(
+    session: ReadAloudSession,
+    messageKey: String,
+    text: String,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val state by session.controller.state.collectAsState()
+    val isPreparing = (state as? SpeechPlaybackState.Preparing)?.messageKey == messageKey
+    val isPlaying = (state as? SpeechPlaybackState.Playing)?.messageKey == messageKey
+    val activeKey = session.controller.activeKey
+    val otherActive = activeKey != null && activeKey != messageKey
+
+    val description = if (isPlaying || isPreparing) "Stop reading aloud" else "Read message aloud"
+    val stateText = when {
+        isPreparing -> "Preparing"
+        isPlaying -> "Playing"
+        else -> "Idle"
+    }
+
+    IconButton(
+        onClick = { session.toggle(messageKey, text) },
+        enabled = enabled && !otherActive,
+        modifier = modifier.semantics {
+            contentDescription = description
+            stateDescription = stateText
+        },
+    ) {
+        when {
+            isPreparing ->
+                CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+            isPlaying ->
+                Icon(
+                    imageVector = Icons.Outlined.Stop,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            else ->
+                Icon(
+                    imageVector = Icons.Outlined.VolumeUp,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SilenceAutoStop.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SilenceAutoStop.kt
@@ -1,0 +1,114 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+/** Verdict for one amplitude sample during an utterance recording. */
+enum class SilenceAutoStopDecision {
+    Continue,
+
+    /** Speech was captured and has ended (or the cap was hit) — transcribe. */
+    Stop,
+
+    /** Nothing but ambient noise was ever heard — discard without uploading. */
+    StopEmpty,
+}
+
+/**
+ * Speech-relative end-pointing over Android `MediaRecorder.maxAmplitude` peaks.
+ *
+ * The server's `voice.silence_threshold` is calibrated for the desktop capture
+ * scale; on phone mics real room tone hovers *around* it (and the first few
+ * hundred milliseconds under-read while capture ramps up), so a fixed floor
+ * comparison either never detects silence or resets on every ambient bounce.
+ * Instead:
+ *
+ * - Speech is detected when a peak clearly exceeds the room (absolute minimum
+ *   plus calibrated-ambient scaling).
+ * - Once speech is seen, the quiet ceiling is *relative to the utterance's own
+ *   loudness* (peak/8, never below the configured floor), so room tone sits
+ *   far under it regardless of mic scale.
+ * - Quiet time accumulates per sample and a loud sample only *drains* it
+ *   ([LOUD_DRAIN_FACTOR]× the sample interval) rather than zeroing it, so a
+ *   page rustle or breath cannot restart the silence clock, while resumed
+ *   speech quickly empties it.
+ * - A recording with no speech at all resolves to
+ *   [SilenceAutoStopDecision.StopEmpty] after [noSpeechTimeoutMillis] so pure
+ *   room tone is never uploaded.
+ */
+class SilenceAutoStop(
+    configuredThreshold: Int,
+    private val silenceMillis: Long,
+    private val maxMillis: Long,
+    private val calibrationMillis: Long = CALIBRATION_MILLIS,
+    private val noSpeechTimeoutMillis: Long = NO_SPEECH_TIMEOUT_MILLIS,
+) {
+    private val configured = configuredThreshold.coerceIn(1, MAX_SILENCE_FLOOR)
+    private var ambientPeak = 0
+    private var utterancePeak = 0
+    private var speechSeen = false
+    private var quietMillis = 0L
+    private var lastElapsedMillis = 0L
+
+    private val silenceFloor: Int
+        get() = maxOf(configured, (ambientPeak * 7) / 4).coerceAtMost(MAX_SILENCE_FLOOR)
+
+    private val speechLevel: Int
+        get() = maxOf(silenceFloor * 3, MIN_SPEECH_LEVEL)
+
+    /** Quiet ceiling once speech was heard: relative to how loud the user is. */
+    private val quietCeiling: Int
+        get() = maxOf(silenceFloor, utterancePeak / QUIET_CEILING_DIVISOR)
+
+    /** Bounded diagnostic snapshot (scale values only; no audio content). */
+    fun debugState(): String =
+        "floor=$silenceFloor ceiling=$quietCeiling ambient=$ambientPeak " +
+            "utterancePeak=$utterancePeak speechSeen=$speechSeen quietMs=$quietMillis " +
+            "lastElapsed=$lastElapsedMillis silenceMs=$silenceMillis maxMs=$maxMillis"
+
+    fun feed(elapsedMillis: Long, amplitude: Int): SilenceAutoStopDecision {
+        val intervalMillis = (elapsedMillis - lastElapsedMillis).coerceIn(0, 1_000)
+        lastElapsedMillis = elapsedMillis
+        if (elapsedMillis >= maxMillis) return SilenceAutoStopDecision.Stop
+
+        if (elapsedMillis < calibrationMillis) {
+            if (amplitude > ambientPeak) ambientPeak = amplitude
+            return SilenceAutoStopDecision.Continue
+        }
+
+        if (amplitude >= speechLevel) {
+            speechSeen = true
+            if (amplitude > utterancePeak) utterancePeak = amplitude
+        }
+        if (!speechSeen) {
+            return if (elapsedMillis >= noSpeechTimeoutMillis) {
+                SilenceAutoStopDecision.StopEmpty
+            } else {
+                SilenceAutoStopDecision.Continue
+            }
+        }
+
+        if (amplitude < quietCeiling) {
+            quietMillis += intervalMillis
+            if (silenceMillis > 0 && quietMillis >= silenceMillis) {
+                return SilenceAutoStopDecision.Stop
+            }
+        } else {
+            quietMillis = (quietMillis - intervalMillis * LOUD_DRAIN_FACTOR).coerceAtLeast(0L)
+        }
+        return SilenceAutoStopDecision.Continue
+    }
+
+    companion object {
+        const val CALIBRATION_MILLIS = 600L
+        const val NO_SPEECH_TIMEOUT_MILLIS = 8_000L
+
+        /** Even a loud room must leave speech peaks detectable above the floor. */
+        private const val MAX_SILENCE_FLOOR = 6_000
+
+        private const val MIN_SPEECH_LEVEL = 2_000
+
+        /** Quiet ceiling = utterance peak divided by this. */
+        private const val QUIET_CEILING_DIVISOR = 8
+
+        /** One loud sample drains this many samples' worth of quiet time. */
+        private const val LOUD_DRAIN_FACTOR = 3
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechDeltaFeeder.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechDeltaFeeder.kt
@@ -1,0 +1,46 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+/**
+ * Turns successive snapshots of a streaming assistant message into append-only
+ * deltas for the speech stream. The server's `SentenceChunker` sanitizes and
+ * cuts sentences across delta boundaries, so deltas are fed raw — whitespace
+ * preserved, no client-side sanitization.
+ *
+ * If the visible text is ever *not* an extension of what was already fed (a
+ * server-side replacement/rewrite), feeding pauses until the authoritative
+ * final text arrives; only a suffix that cleanly extends the fed prefix is
+ * spoken then. Speech may briefly lag a rewrite but never duplicates it.
+ */
+class SpeechDeltaFeeder {
+    private var fedText = ""
+    private var diverged = false
+
+    /** Delta to feed for the current streaming [text], or null when nothing new. */
+    fun nextDelta(text: String): String? {
+        if (diverged) return null
+        if (!text.startsWith(fedText)) {
+            diverged = true
+            return null
+        }
+        if (text.length == fedText.length) return null
+        val delta = text.substring(fedText.length)
+        fedText = text
+        return delta
+    }
+
+    /**
+     * The message finalized as [finalText]. Returns the remaining suffix to feed
+     * before `done`, or null when the final text cannot be reconciled with what
+     * was already spoken (feed nothing rather than repeat).
+     */
+    fun reconcileFinal(finalText: String): String? {
+        val suffix = if (finalText.startsWith(fedText)) {
+            finalText.substring(fedText.length)
+        } else {
+            null
+        }
+        fedText = finalText
+        diverged = false
+        return suffix?.takeIf { it.isNotEmpty() }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechEngine.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechEngine.kt
@@ -1,0 +1,180 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.media.MediaPlayer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * Plays synthesized speech audio. The Android implementation
+ * ([MediaPlayerSpeechEngine]) owns audio focus, the ACTION_AUDIO_BECOMING_NOISY
+ * (unplug) stop, and player/temp-file release; the [SpeechPlaybackController]
+ * state machine and the read-aloud coordination are tested independently.
+ */
+interface SpeechEngine {
+    /**
+     * Begin playback. [onStarted] fires when audio actually starts, [onFinished]
+     * on natural completion or an unplug/becoming-noisy stop, and [onError] on
+     * any failure (focus denied, decode/playback error).
+     */
+    suspend fun play(
+        audio: SpeechAudio,
+        onStarted: () -> Unit,
+        onFinished: () -> Unit,
+        onError: () -> Unit,
+    )
+
+    /** Stop and release without firing [onFinished] (the caller drove the stop). */
+    fun stop()
+
+    /** Release all resources permanently. */
+    fun release()
+}
+
+private fun mimeExtension(mimeType: String): String =
+    when (mimeType.substringAfter('/').substringBefore(';').lowercase()) {
+        "mpeg", "mp3" -> ".mp3"
+        "wav", "x-wav" -> ".wav"
+        "ogg", "opus" -> ".ogg"
+        "aac" -> ".aac"
+        "mp4", "m4a", "x-m4a" -> ".m4a"
+        else -> ".bin"
+    }
+
+/**
+ * [MediaPlayer]-backed speech playback. Requests transient audio focus (so it
+ * ducks other media and yields to calls), stops on headphone unplug, and reuses
+ * the app cache + temp-file/release conventions from the artifact audio player.
+ */
+class MediaPlayerSpeechEngine(
+    private val context: Context,
+) : SpeechEngine {
+    private val audioManager =
+        context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+    private var player: MediaPlayer? = null
+    private var tempFile: File? = null
+    private var focusRequest: AudioFocusRequest? = null
+    private var noisyReceiver: BroadcastReceiver? = null
+
+    override suspend fun play(
+        audio: SpeechAudio,
+        onStarted: () -> Unit,
+        onFinished: () -> Unit,
+        onError: () -> Unit,
+    ) {
+        stop()
+        val file = try {
+            withContext(Dispatchers.IO) {
+                val directory = File(context.cacheDir, "read-aloud").apply { mkdirs() }
+                File.createTempFile("speech-", mimeExtension(audio.mimeType), directory).apply {
+                    writeBytes(audio.bytes)
+                }
+            }
+        } catch (_: Exception) {
+            onError()
+            return
+        }
+        tempFile = file
+
+        if (!requestFocus()) {
+            cleanup()
+            onError()
+            return
+        }
+        registerNoisyReceiver(onFinished)
+
+        try {
+            val mediaPlayer = MediaPlayer().apply {
+                setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .build(),
+                )
+                setDataSource(file.absolutePath)
+                setOnCompletionListener {
+                    cleanup()
+                    onFinished()
+                }
+                setOnErrorListener { _, _, _ ->
+                    cleanup()
+                    onError()
+                    true
+                }
+                setOnPreparedListener {
+                    it.start()
+                    onStarted()
+                }
+                prepareAsync()
+            }
+            player = mediaPlayer
+        } catch (_: Exception) {
+            cleanup()
+            onError()
+        }
+    }
+
+    override fun stop() {
+        cleanup()
+    }
+
+    override fun release() {
+        cleanup()
+    }
+
+    private fun requestFocus(): Boolean {
+        val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build(),
+            )
+            .build()
+        focusRequest = request
+        return audioManager.requestAudioFocus(request) ==
+            AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+    }
+
+    private fun registerNoisyReceiver(onFinished: () -> Unit) {
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                if (intent?.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
+                    cleanup()
+                    onFinished()
+                }
+            }
+        }
+        context.registerReceiver(
+            receiver,
+            IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY),
+        )
+        noisyReceiver = receiver
+    }
+
+    private fun cleanup() {
+        noisyReceiver?.let {
+            runCatching { context.unregisterReceiver(it) }
+            noisyReceiver = null
+        }
+        player?.let {
+            runCatching { it.stop() }
+            it.release()
+        }
+        player = null
+        focusRequest?.let {
+            runCatching { audioManager.abandonAudioFocusRequest(it) }
+            focusRequest = null
+        }
+        tempFile?.delete()
+        tempFile = null
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechPlaybackController.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechPlaybackController.kt
@@ -1,0 +1,87 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** Why a read-aloud attempt ended without playing to completion. */
+enum class SpeechPlaybackFailure {
+    Unavailable,
+    Synthesis,
+    Playback,
+}
+
+/**
+ * Read-aloud phase for a single target. [messageKey] identifies what is being
+ * spoken (an assistant message id, or an artifact source) so the UI can show
+ * the speaker state on exactly one item and disable the others.
+ */
+sealed interface SpeechPlaybackState {
+    data object Idle : SpeechPlaybackState
+
+    data class Preparing(val messageKey: String) : SpeechPlaybackState
+
+    data class Playing(val messageKey: String) : SpeechPlaybackState
+
+    data class Failed(val messageKey: String, val reason: SpeechPlaybackFailure) : SpeechPlaybackState
+}
+
+/**
+ * Pure coordinator for read-aloud. Only one target plays at a time, so starting
+ * a new one supersedes any in-flight playback. The Android [SpeechEngine] and
+ * audio-focus handling live in the host; this state machine is tested directly.
+ */
+class SpeechPlaybackController {
+    private val _state = MutableStateFlow<SpeechPlaybackState>(SpeechPlaybackState.Idle)
+    val state: StateFlow<SpeechPlaybackState> = _state.asStateFlow()
+
+    /** The target currently preparing or playing, or null when idle/failed. */
+    val activeKey: String?
+        get() = when (val current = _state.value) {
+            is SpeechPlaybackState.Preparing -> current.messageKey
+            is SpeechPlaybackState.Playing -> current.messageKey
+            else -> null
+        }
+
+    fun isActiveFor(messageKey: String): Boolean = activeKey == messageKey
+
+    fun isPlaying(messageKey: String): Boolean =
+        (_state.value as? SpeechPlaybackState.Playing)?.messageKey == messageKey
+
+    /** Begin synthesizing/loading for [messageKey], superseding any current target. */
+    fun beginPreparing(messageKey: String) {
+        _state.value = SpeechPlaybackState.Preparing(messageKey)
+    }
+
+    /** Audio started for [messageKey]; ignored if a newer target has taken over. */
+    fun markPlaying(messageKey: String): Boolean {
+        if (activeKey != messageKey) return false
+        _state.value = SpeechPlaybackState.Playing(messageKey)
+        return true
+    }
+
+    /** Playback finished naturally. */
+    fun complete() {
+        if (_state.value is SpeechPlaybackState.Playing || _state.value is SpeechPlaybackState.Preparing) {
+            _state.value = SpeechPlaybackState.Idle
+        }
+    }
+
+    /** Hard stop (session switch, activity stop, user tap, artifact audio takeover). */
+    fun stop() {
+        _state.value = SpeechPlaybackState.Idle
+    }
+
+    fun fail(messageKey: String, reason: SpeechPlaybackFailure) {
+        // A stale failure (a superseded target) must not clobber the active one.
+        if (activeKey == null || activeKey == messageKey) {
+            _state.value = SpeechPlaybackState.Failed(messageKey, reason)
+        }
+    }
+
+    fun dismissError() {
+        if (_state.value is SpeechPlaybackState.Failed) {
+            _state.value = SpeechPlaybackState.Idle
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechStream.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechStream.kt
@@ -1,0 +1,271 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.put
+
+/** One inbound frame from the `/api/audio/speak-stream` socket. */
+sealed interface SpeechSocketFrame {
+    data class Text(val text: String) : SpeechSocketFrame
+
+    class Binary(val bytes: ByteArray) : SpeechSocketFrame
+}
+
+/**
+ * Minimal socket seam for the streaming-speech WebSocket. Mirrors the chat
+ * socket seam but adds binary frames (server PCM). Implementations are
+ * Ktor-backed in production and fakes in tests.
+ */
+interface SpeechStreamSocket {
+    suspend fun sendText(text: String)
+
+    /** Next frame, or null when the peer closed the socket. */
+    suspend fun receiveFrame(): SpeechSocketFrame?
+
+    suspend fun close()
+}
+
+interface SpeechWebSocketFactory {
+    suspend fun connect(url: String): SpeechStreamSocket
+}
+
+/** Where PCM from the speech stream goes. [AudioTrackSpeechSink] on device. */
+interface PcmSpeechSink {
+    /** Prepare output for the announced format. False = unplayable format. */
+    fun start(sampleRateHz: Int, channels: Int): Boolean
+
+    /** Blocking write of int16 little-endian PCM bytes. */
+    suspend fun write(pcm: ByteArray)
+
+    /** No more PCM will arrive; let buffered audio drain, then release. */
+    suspend fun finish()
+
+    /** Immediate stop and release (barge-in, session switch, lifecycle). */
+    fun stop()
+}
+
+/** How a streaming speech session ended. */
+enum class SpeechStreamOutcome {
+    /** Server sent `end` and all PCM was played. */
+    Completed,
+
+    /** The stream dropped after audio had started — never replay via REST. */
+    CompletedPartial,
+
+    /**
+     * The server declared `fallback` (or dropped/failed before any PCM), so
+     * the caller may synthesize the final text once via `POST /api/audio/speak`.
+     */
+    Fallback,
+
+    /** The caller stopped the stream deliberately. */
+    Stopped,
+}
+
+/**
+ * Verified server protocol (hermes_cli/web_server.py `speak_stream_ws`):
+ * client sends `{"text": …}` / `{"done": true}` / `{"stop": true}`; server sends
+ * `{"type":"start","sample_rate":N,"channels":1}`, binary int16 PCM frames,
+ * then `{"type":"end"}` — or `{"type":"fallback"}` when the configured TTS
+ * provider has no chunked API.
+ */
+object SpeechStreamProtocol {
+    /** Server PCM frames are small sentence chunks; anything huge is a bug/attack. */
+    const val MAX_PCM_FRAME_BYTES: Int = 1 shl 20
+
+    const val MAX_TEXT_FRAME_BYTES: Int = 64 * 1024
+
+    /** Sample-rate sanity bounds for `AudioTrack` creation. */
+    val SAMPLE_RATE_RANGE: IntRange = 8_000..48_000
+
+    /**
+     * No start/PCM for this long *before any audio* = treat as dropped and fall
+     * back. Once audio has played the socket may stay quiet for minutes (tool
+     * execution between spoken sentences), so no timeout applies after that —
+     * drops are detected by the socket closing.
+     */
+    const val PROGRESS_TIMEOUT_MILLIS: Long = 15_000L
+
+    fun textFrame(text: String): String =
+        buildJsonObject { put("text", text) }.toString()
+
+    const val DONE_FRAME: String = """{"done":true}"""
+    const val STOP_FRAME: String = """{"stop":true}"""
+}
+
+/** Parsed server control frame. */
+internal sealed interface SpeechServerFrame {
+    data class Start(val sampleRate: Int, val channels: Int) : SpeechServerFrame
+
+    data object End : SpeechServerFrame
+
+    data object Fallback : SpeechServerFrame
+
+    data object Unknown : SpeechServerFrame
+}
+
+internal fun parseSpeechServerFrame(text: String): SpeechServerFrame {
+    if (text.length > SpeechStreamProtocol.MAX_TEXT_FRAME_BYTES) return SpeechServerFrame.Unknown
+    val root = try {
+        Json.parseToJsonElement(text) as? JsonObject
+    } catch (_: Exception) {
+        null
+    } ?: return SpeechServerFrame.Unknown
+    return when ((root["type"] as? JsonPrimitive)?.contentOrNull) {
+        "start" -> SpeechServerFrame.Start(
+            sampleRate = (root["sample_rate"] as? JsonPrimitive)?.intOrNull ?: 0,
+            channels = (root["channels"] as? JsonPrimitive)?.intOrNull ?: 1,
+        )
+        "end" -> SpeechServerFrame.End
+        "fallback" -> SpeechServerFrame.Fallback
+        else -> SpeechServerFrame.Unknown
+    }
+}
+
+/**
+ * Drives one speech-stream session: pumps server frames into [sink] while the
+ * caller feeds text via [feedText]/[finishText] (typically from live assistant
+ * deltas) and can [stop] at any moment (barge-in). The whole-text-replay rule
+ * is enforced here: a drop or failure only maps to [SpeechStreamOutcome.Fallback]
+ * while no PCM has been played yet.
+ */
+class SpeechStreamRun(
+    private val socket: SpeechStreamSocket,
+    private val sink: PcmSpeechSink,
+    private val progressTimeoutMillis: Long = SpeechStreamProtocol.PROGRESS_TIMEOUT_MILLIS,
+    /** Bounded diagnostic sink (frame kinds/sizes only, never content). */
+    private val log: (String) -> Unit = {},
+) {
+    @Volatile
+    private var stopped = false
+
+    @Volatile
+    var audioStarted = false
+        private set
+
+    /** Feed incremental reply text. Safe to call while the pump is running. */
+    suspend fun feedText(text: String) {
+        if (stopped || text.isEmpty()) return
+        sendIgnoringSocketTeardown(SpeechStreamProtocol.textFrame(text))
+    }
+
+    /** The reply is complete — no more text will be fed. */
+    suspend fun finishText() {
+        if (stopped) return
+        sendIgnoringSocketTeardown(SpeechStreamProtocol.DONE_FRAME)
+    }
+
+    /**
+     * A send suspended on the socket resumes with CancellationException when the
+     * *socket session* is torn down (e.g. the server answered `fallback` and the
+     * pump closed it) — that is the socket's cancellation, not the caller's, and
+     * rethrowing it would silently kill the whole voice loop. Only propagate
+     * cancellation when this coroutine itself was cancelled; every other send
+     * failure is resolved by the pump's outcome.
+     */
+    private suspend fun sendIgnoringSocketTeardown(frame: String) {
+        try {
+            socket.sendText(frame)
+        } catch (cancelled: CancellationException) {
+            if (!currentCoroutineContext().isActive) throw cancelled
+        } catch (_: Exception) {
+        }
+    }
+
+    /** Deliberate stop (barge-in, session switch). Best-effort stop frame, then close. */
+    suspend fun stop() {
+        stopped = true
+        sink.stop()
+        try {
+            socket.sendText(SpeechStreamProtocol.STOP_FRAME)
+        } catch (_: Exception) {
+        }
+        try {
+            socket.close()
+        } catch (_: Exception) {
+        }
+    }
+
+    /**
+     * Receive-side pump. Suspends until the session resolves and returns how it
+     * ended. Runs concurrently with [feedText]/[finishText].
+     */
+    suspend fun pump(): SpeechStreamOutcome {
+        var started = false
+        log("pump:begin")
+        try {
+            while (true) {
+                // Long.MAX_VALUE disables the watchdog entirely (no timer is
+                // scheduled — virtual-time tests would otherwise fire it).
+                val frame = if (audioStarted || progressTimeoutMillis == Long.MAX_VALUE) {
+                    socket.receiveFrame()
+                } else {
+                    withTimeoutOrNull(progressTimeoutMillis) { socket.receiveFrame() }
+                }
+                if (stopped) return SpeechStreamOutcome.Stopped
+                when (frame) {
+                    is SpeechSocketFrame.Text -> log("pump:text len=${frame.text.length}")
+                    is SpeechSocketFrame.Binary -> log("pump:pcm len=${frame.bytes.size}")
+                    null -> log("pump:closed-or-timeout")
+                }
+                when (frame) {
+                    null -> return dropOutcome()
+                    is SpeechSocketFrame.Text -> when (val parsed = parseSpeechServerFrame(frame.text)) {
+                        is SpeechServerFrame.Start -> {
+                            if (started) return dropOutcome()
+                            if (parsed.channels != 1 ||
+                                parsed.sampleRate !in SpeechStreamProtocol.SAMPLE_RATE_RANGE
+                            ) {
+                                return dropOutcome()
+                            }
+                            if (!sink.start(parsed.sampleRate, parsed.channels)) return dropOutcome()
+                            started = true
+                        }
+                        SpeechServerFrame.End -> {
+                            if (!audioStarted) return SpeechStreamOutcome.Fallback
+                            sink.finish()
+                            return SpeechStreamOutcome.Completed
+                        }
+                        SpeechServerFrame.Fallback -> return dropOutcome()
+                        SpeechServerFrame.Unknown -> Unit
+                    }
+                    is SpeechSocketFrame.Binary -> {
+                        if (!started || frame.bytes.size > SpeechStreamProtocol.MAX_PCM_FRAME_BYTES) {
+                            return dropOutcome()
+                        }
+                        if (frame.bytes.isNotEmpty()) {
+                            audioStarted = true
+                            sink.write(frame.bytes)
+                        }
+                    }
+                }
+            }
+        } catch (cancelled: CancellationException) {
+            sink.stop()
+            throw cancelled
+        } catch (_: Exception) {
+            return dropOutcome()
+        } finally {
+            stopped = true
+            try {
+                socket.close()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    /** A drop after audio must never replay whole text; before audio it may fall back. */
+    private fun dropOutcome(): SpeechStreamOutcome {
+        sink.stop()
+        return if (audioStarted) SpeechStreamOutcome.CompletedPartial else SpeechStreamOutcome.Fallback
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechSynthesis.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechSynthesis.kt
@@ -1,0 +1,33 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import java.util.Base64
+
+/** Decoded TTS audio ready for playback. */
+class SpeechAudio(val bytes: ByteArray, val mimeType: String) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SpeechAudio) return false
+        return mimeType == other.mimeType && bytes.contentEquals(other.bytes)
+    }
+
+    override fun hashCode(): Int = 31 * mimeType.hashCode() + bytes.contentHashCode()
+}
+
+/**
+ * Decode a `data:<mime>;base64,<...>` audio URL (as returned by
+ * `POST /api/audio/speak`) into raw bytes. Pure (JVM Base64) so it is
+ * unit-testable. Returns null if the URL is not a base64 audio data URL.
+ */
+fun decodeAudioDataUrl(dataUrl: String): SpeechAudio? {
+    if (!dataUrl.startsWith("data:")) return null
+    val comma = dataUrl.indexOf(',')
+    if (comma < 0) return null
+    val header = dataUrl.substring("data:".length, comma)
+    if (!header.contains(";base64")) return null
+    val mimeType = header.substringBefore(';').ifBlank { "audio/mpeg" }
+    return try {
+        SpeechAudio(Base64.getDecoder().decode(dataUrl.substring(comma + 1)), mimeType)
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechText.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/SpeechText.kt
@@ -1,0 +1,172 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+/**
+ * Prepares assistant text for text-to-speech. A faithful Kotlin port of the
+ * desktop `sanitizeTextForSpeech` (apps/desktop/src/lib/speech-text.ts): fenced
+ * code becomes "code block omitted", markdown tables are dropped, links read as
+ * their label, URLs as " link ", emoji and a leading "thinking…" prefix are
+ * removed, and residual markdown punctuation is stripped. The
+ * [SpeechTextTest] cases mirror speech-text.test.ts one-for-one.
+ */
+
+private val EMOJI_RE = Regex(
+    "(?:[\\x{1F000}-\\x{1FAFF}\\x{2600}-\\x{27BF}]|[\\x{FE0F}\\x{200D}]|[\\x{E0020}-\\x{E007F}])+",
+)
+private val FENCED_CODE_RE = Regex("```[\\s\\S]*?(?:```|$)")
+private const val CODE_BLOCK_SUMMARY = " code block omitted "
+private val INLINE_CODE_RE = Regex("`([^`]+)`")
+private val MARKDOWN_LINK_RE = Regex("\\[([^\\]]+)\\]\\(([^)]+)\\)")
+private val PARAGRAPH_BREAK_RE = Regex("[ \\t]*\\n{2,}[ \\t]*")
+private val PUNCTUATED_PARAGRAPH_BREAK_RE =
+    Regex("([.!?])([*_~`>\"'’”)}\\]]*)[ \\t]*\\n{2,}[ \\t]*")
+private val SOFT_BREAK_RE = Regex("[ \\t]*\\n[ \\t]*")
+private val CARRIAGE_RETURN_RE = Regex("\\r\\n?")
+private val HYPHEN_LINE_BREAK_RE = Regex("(\\p{L})-\\n(\\p{L})")
+private val HEADING_RE = Regex("^#{1,6}\\s+", RegexOption.MULTILINE)
+private val RESIDUAL_MARKDOWN_RE = Regex("[*_~>#]")
+private val LIST_MARKER_RE = Regex("^\\s*[-+*]\\s+", RegexOption.MULTILINE)
+private val WHITESPACE_RE = Regex("\\s+")
+
+private val THINKING_PREFIX_RE = Regex(
+    "^\\s*(?:\\([^)\\n]{1,48}\\)\\s*)?(?:processing|thinking|reasoning|analyzing|pondering|" +
+        "contemplating|musing|cogitating|ruminating|deliberating|mulling|reflecting|computing|" +
+        "synthesizing|formulating|brainstorming)\\.\\.\\.\\s*",
+    RegexOption.IGNORE_CASE,
+)
+
+private val URL_RE = Regex("\\bhttps?://\\S+", RegexOption.IGNORE_CASE)
+private val MARKDOWN_TABLE_DELIMITER_CELL_RE = Regex("^:?-{3,}:?$")
+
+private data class MarkdownTableRow(val blockquoteDepth: Int, val cells: List<String>)
+
+private fun isUnescapedPipe(row: String, index: Int): Boolean {
+    var backslashes = 0
+    var cursor = index - 1
+    while (cursor >= 0 && row[cursor] == '\\') {
+        backslashes += 1
+        cursor -= 1
+    }
+    return backslashes % 2 == 0
+}
+
+private fun unescapedPipeIndexes(row: String): List<Int> =
+    row.indices.filter { row[it] == '|' && isUnescapedPipe(row, it) }
+
+private fun splitMarkdownTableCells(row: String): List<String> {
+    val cells = mutableListOf<String>()
+    var cellStart = 0
+    for (index in row.indices) {
+        if (row[index] == '|' && isUnescapedPipe(row, index)) {
+            cells.add(row.substring(cellStart, index).trim())
+            cellStart = index + 1
+        }
+    }
+    cells.add(row.substring(cellStart).trim())
+    return cells
+}
+
+private fun parseMarkdownTableRow(line: String): MarkdownTableRow? {
+    var row = line
+    var blockquoteDepth = 0
+
+    while (true) {
+        val indentation = Regex("^[ \\t]*").find(row)?.value ?: ""
+        if (indentation.contains('\t') || indentation.length > 3) {
+            return null
+        }
+        row = row.substring(indentation.length)
+        if (!row.startsWith('>')) {
+            break
+        }
+        blockquoteDepth += 1
+        row = row.substring(1)
+        if (row.startsWith(' ')) {
+            row = row.substring(1)
+        }
+    }
+
+    row = row.trimEnd()
+
+    val pipeIndexes = unescapedPipeIndexes(row)
+    if (pipeIndexes.isEmpty()) {
+        return null
+    }
+
+    val hasLeadingPipe = pipeIndexes.first() == 0
+    val hasTrailingPipe = pipeIndexes.last() == row.length - 1
+
+    if (hasLeadingPipe) {
+        row = row.substring(1)
+    }
+    if (hasTrailingPipe) {
+        row = row.substring(0, row.length - 1)
+    }
+
+    val cells = splitMarkdownTableCells(row)
+    if (cells.size < 2 && !(hasLeadingPipe && hasTrailingPipe && cells.size == 1)) {
+        return null
+    }
+
+    return MarkdownTableRow(blockquoteDepth, cells)
+}
+
+private fun stripMarkdownTables(text: String): String {
+    val lines = CARRIAGE_RETURN_RE.replace(text, "\n").split("\n")
+    val tableLines = mutableSetOf<Int>()
+
+    var index = 1
+    while (index < lines.size) {
+        val delimiterRow = parseMarkdownTableRow(lines[index])
+        val headerRow = parseMarkdownTableRow(lines[index - 1])
+
+        if (
+            delimiterRow == null ||
+            headerRow == null ||
+            !delimiterRow.cells.all { MARKDOWN_TABLE_DELIMITER_CELL_RE.matches(it) } ||
+            headerRow.cells.size != delimiterRow.cells.size ||
+            headerRow.blockquoteDepth != delimiterRow.blockquoteDepth
+        ) {
+            index += 1
+            continue
+        }
+
+        tableLines.add(index - 1)
+        tableLines.add(index)
+
+        var rowIndex = index + 1
+        while (rowIndex < lines.size) {
+            val bodyRow = parseMarkdownTableRow(lines[rowIndex])
+            if (bodyRow == null || bodyRow.blockquoteDepth != delimiterRow.blockquoteDepth) {
+                break
+            }
+            tableLines.add(rowIndex)
+            rowIndex += 1
+        }
+
+        index = rowIndex
+    }
+
+    return lines.filterIndexed { lineIndex, _ -> lineIndex !in tableLines }.joinToString("\n")
+}
+
+private fun normalizeLineBreaks(text: String): String =
+    text
+        .let { CARRIAGE_RETURN_RE.replace(it, "\n") }
+        .let { HYPHEN_LINE_BREAK_RE.replace(it, "$1$2") }
+        .let { PUNCTUATED_PARAGRAPH_BREAK_RE.replace(it, "$1$2 ") }
+        .let { PARAGRAPH_BREAK_RE.replace(it, ". ") }
+        .let { SOFT_BREAK_RE.replace(it, " ") }
+
+fun sanitizeTextForSpeech(text: String): String =
+    normalizeLineBreaks(stripMarkdownTables(text))
+        .let { FENCED_CODE_RE.replace(it, CODE_BLOCK_SUMMARY) }
+        .let { THINKING_PREFIX_RE.replace(it, " ") }
+        .let { MARKDOWN_LINK_RE.replace(it, "$1") }
+        .let { INLINE_CODE_RE.replace(it, "$1") }
+        .let { URL_RE.replace(it, " link ") }
+        .let { EMOJI_RE.replace(it, " ") }
+        .let { HEADING_RE.replace(it, "") }
+        .let { RESIDUAL_MARKDOWN_RE.replace(it, "") }
+        .let { LIST_MARKER_RE.replace(it, "") }
+        .let { WHITESPACE_RE.replace(it, " ") }
+        .trim()

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/StreamingSpeechTransport.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/StreamingSpeechTransport.kt
@@ -1,0 +1,98 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import com.unsupportedpastels.hermesandroid.gateway.WsTicketClient
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.client.request.url
+import io.ktor.websocket.Frame
+import io.ktor.websocket.WebSocketSession
+import io.ktor.websocket.send
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancel
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Builds the same-origin `wss://…/api/audio/speak-stream` URL. Speech sockets
+ * authenticate exactly like the chat socket: a fresh single-use ticket minted
+ * via `POST /api/auth/ws-ticket`, never a bearer token in the URL. The URL is
+ * never logged (it carries the ticket).
+ */
+internal fun speakStreamUrl(origin: ServerOrigin, ticket: String, profile: String): String {
+    val wssOrigin = origin.value.replaceFirst("https://", "wss://")
+    val encodedTicket = URLEncoder.encode(ticket, StandardCharsets.UTF_8.name())
+    val encodedProfile = URLEncoder.encode(profile.take(64), StandardCharsets.UTF_8.name())
+    return "$wssOrigin/api/audio/speak-stream?ticket=$encodedTicket&profile=$encodedProfile"
+}
+
+/** Seam the ViewModel uses to open speech sockets (fake-able in tests). */
+fun interface SpeechStreamConnector {
+    suspend fun connect(
+        origin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+    ): SpeechStreamSocket
+}
+
+/**
+ * Opens streaming-speech sockets. Each [connect] mints a fresh single-use
+ * ticket — tickets are consumed by the server on upgrade, so reuse would fail
+ * closed anyway. Dedicated to `/api/audio/speak-stream`; the chat socket and
+ * its connection lifecycle are untouched.
+ */
+class StreamingSpeechTransport(
+    private val ticketClient: WsTicketClient,
+    private val socketFactory: SpeechWebSocketFactory,
+) : SpeechStreamConnector {
+    override suspend fun connect(
+        origin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+    ): SpeechStreamSocket {
+        val ticket = ticketClient.mintTicket(origin, accessToken)
+        return socketFactory.connect(speakStreamUrl(origin, ticket.ticket, profile))
+    }
+}
+
+/** Ktor-backed speech socket supporting the binary PCM frames the server sends. */
+class KtorSpeechWebSocketFactory(
+    private val client: HttpClient,
+) : SpeechWebSocketFactory {
+    override suspend fun connect(url: String): SpeechStreamSocket {
+        return try {
+            KtorSpeechSocket(client.webSocketSession { url(url) })
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            throw SpeechStreamConnectException(error)
+        }
+    }
+}
+
+/** Bounded connect failure — carries no URL/ticket detail. */
+class SpeechStreamConnectException(cause: Throwable?) :
+    Exception("Could not connect Hermes speech stream", cause)
+
+private class KtorSpeechSocket(
+    private val session: WebSocketSession,
+) : SpeechStreamSocket {
+    override suspend fun sendText(text: String) {
+        session.send(text)
+    }
+
+    override suspend fun receiveFrame(): SpeechSocketFrame? {
+        while (true) {
+            val frame = session.incoming.receiveCatching().getOrNull() ?: return null
+            when (frame) {
+                is Frame.Text -> return SpeechSocketFrame.Text(String(frame.data, StandardCharsets.UTF_8))
+                is Frame.Binary -> return SpeechSocketFrame.Binary(frame.data)
+                else -> Unit
+            }
+        }
+    }
+
+    override suspend fun close() {
+        session.cancel()
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceAudioTimeouts.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceAudioTimeouts.kt
@@ -1,0 +1,28 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.HttpRequestBuilder
+
+/**
+ * Audio transcription and synthesis run far longer than ordinary chat REST
+ * calls — the desktop client uses scaled 180–600s windows because a provider may
+ * spend minutes on a long utterance. These per-request timeouts are applied
+ * ONLY to `/api/audio/…` calls via [audioRequestTimeout]; the shared Hermes
+ * client installs `HttpTimeout` with no defaults, so ordinary requests keep
+ * their engine-level behaviour untouched.
+ */
+object VoiceAudioTimeouts {
+    const val TRANSCRIBE_REQUEST_MILLIS = 180_000L
+    const val SPEAK_REQUEST_MILLIS = 180_000L
+    const val CONNECT_MILLIS = 30_000L
+    const val SOCKET_MILLIS = 600_000L
+}
+
+/** Apply the extended audio window to a single `/api/audio/…` request. */
+fun HttpRequestBuilder.audioRequestTimeout(requestMillis: Long) {
+    timeout {
+        connectTimeoutMillis = VoiceAudioTimeouts.CONNECT_MILLIS
+        requestTimeoutMillis = requestMillis
+        socketTimeoutMillis = VoiceAudioTimeouts.SOCKET_MILLIS
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceCapabilities.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceCapabilities.kt
@@ -1,0 +1,48 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+/**
+ * Which official `/api/audio/…` contracts the connected `hermes serve`
+ * advertises. Everything downstream is fail-closed: an absent contract means the
+ * corresponding affordance is hidden, never surfaced as an error.
+ *
+ * Contracts verified against the installed server (hermes_cli/web_server.py):
+ * `POST /api/audio/transcribe`, `POST /api/audio/speak`,
+ * `WS /api/audio/speak-stream`, `GET /api/audio/elevenlabs/voices`.
+ */
+data class VoiceCapabilities(
+    /** The `/api/audio/…` route family exists on this server. */
+    val audioRoutesPresent: Boolean,
+    /** An ElevenLabs API key is configured, so the voice picker can populate. */
+    val elevenLabsVoicesAvailable: Boolean,
+) {
+    val canDictateViaServer: Boolean get() = audioRoutesPresent
+    val canReadAloud: Boolean get() = audioRoutesPresent
+    val canStreamSpeech: Boolean get() = audioRoutesPresent
+    val canPickElevenLabsVoice: Boolean get() = audioRoutesPresent && elevenLabsVoicesAvailable
+
+    companion object {
+        val NONE = VoiceCapabilities(audioRoutesPresent = false, elevenLabsVoicesAvailable = false)
+    }
+}
+
+/**
+ * Derives [VoiceCapabilities] from a lightweight, side-effect-free probe of the
+ * `GET /api/audio/elevenlabs/voices` route.
+ *
+ * That route is the family's cheapest existence test: released servers answer
+ * `200` (even with `available:false` when no key is set), while servers without
+ * the audio routes answer `404`/`405` — the same "unsupported route" signal HAM
+ * already uses for cron and bulk-delete endpoints. Any non-2xx (including auth
+ * or 5xx) fails closed to [VoiceCapabilities.NONE] and is re-probed later.
+ */
+object VoiceCapabilityPolicy {
+    fun fromVoicesProbe(statusCode: Int, elevenLabsAvailable: Boolean): VoiceCapabilities =
+        if (statusCode in 200..299) {
+            VoiceCapabilities(
+                audioRoutesPresent = true,
+                elevenLabsVoicesAvailable = elevenLabsAvailable,
+            )
+        } else {
+            VoiceCapabilities.NONE
+        }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceCommunicationAudioRoute.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceCommunicationAudioRoute.kt
@@ -1,0 +1,69 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.content.Context
+import android.media.AudioManager
+import android.media.AudioDeviceInfo
+import android.os.Build
+
+/** Owns the process-wide Android voice-communication audio mode. */
+class VoiceCommunicationAudioRoute(
+    context: Context,
+    private val onDiagnostics: (String) -> Unit = {},
+) {
+    private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private var holders = 0
+    private var previousMode = AudioManager.MODE_NORMAL
+    private var previousSpeakerphone = false
+    private var previousCommunicationDevice: AudioDeviceInfo? = null
+
+    @Synchronized
+    fun acquire() {
+        if (holders == 0) {
+            previousMode = audioManager.mode
+            previousSpeakerphone = audioManager.isSpeakerphoneOn
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                previousCommunicationDevice = audioManager.communicationDevice
+            }
+            audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+            selectSpeaker()
+        }
+        holders++
+    }
+
+    @Synchronized
+    fun release() {
+        if (holders == 0) return
+        holders--
+        if (holders == 0) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val previousDevice = previousCommunicationDevice
+                if (previousDevice != null) {
+                    val restored = audioManager.setCommunicationDevice(previousDevice)
+                    onDiagnostics("audio:route speaker-restored=$restored")
+                } else {
+                    audioManager.clearCommunicationDevice()
+                    onDiagnostics("audio:route speaker-restored=true")
+                }
+            } else {
+                audioManager.isSpeakerphoneOn = previousSpeakerphone
+            }
+            audioManager.mode = previousMode
+        }
+    }
+
+    @Synchronized
+    fun isHeld(): Boolean = holders > 0
+
+    private fun selectSpeaker() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val speaker = audioManager.availableCommunicationDevices.firstOrNull {
+                it.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
+            }
+            val selected = speaker?.let(audioManager::setCommunicationDevice) == true
+            onDiagnostics("audio:route speaker-selected=$selected available=${speaker != null}")
+        } else {
+            audioManager.isSpeakerphoneOn = true
+            onDiagnostics("audio:route speaker-selected=${audioManager.isSpeakerphoneOn}")
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationBar.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationBar.kt
@@ -523,7 +523,7 @@ fun VoiceConversationBar(
                 )
             }
             IconButton(
-                onClick = { host.controller.setMuted(!muted) },
+                onClick = { host.setMuted(!muted) },
                 modifier = Modifier
                     .size(36.dp)
                     .scale(0.9f)

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationBar.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationBar.kt
@@ -1,0 +1,546 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.content.Context
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Headphones
+import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.MicOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.unsupportedpastels.hermesandroid.gateway.ChatSessionSnapshot
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
+/**
+ * Everything the hands-free voice conversation needs from the connection layer.
+ * Null when the connected server lacks the audio routes, so the affordance is
+ * hidden (fail-closed). Entering the conversation is the user's explicit
+ * consent to auto-submit transcripts — unlike dictation, which only drafts.
+ */
+data class ComposerVoiceConversation(
+    val serverConfig: VoiceServerConfig,
+    val transcribe: suspend (dataUrl: String, mimeType: String?) -> Result<TranscriptionResult>,
+    val openStream: suspend () -> SpeechStreamSocket?,
+    val synthesize: suspend (text: String) -> Result<SpeechAudio>,
+)
+
+private const val LEVEL_POLL_MILLIS = 100L
+
+
+/**
+ * Record one utterance: level metering, silence auto-stop, and the server
+ * recording cap — the conversation-loop twin of the dictation mic's polling.
+ */
+internal suspend fun recordUtterance(
+    recorder: DictationRecorder,
+    config: VoiceServerConfig,
+    onLevel: (Float) -> Unit,
+    log: (String) -> Unit = {},
+): DictationRecording? {
+    if (!recorder.start()) {
+        log("recorder:start-failed")
+        return null
+    }
+    val autoStop = SilenceAutoStop(
+        configuredThreshold = config.silenceThreshold,
+        silenceMillis = (config.silenceDurationSeconds * 1_000).toLong(),
+        maxMillis = config.maxRecordingSeconds.toLong() * 1_000L,
+    )
+    val startedAt = System.currentTimeMillis()
+    log(
+        "recorder:cfg threshold=${config.silenceThreshold} " +
+            "silence=${(config.silenceDurationSeconds * 1_000).toLong()}ms " +
+            "max=${config.maxRecordingSeconds}s",
+    )
+    var peak = 0
+    var samples = 0
+    try {
+        while (true) {
+            delay(LEVEL_POLL_MILLIS)
+            val amplitude = recorder.sampleAmplitude()
+            if (amplitude > peak) peak = amplitude
+            // One diagnostic line per 2s: amplitude scale + detector state only.
+            if (++samples % 20 == 0) {
+                log("recorder:amp=$amplitude peak=$peak ${autoStop.debugState()}")
+            }
+            onLevel((amplitude / 32_767f).coerceIn(0f, 1f))
+            when (autoStop.feed(System.currentTimeMillis() - startedAt, amplitude)) {
+                SilenceAutoStopDecision.Continue -> Unit
+                SilenceAutoStopDecision.Stop -> {
+                    log("recorder:stop ${autoStop.debugState()}")
+                    return withContext(Dispatchers.IO) { recorder.stopAndEncode() }
+                }
+                SilenceAutoStopDecision.StopEmpty -> {
+                    log("recorder:stop-empty ${autoStop.debugState()}")
+                    // Nothing but room tone — never upload it.
+                    recorder.cancel()
+                    return null
+                }
+            }
+        }
+    } catch (cancelled: CancellationException) {
+        log("recorder:cancelled")
+        recorder.cancel()
+        throw cancelled
+    } catch (error: Exception) {
+        log("recorder:error ${error.javaClass.simpleName}")
+        recorder.cancel()
+        return null
+    }
+}
+
+/**
+ * REST-clip playback that the barge trigger can interrupt: [stop] both stops
+ * the engine and resolves the in-flight await (the engine fires no callback on
+ * an external stop), so the loop never hangs on a barged clip.
+ */
+internal class InterruptiblePlayback(private val engine: SpeechEngine) {
+    private var active: CompletableDeferred<Boolean>? = null
+
+    /** Play and suspend until the clip finishes (true) or fails/was stopped (false). */
+    suspend fun play(audio: SpeechAudio, onStarted: () -> Unit): Boolean {
+        val done = CompletableDeferred<Boolean>()
+        active = done
+        engine.play(
+            audio = audio,
+            onStarted = onStarted,
+            onFinished = { done.complete(true) },
+            onError = { done.complete(false) },
+        )
+        return try {
+            done.await()
+        } catch (cancelled: CancellationException) {
+            engine.stop()
+            throw cancelled
+        }
+    }
+
+    fun stop() {
+        engine.stop()
+        active?.complete(false)
+    }
+}
+
+/**
+ * Full-duplex barge-in monitor: meters the microphone while the agent
+ * thinks/speaks, using rotating short recorder segments so the eventual upload
+ * carries only a bounded pre-roll plus the interruption itself. On sustained
+ * speech it fires [onTrigger] once, keeps recording until the utterance ends
+ * (server silence tuning), and returns the encoded capture.
+ */
+internal suspend fun monitorBargeInWithRecorder(
+    recorderFactory: () -> DictationRecorder,
+    config: VoiceServerConfig,
+    onTrigger: () -> Unit,
+    /** True while TTS is audible — raises the trip point to the playback clamp. */
+    playbackActive: () -> Boolean = { false },
+): DictationRecording? {
+    val graceMillis = (config.bargeInGraceSeconds * 1_000).toLong()
+    val silenceMillis = minOf(
+        (config.silenceDurationSeconds * 1_000).toLong(),
+        BARGE_CAPTURE_SILENCE_MILLIS,
+    ).coerceAtLeast(400L)
+    val monitorStart = System.currentTimeMillis()
+    // One detector for the whole monitor: its grace-window ambient calibration
+    // must survive recorder segment rotation.
+    val detector = BargeInDetector(config.bargeTriggerAmplitude(), graceMillis)
+    while (true) {
+        val recorder = recorderFactory()
+        if (!recorder.start()) {
+            // Recorder contention (route change, transient failure) — back off.
+            delay(1_000)
+            continue
+        }
+        var triggered = false
+        val segmentStart = System.currentTimeMillis()
+        try {
+            while (true) {
+                delay(LEVEL_POLL_MILLIS)
+                val amplitude = recorder.sampleAmplitude()
+                val now = System.currentTimeMillis()
+                if (detector.onSample(now - monitorStart, amplitude, playbackActive())) {
+                    triggered = true
+                    onTrigger()
+                    break
+                }
+                if (now - segmentStart >= BARGE_SEGMENT_MILLIS) break
+            }
+            if (!triggered) {
+                recorder.cancel()
+                continue
+            }
+            // Capture the rest of the interruption until sustained silence,
+            // judged against the calibrated ambient floor (the raw server
+            // threshold sits below phone-mic room tone).
+            val utteranceStart = System.currentTimeMillis()
+            var silentFor = 0L
+            while (true) {
+                delay(LEVEL_POLL_MILLIS)
+                val amplitude = recorder.sampleAmplitude()
+                silentFor = if (amplitude < detector.silenceFloorAmplitude) {
+                    silentFor + LEVEL_POLL_MILLIS
+                } else {
+                    0L
+                }
+                val elapsed = System.currentTimeMillis() - utteranceStart
+                if (silentFor >= silenceMillis || elapsed >= BARGE_UTTERANCE_CAP_MILLIS) break
+            }
+            return withContext(Dispatchers.IO) { recorder.stopAndEncode() }
+        } catch (cancelled: CancellationException) {
+            recorder.cancel()
+            throw cancelled
+        }
+    }
+}
+
+private const val BARGE_SEGMENT_MILLIS = 5_000L
+private const val BARGE_UTTERANCE_CAP_MILLIS = 30_000L
+/** Do not wait for the normal 3s dictation pause before classifying a barge. */
+private const val BARGE_CAPTURE_SILENCE_MILLIS = 1_200L
+
+/**
+ * Builds a [VoiceConversationHost] bound to the open session. The loop ends on
+ * session switch, when the composable leaves composition, and on activity stop
+ * (privacy default: no capture while not visible). Draft text is untouched.
+ */
+@Composable
+fun rememberVoiceConversationHost(
+    conversation: ComposerVoiceConversation?,
+    sessionId: String,
+    chat: ChatSessionSnapshot,
+    onSubmit: (text: String, interrupted: Boolean) -> Unit,
+    onStopTurn: () -> Unit = {},
+    screenOffContinuation: Boolean = false,
+    recorderFactory: (Context) -> DictationRecorder = { MediaRecorderDictationRecorder(it) },
+    bargeRecorderFactory: (Context) -> DictationRecorder = { context: Context ->
+        AudioRecordBargeRecorder(context = context)
+    },
+    speechEngineFactory: (Context) -> SpeechEngine = { MediaPlayerSpeechEngine(it) },
+): VoiceConversationHost? {
+    if (conversation == null) return null
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val chatState = rememberUpdatedState(chat)
+    val submitState = rememberUpdatedState(onSubmit)
+    val stopTurnState = rememberUpdatedState(onStopTurn)
+    // The dependency bundle is rebuilt by callers on recomposition; reading it
+    // through updated state keeps ONE host per open session. Keying the host on
+    // the bundle would tear the loop down on every recomposition.
+    val conversationState = rememberUpdatedState(conversation)
+    val audioRoute = remember { VoiceCommunicationAudioRoute(context) }
+    val speechEngine = remember { speechEngineFactory(context) }
+
+    val host = remember(sessionId) {
+        val controller = VoiceConversationController {
+            conversationState.value.serverConfig.stopPhrases
+        }
+        val recorder = recorderFactory(context)
+        val playback = InterruptiblePlayback(speechEngine)
+        VoiceConversationHost(
+            controller = controller,
+            scope = scope,
+            engines = VoiceConversationEngines(
+                listen = { onLevel ->
+                    recordUtterance(
+                        recorder,
+                        conversationState.value.serverConfig,
+                        onLevel,
+                        log = {},
+                    )
+                },
+                transcribe = { dataUrl, mimeType ->
+                    conversationState.value.transcribe(dataUrl, mimeType)
+                },
+                submit = { text, interrupted -> submitState.value(text, interrupted) },
+                replies = snapshotFlow { chatState.value.toVoiceReplyView() },
+                openStream = { conversationState.value.openStream() },
+                sinkFactory = { AudioTrackSpeechSink() },
+                restSpeak = { text -> conversationState.value.synthesize(text) },
+                playAudio = { audio, onStarted, onFinished, onError ->
+                    if (playback.play(audio, onStarted)) onFinished() else onError()
+                },
+                stopPlayback = { playback.stop() },
+                stopTurn = { stopTurnState.value() },
+                startAudioSession = {
+                    audioRoute.acquire()
+                },
+                stopAudioSession = { audioRoute.release() },
+                monitorBargeIn = { onTrigger ->
+                    val config = conversationState.value.serverConfig
+                    if (config.bargeInEnabled) {
+                        monitorBargeInWithRecorder(
+                            recorderFactory = { bargeRecorderFactory(context) },
+                            config = config,
+                            onTrigger = onTrigger,
+                            playbackActive = {
+                                controller.state.value == VoiceConversationState.Speaking
+                            },
+                        )
+                    } else {
+                        // Barge-in disabled by server config: idle until the
+                        // turn's monitor window is cancelled.
+                        kotlinx.coroutines.awaitCancellation()
+                    }
+                },
+                log = {},
+            ),
+        )
+    }
+
+    // End on session switch / leaving composition; release the media engine.
+    DisposableEffect(host) {
+        onDispose { host.end() }
+    }
+    DisposableEffect(Unit) {
+        onDispose { speechEngine.release() }
+    }
+    // Privacy default: leaving the foreground (including device lock) ends the
+    // loop — unless the user opted into screen-off continuation and its
+    // microphone foreground service is already running.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val continuationState = rememberUpdatedState(screenOffContinuation)
+    DisposableEffect(lifecycleOwner, host) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP &&
+                !(continuationState.value && VoiceServiceBridge.running)
+            ) {
+                host.end()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // While the loop is active: run the opted-in foreground service (persistent
+    // stoppable notification, phase label only — never transcript text), stop
+    // the loop on headphone route loss, and expose Stop to the notification.
+    val hostState = host.controller.state.collectAsState()
+    DisposableEffect(host) {
+        VoiceServiceBridge.onStopRequested = { host.end() }
+        onDispose {
+            VoiceServiceBridge.onStopRequested = null
+            VoiceConversationService.stop(context)
+        }
+    }
+    LaunchedEffect(host, screenOffContinuation) {
+        snapshotFlow { hostState.value }.collect { state ->
+            if (state == VoiceConversationState.Idle) {
+                VoiceConversationService.stop(context)
+            } else if (screenOffContinuation) {
+                val label = when (state) {
+                    is VoiceConversationState.Listening -> "Listening"
+                    VoiceConversationState.Transcribing -> "Transcribing"
+                    VoiceConversationState.Thinking -> "Thinking"
+                    VoiceConversationState.Speaking -> "Speaking"
+                    VoiceConversationState.Idle -> ""
+                }
+                VoiceConversationService.start(context, label)
+            }
+        }
+    }
+    DisposableEffect(host) {
+        val receiver = object : android.content.BroadcastReceiver() {
+            override fun onReceive(receiverContext: Context?, intent: android.content.Intent?) {
+                if (intent?.action == android.media.AudioManager.ACTION_AUDIO_BECOMING_NOISY &&
+                    host.isActive
+                ) {
+                    // Wired/Bluetooth route loss must not continue through speakers.
+                    host.end()
+                }
+            }
+        }
+        context.registerReceiver(
+            receiver,
+            android.content.IntentFilter(android.media.AudioManager.ACTION_AUDIO_BECOMING_NOISY),
+        )
+        onDispose { runCatching { context.unregisterReceiver(receiver) } }
+    }
+    return host
+}
+
+/** Headphones toggle that enters/ends the hands-free voice conversation. */
+@Composable
+fun VoiceConversationToggleButton(
+    host: VoiceConversationHost,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val state by host.controller.state.collectAsState()
+    val active = state != VoiceConversationState.Idle
+    val description = if (active) "End voice conversation" else "Start voice conversation"
+    val permissionLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+        androidx.activity.result.contract.ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) host.start()
+    }
+    fun startWithPermission() {
+        val granted = androidx.core.content.ContextCompat.checkSelfPermission(
+            context,
+            android.Manifest.permission.RECORD_AUDIO,
+        ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+        if (granted) host.start() else permissionLauncher.launch(android.Manifest.permission.RECORD_AUDIO)
+    }
+    IconButton(
+        onClick = { if (active) host.end() else startWithPermission() },
+        enabled = enabled || active,
+        modifier = modifier.semantics { contentDescription = description },
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Headphones,
+            contentDescription = null,
+            tint = if (active) {
+                MaterialTheme.colorScheme.primary
+            } else if (enabled) {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            } else {
+                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+            },
+        )
+    }
+}
+
+/**
+ * Compact status bar shown above the composer while the conversation is active:
+ * phase label + level animation, mute toggle, and hard End. Stop-Hermes-response
+ * remains the composer's separate destructive control.
+ */
+@Composable
+fun VoiceConversationBar(
+    host: VoiceConversationHost,
+    modifier: Modifier = Modifier,
+) {
+    val state by host.controller.state.collectAsState()
+    val muted by host.controller.muted.collectAsState()
+    val notice by host.controller.notice.collectAsState()
+    if (state == VoiceConversationState.Idle) return
+
+    val label = when {
+        muted -> "Muted"
+        else -> when (state) {
+            is VoiceConversationState.Listening -> "Listening"
+            VoiceConversationState.Transcribing -> "Transcribing"
+            VoiceConversationState.Thinking -> "Thinking"
+            VoiceConversationState.Speaking -> "Speaking"
+            VoiceConversationState.Idle -> ""
+        }
+    }
+    val level = (state as? VoiceConversationState.Listening)?.level ?: 0f
+    val pulse by animateFloatAsState(targetValue = 1f + level * 0.6f, label = "voiceLevelPulse")
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("Voice conversation bar")
+            .semantics {
+                contentDescription = "Voice conversation"
+                stateDescription = label
+            },
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(20.dp)
+                    .graphicsLayer { scaleX = pulse; scaleY = pulse },
+                contentAlignment = Alignment.Center,
+            ) {
+                Surface(
+                    modifier = Modifier.size(10.dp),
+                    shape = CircleShape,
+                    color = when {
+                        muted -> MaterialTheme.colorScheme.outline
+                        state is VoiceConversationState.Listening ->
+                            MaterialTheme.colorScheme.error
+                        else -> MaterialTheme.colorScheme.primary
+                    },
+                ) {}
+            }
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier
+                    .padding(start = 8.dp)
+                    .weight(1f),
+            )
+            notice?.let {
+                Text(
+                    text = when (it) {
+                        VoiceConversationNotice.TranscriptionFailed -> "Couldn't transcribe"
+                        VoiceConversationNotice.SpeechFailed -> "Couldn't speak reply"
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(end = 8.dp),
+                )
+            }
+            IconButton(
+                onClick = { host.controller.setMuted(!muted) },
+                modifier = Modifier
+                    .size(36.dp)
+                    .scale(0.9f)
+                    .semantics {
+                        contentDescription = if (muted) "Unmute microphone" else "Mute microphone"
+                    },
+            ) {
+                Icon(
+                    imageVector = if (muted) Icons.Outlined.MicOff else Icons.Outlined.Mic,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            IconButton(
+                onClick = { host.end() },
+                modifier = Modifier
+                    .size(36.dp)
+                    .semantics { contentDescription = "End voice conversation" },
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Close,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationBar.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -425,6 +426,13 @@ fun VoiceConversationToggleButton(
         Icon(
             imageVector = Icons.Outlined.Headphones,
             contentDescription = null,
+            // The Headphones glyph fills 18dp of its 24dp viewport, dead-center,
+            // while the composer's Mic glyph fills 19dp optically centered 0.5dp
+            // high. Render slightly larger and nudged up so the pair reads as the
+            // same size on the same optical baseline.
+            modifier = Modifier
+                .size(26.dp)
+                .offset(y = (-0.5).dp),
             tint = if (active) {
                 MaterialTheme.colorScheme.primary
             } else if (enabled) {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationController.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationController.kt
@@ -1,0 +1,189 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** Phase of the hands-free voice conversation loop. */
+sealed interface VoiceConversationState {
+    data object Idle : VoiceConversationState
+
+    /** Microphone armed, waiting for the user to finish an utterance. */
+    data class Listening(val level: Float = 0f) : VoiceConversationState
+
+    data object Transcribing : VoiceConversationState
+
+    /** Prompt submitted; the agent is generating. */
+    data object Thinking : VoiceConversationState
+
+    /** The reply is being spoken aloud. */
+    data object Speaking : VoiceConversationState
+}
+
+/** What to do with a finished transcript. */
+enum class TranscriptDisposition {
+    /** Substantive text — submit it as a prompt. */
+    Submit,
+
+    /** Whole-utterance stop phrase — end the conversation without submitting. */
+    EndConversation,
+
+    /** Silence/empty — re-arm the microphone without submitting. */
+    Rearm,
+}
+
+/** Bounded, category-only error surfaced on the voice bar. */
+enum class VoiceConversationNotice {
+    TranscriptionFailed,
+    SpeechFailed,
+}
+
+/**
+ * Pure state machine for the explicit voice-conversation loop:
+ * listen → transcribe → think → speak → re-arm. Entering the loop is the
+ * user's deliberate consent, so (unlike dictation) a substantive transcript
+ * *is* submitted automatically. Owns no Android, transport, or timer state —
+ * the host drives it and every callback is guarded by [generation] so stale
+ * engine events from a previous loop are ignored.
+ */
+class VoiceConversationController(
+    private val stopPhrases: () -> List<String>,
+) {
+    private val _state = MutableStateFlow<VoiceConversationState>(VoiceConversationState.Idle)
+    val state: StateFlow<VoiceConversationState> = _state.asStateFlow()
+
+    private val _muted = MutableStateFlow(false)
+    val muted: StateFlow<Boolean> = _muted.asStateFlow()
+
+    private val _notice = MutableStateFlow<VoiceConversationNotice?>(null)
+    val notice: StateFlow<VoiceConversationNotice?> = _notice.asStateFlow()
+
+    /** Increments on every start/end; hosts tag async callbacks with it. */
+    var generation: Long = 0L
+        private set
+
+    val isActive: Boolean get() = _state.value != VoiceConversationState.Idle
+
+    /** Begin the loop. Only valid from Idle. */
+    fun start(): Boolean {
+        if (isActive) return false
+        generation++
+        _muted.value = false
+        _notice.value = null
+        _state.value = VoiceConversationState.Listening()
+        return true
+    }
+
+    /** Hard end from any phase (user End, stop phrase, lifecycle, fatal error). */
+    fun end() {
+        generation++
+        _state.value = VoiceConversationState.Idle
+        _muted.value = false
+    }
+
+    fun onListeningLevel(level: Float) {
+        if (_state.value is VoiceConversationState.Listening) {
+            _state.value = VoiceConversationState.Listening(level.coerceIn(0f, 1f))
+        }
+    }
+
+    /** An utterance was captured; move to transcription. */
+    fun onUtteranceCaptured(): Boolean {
+        if (_state.value !is VoiceConversationState.Listening) return false
+        _state.value = VoiceConversationState.Transcribing
+        return true
+    }
+
+    /** Nothing captured (recorder failure / pure silence) — re-arm. */
+    fun onCaptureEmpty() {
+        if (_state.value is VoiceConversationState.Transcribing ||
+            _state.value is VoiceConversationState.Listening
+        ) {
+            _state.value = VoiceConversationState.Listening()
+        }
+    }
+
+    /**
+     * Transcription finished. Decides the transcript's fate and transitions:
+     * stop phrase ends the loop, blank re-arms, substantive text moves to
+     * Thinking (the host submits it).
+     */
+    fun onTranscript(transcript: String): TranscriptDisposition {
+        if (_state.value !is VoiceConversationState.Transcribing) return TranscriptDisposition.Rearm
+        _notice.value = null
+        return when {
+            transcript.isBlank() -> {
+                _state.value = VoiceConversationState.Listening()
+                TranscriptDisposition.Rearm
+            }
+            isVoiceStopPhrase(transcript, stopPhrases()) -> {
+                end()
+                TranscriptDisposition.EndConversation
+            }
+            else -> {
+                _state.value = VoiceConversationState.Thinking
+                TranscriptDisposition.Submit
+            }
+        }
+    }
+
+    /** Transcription failed — visible bounded notice, then re-arm. */
+    fun onTranscriptionFailed() {
+        if (_state.value !is VoiceConversationState.Transcribing) return
+        _notice.value = VoiceConversationNotice.TranscriptionFailed
+        _state.value = VoiceConversationState.Listening()
+    }
+
+    /** Reply audio started. */
+    fun onSpeechStarted(): Boolean {
+        if (_state.value !is VoiceConversationState.Thinking) return false
+        _state.value = VoiceConversationState.Speaking
+        return true
+    }
+
+    /** The turn ended with nothing speakable (tool-only, error, muted) — re-arm. */
+    fun onTurnCompleteWithoutSpeech() {
+        if (_state.value is VoiceConversationState.Thinking ||
+            _state.value is VoiceConversationState.Speaking
+        ) {
+            _state.value = VoiceConversationState.Listening()
+        }
+    }
+
+    /** Reply playback finished naturally — re-arm the microphone. */
+    fun onSpeechFinished() {
+        if (_state.value is VoiceConversationState.Speaking) {
+            _state.value = VoiceConversationState.Listening()
+        }
+    }
+
+    /** Speech synthesis/playback failed nonfatally — notice, then re-arm. */
+    fun onSpeechFailed() {
+        if (_state.value is VoiceConversationState.Thinking ||
+            _state.value is VoiceConversationState.Speaking
+        ) {
+            _notice.value = VoiceConversationNotice.SpeechFailed
+            _state.value = VoiceConversationState.Listening()
+        }
+    }
+
+    /**
+     * The user spoke over thinking/playback (barge-in). Playback stops and the
+     * mic is already capturing the interruption; state returns to Listening.
+     */
+    fun onBargeIn(): Boolean {
+        if (_state.value !is VoiceConversationState.Thinking &&
+            _state.value !is VoiceConversationState.Speaking
+        ) {
+            return false
+        }
+        _state.value = VoiceConversationState.Listening()
+        return true
+    }
+
+    /** Mute pauses capture without ending the loop; unmute re-arms listening. */
+    fun setMuted(muted: Boolean) {
+        if (!isActive) return
+        _muted.value = muted
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationHost.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationHost.kt
@@ -7,11 +7,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.selects.select
 
 /**
  * The slice of a chat snapshot the voice loop watches: whether the turn is
@@ -159,6 +161,32 @@ class VoiceConversationHost(
 
     val isActive: Boolean get() = controller.isActive
 
+    /**
+     * Run one microphone operation until it completes or mute is enabled. The
+     * child job is deliberately separate from the loop job so muting cancels
+     * recorder polling without ending the conversation itself.
+     */
+    private suspend fun captureUntilMuted(
+        operation: suspend () -> DictationRecording?,
+    ): DictationRecording? = coroutineScope {
+        val capture = async(start = CoroutineStart.UNDISPATCHED) { operation() }
+        val muted = async(start = CoroutineStart.UNDISPATCHED) {
+            controller.muted.first { it }
+        }
+        try {
+            select {
+                capture.onAwait { it }
+                muted.onAwait {
+                    capture.cancel()
+                    null
+                }
+            }
+        } finally {
+            muted.cancel()
+            capture.cancel()
+        }
+    }
+
     fun start() {
         if (!controller.start()) return
         engines.startAudioSession()
@@ -198,7 +226,9 @@ class VoiceConversationHost(
         controller.muted.first { !it }
 
         engines.log("listen:start")
-        val recording = engines.listen { level -> controller.onListeningLevel(level) }
+        val recording = captureUntilMuted {
+            engines.listen { level -> controller.onListeningLevel(level) }
+        }
         engines.log("listen:done captured=${recording != null}")
         if (!controller.onUtteranceCaptured()) return
         if (recording == null) {
@@ -276,23 +306,36 @@ class VoiceConversationHost(
     private fun startBargeMonitor(): Job? {
         val monitor = engines.monitorBargeIn ?: return null
         val job = scope.launch {
-            val recording = monitor {
-                barged = true
-                engines.log("barge:candidate")
-                if (controller.state.value !is VoiceConversationState.Speaking) {
-                    // There is no audible reply to classify while Thinking,
-                    // so preserve the responsive interruption path.
-                    stopForBarge()
-                    controller.onBargeIn()
-                } else {
-                    // Stop only local audio immediately so a real user can
-                    // take the floor. Do not cancel Hermes until STT and echo
-                    // comparison complete; otherwise TTS cancels itself.
-                    stopPlaybackForBarge()
-                    engines.log("barge:playback-candidate")
+            val recording = captureUntilMuted {
+                monitor {
+                    barged = true
+                    engines.log("barge:candidate")
+                    if (controller.state.value !is VoiceConversationState.Speaking) {
+                        // There is no audible reply to classify while Thinking,
+                        // so preserve the responsive interruption path.
+                        stopForBarge()
+                        controller.onBargeIn()
+                    } else {
+                        // Stop only local audio immediately so a real user can
+                        // take the floor. Do not cancel Hermes until STT and echo
+                        // comparison complete; otherwise TTS cancels itself.
+                        stopPlaybackForBarge()
+                        engines.log("barge:playback-candidate")
+                    }
                 }
             }
-            if (barged) bargedCapture = recording
+            if (barged && !controller.muted.value) {
+                bargedCapture = recording
+            } else if (controller.muted.value) {
+                // Mute can race with the detector after it has stopped local
+                // playback. Discard that partial barge and re-arm once unmuted.
+                val playbackWasStopped = bargePlaybackStopIssued
+                barged = false
+                bargedCapture = null
+                bargeStopIssued = false
+                bargePlaybackStopIssued = false
+                if (playbackWasStopped) controller.onBargeIn()
+            }
         }
         bargeMonitorJob = job
         return job
@@ -355,6 +398,11 @@ class VoiceConversationHost(
         bargePlaybackStopIssued = true
         activeRun?.let { run -> scope.launch { run.stop() } }
         engines.stopPlayback()
+    }
+
+    /** Mute only the microphone capture; the loop remains explicitly active. */
+    fun setMuted(muted: Boolean) {
+        controller.setMuted(muted)
     }
 
     private suspend fun speakTurn(promptText: String, interrupted: Boolean = false) {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationHost.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationHost.kt
@@ -1,0 +1,536 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import com.unsupportedpastels.hermesandroid.gateway.ChatMessageRole
+import com.unsupportedpastels.hermesandroid.gateway.ChatSessionSnapshot
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * The slice of a chat snapshot the voice loop watches: whether the turn is
+ * still running, the live streaming text, and the last finalized assistant
+ * reply with its position (so a baseline taken at submit time can exclude
+ * history — the loop must never speak an old reply).
+ */
+data class VoiceReplyView(
+    val turnRunning: Boolean,
+    val streamingText: String?,
+    /** Position of the streaming assistant message, or -1. Both the streaming
+     * and final speech paths are baseline-gated: session resume/reconcile can
+     * re-mark a *historical* assistant message as streaming, and it must never
+     * be fed to TTS as if it were this turn's reply. */
+    val streamingIndex: Int,
+    val finalAssistantText: String?,
+    val finalAssistantIndex: Int,
+    val messageCount: Int,
+)
+
+fun ChatSessionSnapshot.toVoiceReplyView(): VoiceReplyView {
+    var finalIndex = -1
+    var finalText: String? = null
+    var streamingIndex = -1
+    var streamingText: String? = null
+    messages.forEachIndexed { index, message ->
+        if (message.role != ChatMessageRole.Assistant) return@forEachIndexed
+        if (message.isStreaming) {
+            streamingIndex = index
+            streamingText = message.text.takeIf { it.isNotEmpty() }
+        } else if (message.text.isNotBlank()) {
+            finalIndex = index
+            finalText = message.text
+        }
+    }
+    return VoiceReplyView(
+        turnRunning = isSending || messages.any { it.isStreaming },
+        streamingText = streamingText,
+        streamingIndex = if (streamingText != null) streamingIndex else -1,
+        finalAssistantText = finalText,
+        finalAssistantIndex = finalIndex,
+        messageCount = messages.size,
+    )
+}
+
+/**
+ * Everything the voice loop needs from the outside world, as injectable seams:
+ * Android capture, server transcription, prompt submission, chat progress, the
+ * streaming speech socket, and the REST/playback fallback. The host contains
+ * the loop *logic* and is tested against fakes; the composable wrapper supplies
+ * real engines.
+ */
+class VoiceConversationEngines(
+    /** Record one utterance (level callbacks in 0..1) until silence/cap; null = nothing captured. */
+    val listen: suspend (onLevel: (Float) -> Unit) -> DictationRecording?,
+    val transcribe: suspend (dataUrl: String, mimeType: String?) -> Result<TranscriptionResult>,
+    /**
+     * Submit a voice prompt through the exact-session controller seam.
+     * [interrupted] is true only for the utterance captured by a barge-in — the
+     * flag is scoped to that one call, so a stale barge can never annotate a
+     * later typed message or another session's submit.
+     */
+    val submit: (text: String, interrupted: Boolean) -> Unit,
+    /** Live view of the open session's chat progress. */
+    val replies: Flow<VoiceReplyView>,
+    /** Fresh-ticket streaming socket, or null when streaming is unavailable. */
+    val openStream: suspend () -> SpeechStreamSocket?,
+    val sinkFactory: () -> PcmSpeechSink,
+    /** REST synthesis fallback (sanitized text). */
+    val restSpeak: suspend (text: String) -> Result<SpeechAudio>,
+    /** Play a REST-synthesized clip; suspends until playback finishes or fails. */
+    val playAudio: suspend (
+        audio: SpeechAudio,
+        onStarted: () -> Unit,
+        onFinished: () -> Unit,
+        onError: () -> Unit,
+    ) -> Unit,
+    val stopPlayback: () -> Unit,
+    /** Stop the running turn (the same seam as the composer Stop button). */
+    val stopTurn: () -> Unit = {},
+    /** Acquire/release Android voice-communication routing for the full loop. */
+    val startAudioSession: () -> Unit = {},
+    val stopAudioSession: () -> Unit = {},
+    /**
+     * Full-duplex barge-in monitor, or null when barge-in is disabled. Runs
+     * while the agent thinks/speaks; calls its trigger callback the moment
+     * sustained user speech is detected, keeps capturing until the utterance
+     * ends, and returns the captured recording (null if capture failed).
+     */
+    val monitorBargeIn: (suspend (onTrigger: () -> Unit) -> DictationRecording?)? = null,
+    /** How long to wait for the submitted turn to start before re-arming. */
+    val turnStartTimeoutMillis: Long = 10_000L,
+    /** After a barge stops the turn, how long to wait for busy state to settle. */
+    val bargeSettleTimeoutMillis: Long = 5_000L,
+    /** Bound on the speech-socket connect; past it, REST speaks instead. */
+    val streamOpenTimeoutMillis: Long = 10_000L,
+    /** A "turn finished" report must hold this long before the reply speaks. */
+    val settleConfirmMillis: Long = 2_000L,
+    /** Pre-audio watchdog for the speech stream (see [SpeechStreamProtocol]). */
+    val streamProgressTimeoutMillis: Long = SpeechStreamProtocol.PROGRESS_TIMEOUT_MILLIS,
+    /**
+     * Diagnostic sink for loop-phase events. Receives bounded category strings
+     * only — never transcript, audio, or config content. No-op by default.
+     */
+    val log: (String) -> Unit = {},
+)
+
+/**
+ * Drives one voice-conversation loop: listen → transcribe → submit → speak →
+ * re-arm, per [VoiceConversationController] rules. Runs as a single coroutine
+ * so session switch/lifecycle teardown is one [end] call; every engine callback
+ * is inherently generation-safe because ending cancels the loop job.
+ */
+private const val EMPTY_CAPTURE_BACKOFF_MILLIS = 500L
+/** Let the barge detector observe Speaking before TTS emits audio. */
+private const val BARGE_PLAYBACK_ARM_MILLIS = 600L
+/** Let the speaker/audio route drain before reopening the microphone. */
+private const val POST_PLAYBACK_MIC_COOLDOWN_MILLIS = 1_500L
+
+class VoiceConversationHost(
+    val controller: VoiceConversationController,
+    private val scope: CoroutineScope,
+    private val engines: VoiceConversationEngines,
+) {
+    private var loopJob: Job? = null
+    private var activeRun: SpeechStreamRun? = null
+
+    @Volatile
+    private var barged = false
+
+    @Volatile
+    private var bargedCapture: DictationRecording? = null
+
+    @Volatile
+    private var bargeStopIssued = false
+
+    @Volatile
+    private var bargePlaybackStopIssued = false
+
+    private var bargeMonitorJob: Job? = null
+
+    /** The reply text most recently sent to TTS, for echo self-capture checks. */
+    @Volatile
+    private var lastSpokenText: String? = null
+
+    val isActive: Boolean get() = controller.isActive
+
+    fun start() {
+        if (!controller.start()) return
+        engines.startAudioSession()
+        engines.log("host:start gen=${controller.generation}")
+        loopJob = scope.launch {
+            try {
+                while (isActive && controller.isActive) {
+                    runTurn()
+                }
+            } finally {
+                engines.stopPlayback()
+                engines.stopAudioSession()
+            }
+        }
+    }
+
+    /** Hard end from UI, stop phrase, session switch, or lifecycle. */
+    fun end() {
+        engines.log("host:end gen=${controller.generation}")
+        controller.end()
+        val job = loopJob
+        loopJob = null
+        job?.cancel()
+        bargeMonitorJob?.cancel()
+        bargeMonitorJob = null
+        val run = activeRun
+        activeRun = null
+        if (run != null) {
+            scope.launch { run.stop() }
+        }
+        engines.stopPlayback()
+        engines.stopAudioSession()
+    }
+
+    private suspend fun runTurn() {
+        // Muted: hold without capturing until unmuted or ended.
+        controller.muted.first { !it }
+
+        engines.log("listen:start")
+        val recording = engines.listen { level -> controller.onListeningLevel(level) }
+        engines.log("listen:done captured=${recording != null}")
+        if (!controller.onUtteranceCaptured()) return
+        if (recording == null) {
+            controller.onCaptureEmpty()
+            // A failing recorder must not spin the loop.
+            kotlinx.coroutines.delay(EMPTY_CAPTURE_BACKOFF_MILLIS)
+            return
+        }
+
+        val transcript = try {
+            engines.transcribe(recording.dataUrl, recording.mimeType)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            Result.failure(error)
+        }
+        val text = transcript.getOrNull()
+        engines.log("transcribe:done chars=${text?.transcript?.length ?: -1}")
+        if (text == null) {
+            controller.onTranscriptionFailed()
+            return
+        }
+        when (controller.onTranscript(text.transcript)) {
+            TranscriptDisposition.Submit -> submitAndSpeakLoop(text.transcript)
+            TranscriptDisposition.EndConversation -> end()
+            TranscriptDisposition.Rearm -> Unit
+        }
+    }
+
+    /**
+     * Submit → speak, then chain barge-in follow-ups: a barge stops the reply
+     * mid-flight, captures the interruption, and (for substantive text) submits
+     * it as the next prompt with `interrupted=true`.
+     */
+    private suspend fun submitAndSpeakLoop(firstText: String) {
+        var pending: String? = firstText
+        var interrupted = false
+        while (pending != null && controller.isActive) {
+            val text = pending
+            pending = null
+            if (interrupted) {
+                // Give the stopped turn a bounded window to settle before resubmitting.
+                withTimeoutOrNull(engines.bargeSettleTimeoutMillis) {
+                    engines.replies.first { !it.turnRunning }
+                }
+                if (!controller.isActive) return
+            }
+            barged = false
+            bargedCapture = null
+            bargeStopIssued = false
+            bargePlaybackStopIssued = false
+            val monitor = startBargeMonitor()
+            try {
+                speakTurn(text, interrupted)
+            } finally {
+                // A triggered monitor is mid-capture; let it finish its utterance.
+                if (!barged) monitor?.cancel()
+            }
+            if (barged) {
+                monitor?.join()
+                pending = processBargeCapture(bargedCapture)
+                bargedCapture = null
+                interrupted = true
+            } else {
+                // Do not reopen the normal microphone listener on the same
+                // scheduler turn as TTS completion. The speaker/audio route can
+                // still contain the tail of the reply, which otherwise becomes
+                // the next user utterance (even though barge monitoring has
+                // already been canceled).
+                kotlinx.coroutines.delay(POST_PLAYBACK_MIC_COOLDOWN_MILLIS)
+            }
+        }
+    }
+
+    private fun startBargeMonitor(): Job? {
+        val monitor = engines.monitorBargeIn ?: return null
+        val job = scope.launch {
+            val recording = monitor {
+                barged = true
+                engines.log("barge:candidate")
+                if (controller.state.value !is VoiceConversationState.Speaking) {
+                    // There is no audible reply to classify while Thinking,
+                    // so preserve the responsive interruption path.
+                    stopForBarge()
+                    controller.onBargeIn()
+                } else {
+                    // Stop only local audio immediately so a real user can
+                    // take the floor. Do not cancel Hermes until STT and echo
+                    // comparison complete; otherwise TTS cancels itself.
+                    stopPlaybackForBarge()
+                    engines.log("barge:playback-candidate")
+                }
+            }
+            if (barged) bargedCapture = recording
+        }
+        bargeMonitorJob = job
+        return job
+    }
+
+    /** Transcribe the barged utterance; returns the next prompt text or null. */
+    private suspend fun processBargeCapture(capture: DictationRecording?): String? {
+        if (!controller.isActive) return null
+        if (capture == null) return null
+        if (!controller.onUtteranceCaptured()) return null
+        val result = try {
+            engines.transcribe(capture.dataUrl, capture.mimeType)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            Result.failure(error)
+        }
+        val text = result.getOrNull()
+        if (text == null) {
+            controller.onTranscriptionFailed()
+            return null
+        }
+        // Speaker bleed: a playback-phase capture that matches the reply Hermes
+        // just spoke is a self-capture, not the user — discard it or the loop
+        // feeds its own voice back into itself (TTS → STT → TTS).
+        val echoSimilarity = VoiceEchoFilter.bestSimilarity(text.transcript, lastSpokenText)
+        engines.log(
+            "barge:echo-check sim=${"%.2f".format(echoSimilarity)} " +
+                "aChars=${text.transcript.length} bChars=${lastSpokenText?.length ?: 0}",
+        )
+        if (echoSimilarity >= VoiceEchoFilter.DEFAULT_SIMILARITY_THRESHOLD) {
+            engines.log("barge:echo-discarded")
+            controller.onCaptureEmpty()
+            return null
+        }
+        // The capture is now classified as user speech. Keep the stop seam
+        // for a genuine interruption, but never invoke it for speaker bleed.
+        stopForBarge()
+        controller.onBargeIn()
+        return when (controller.onTranscript(text.transcript)) {
+            TranscriptDisposition.Submit -> text.transcript
+            TranscriptDisposition.EndConversation -> {
+                end()
+                null
+            }
+            TranscriptDisposition.Rearm -> null
+        }
+    }
+
+    private fun stopForBarge() {
+        if (bargeStopIssued) return
+        bargeStopIssued = true
+        activeRun?.let { run -> scope.launch { run.stop() } }
+        if (!bargePlaybackStopIssued) engines.stopPlayback()
+        engines.stopTurn()
+    }
+
+    private fun stopPlaybackForBarge() {
+        if (bargePlaybackStopIssued) return
+        bargePlaybackStopIssued = true
+        activeRun?.let { run -> scope.launch { run.stop() } }
+        engines.stopPlayback()
+    }
+
+    private suspend fun speakTurn(promptText: String, interrupted: Boolean = false) {
+        val baseline = engines.replies.first().messageCount
+        engines.log("submit interrupted=$interrupted baseline=$baseline")
+        engines.submit(promptText, interrupted)
+
+        val started = withTimeoutOrNull(engines.turnStartTimeoutMillis) {
+            engines.replies.first { it.turnRunning || it.messageCount > baseline }
+        }
+        if (started == null) {
+            engines.log("turn:never-started")
+            controller.onTurnCompleteWithoutSpeech()
+            return
+        }
+        engines.log("turn:started")
+
+        // Wait for the turn to settle WITHOUT touching the speech socket. An
+        // open `/api/audio/speak-stream` session during generation starves the
+        // same single-process server that is producing the reply (observed on a
+        // released host: chat deltas froze the moment the socket opened and
+        // resumed the moment it closed), deadlocking the loop. Speech starts
+        // only after the reply finalizes; the streaming socket is then used as
+        // a one-shot transport so audio still begins on the first synthesized
+        // sentence rather than after whole-reply synthesis.
+        var lastViewLog = ""
+        suspend fun awaitNotRunning(): VoiceReplyView = engines.replies.first { view ->
+            val viewLog = "turn:view running=${view.turnRunning} " +
+                "streamIdx=${view.streamingIndex} finalIdx=${view.finalAssistantIndex} " +
+                "count=${view.messageCount}"
+            if (viewLog != lastViewLog) {
+                lastViewLog = viewLog
+                engines.log(viewLog)
+            }
+            !view.turnRunning
+        }
+
+        // The settle must be STABLE: transcript reconciliation can transiently
+        // replace the optimistic messages mid-generation, briefly reporting "no
+        // turn running" with the reply missing. A flap back to running within
+        // the confirmation window means the turn is still going.
+        var settled = awaitNotRunning()
+        while (true) {
+            val resumed = withTimeoutOrNull(engines.settleConfirmMillis) {
+                engines.replies.first { it.turnRunning }
+            } ?: break
+            engines.log("turn:resumed-after-flap")
+            settled = awaitNotRunning()
+        }
+        settled = engines.replies.first()
+        engines.log("turn:settled finalIdx=${settled.finalAssistantIndex} baseline=$baseline")
+        if (!controller.isActive || barged) return
+
+        // Only a reply created after this turn's baseline is speakable — a
+        // resumed session can resurface historical replies, and they must
+        // stay silent.
+        val replyText = settled.finalAssistantText
+            ?.takeIf { settled.finalAssistantIndex >= baseline }
+        if (replyText == null) {
+            controller.onTurnCompleteWithoutSpeech()
+            return
+        }
+        speakFinalizedReply(replyText)
+    }
+
+    /** Speak a finalized reply: one-shot streaming first, REST fallback. */
+    private suspend fun speakFinalizedReply(replyText: String) {
+        lastSpokenText = replyText
+        engines.log("stream:opening")
+        // The connect itself must be bounded: a host that accepts the route in
+        // capability probes can still leave the WS upgrade hanging, and an
+        // unbounded connect would freeze the loop in Thinking forever.
+        val socket = withTimeoutOrNull(engines.streamOpenTimeoutMillis) {
+            try {
+                engines.openStream()
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (_: Exception) {
+                null
+            }
+        }
+        if (socket == null) {
+            engines.log("stream:unavailable")
+            speakViaRest(replyText)
+            return
+        }
+        engines.log("stream:opened")
+        val sink = FirstAudioNotifyingSink(engines.sinkFactory()) {
+            controller.onSpeechStarted()
+        }
+        val run = SpeechStreamRun(socket, sink, engines.streamProgressTimeoutMillis, engines.log)
+        activeRun = run
+        val pump = scope.async(start = CoroutineStart.DEFAULT) { run.pump() }
+        engines.log("stream:feeding chars=${replyText.length}")
+        run.feedText(replyText)
+        engines.log("stream:fed")
+        run.finishText()
+        engines.log("stream:done-sent")
+        val outcome = pump.await()
+        activeRun = null
+        engines.log("stream:outcome=$outcome audio=${run.audioStarted}")
+        if (!controller.isActive || barged) return
+        when (outcome) {
+            SpeechStreamOutcome.Completed,
+            SpeechStreamOutcome.CompletedPartial,
+            -> if (run.audioStarted) {
+                controller.onSpeechFinished()
+            } else {
+                speakViaRest(replyText)
+            }
+            SpeechStreamOutcome.Fallback -> speakViaRest(replyText)
+            SpeechStreamOutcome.Stopped -> Unit
+        }
+    }
+
+    /** One-shot REST synthesis + playback of the finalized reply, or re-arm. */
+    private suspend fun speakViaRest(replyText: String?) {
+        // A barge already cut this turn; its reply must stay silent.
+        if (barged) return
+        val speechText = replyText?.let { sanitizeTextForSpeech(it) }.orEmpty()
+        engines.log("rest:speak chars=${speechText.length}")
+        if (speechText.isBlank()) {
+            controller.onTurnCompleteWithoutSpeech()
+            return
+        }
+        val audio = engines.restSpeak(speechText).getOrNull()
+        if (audio == null) {
+            engines.log("rest:synthesis-failed")
+            controller.onSpeechFailed()
+            return
+        }
+        if (!controller.isActive || barged) return
+        engines.log("rest:playing bytes=${audio.bytes.size}")
+        // Arm playback protection before handing the clip to MediaPlayer. The
+        // Android engine invokes onStarted immediately after player.start(),
+        // which leaves a race where the monitor can sample speaker bleed while
+        // controller is still Thinking and fire a false barge.
+        controller.onSpeechStarted()
+        // The barge monitor samples independently every 100 ms. Give it a
+        // chance to observe Speaking and enter BargeInDetector's playback
+        // grace window before MediaPlayer can emit the first samples.
+        kotlinx.coroutines.delay(BARGE_PLAYBACK_ARM_MILLIS)
+        engines.playAudio(
+            audio,
+            { controller.onSpeechStarted() },
+            { controller.onSpeechFinished() },
+            { controller.onSpeechFailed() },
+        )
+        engines.log("rest:playback-done")
+    }
+}
+
+/** Wraps a sink to arm playback protection before the first PCM write. */
+internal class FirstAudioNotifyingSink(
+    private val delegate: PcmSpeechSink,
+    private val onFirstAudio: () -> Unit,
+) : PcmSpeechSink {
+    private var notified = false
+
+    override fun start(sampleRateHz: Int, channels: Int): Boolean {
+        if (!notified) {
+            // The barge monitor runs concurrently with the stream pump. Arm
+            // playback protection before AudioTrack setup and before any PCM
+            // can be written, so its next sample enters playback grace rather
+            // than using the normal speech threshold.
+            notified = true
+            onFirstAudio()
+        }
+        return delegate.start(sampleRateHz, channels)
+    }
+
+    override suspend fun write(pcm: ByteArray) {
+        delegate.write(pcm)
+    }
+
+    override suspend fun finish() = delegate.finish()
+
+    override fun stop() = delegate.stop()
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationService.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationService.kt
@@ -1,0 +1,141 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.os.PowerManager
+import androidx.core.app.NotificationCompat
+
+/**
+ * Process-level bridge between the Compose-owned voice loop and the
+ * foreground service: the loop registers its stop callback and state label
+ * here; the service's notification Stop action and teardown paths call it.
+ * Nothing here persists across process death — recreation never silently
+ * re-arms the microphone (the user must explicitly restart voice).
+ */
+object VoiceServiceBridge {
+    @Volatile
+    var onStopRequested: (() -> Unit)? = null
+
+    @Volatile
+    var running: Boolean = false
+        internal set
+}
+
+/**
+ * Opt-in microphone foreground service that keeps an already-started voice
+ * conversation alive across screen-off. Started only from a visible activity
+ * after explicit user opt-in; non-exported; START_NOT_STICKY so a killed
+ * process never restarts capture on its own. The persistent notification shows
+ * the loop phase (never transcript text) and always carries a Stop action.
+ */
+class VoiceConversationService : Service() {
+    private var wakeLock: PowerManager.WakeLock? = null
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_STOP) {
+            VoiceServiceBridge.onStopRequested?.invoke()
+            stopSelfCleanly()
+            return START_NOT_STICKY
+        }
+        val stateLabel = intent?.getStringExtra(EXTRA_STATE)?.take(32) ?: "Listening"
+        ensureChannel()
+        val notification = buildNotification(stateLabel)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+        VoiceServiceBridge.running = true
+        acquireWakeLock()
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        stopSelfCleanly()
+        super.onDestroy()
+    }
+
+    private fun stopSelfCleanly() {
+        VoiceServiceBridge.running = false
+        wakeLock?.let { if (it.isHeld) it.release() }
+        wakeLock = null
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    private fun acquireWakeLock() {
+        if (wakeLock?.isHeld == true) return
+        val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+        wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKE_LOCK_TAG).apply {
+            setReferenceCounted(false)
+            // Bounded: the voice loop's own lifecycle stops the service long
+            // before this ceiling; the timeout is a leak backstop only.
+            acquire(WAKE_LOCK_TIMEOUT_MILLIS)
+        }
+    }
+
+    private fun ensureChannel() {
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                "Voice conversation",
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = "Shown while hands-free voice stays active with the screen off"
+            },
+        )
+    }
+
+    private fun buildNotification(stateLabel: String): Notification {
+        val stopIntent = PendingIntent.getService(
+            this,
+            0,
+            Intent(this, VoiceConversationService::class.java).setAction(ACTION_STOP),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_btn_speak_now)
+            .setContentTitle("Hermes voice conversation")
+            .setContentText(stateLabel)
+            .setOngoing(true)
+            .setSilent(true)
+            .addAction(0, "Stop", stopIntent)
+            .build()
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "voice_conversation"
+        private const val NOTIFICATION_ID = 0x5601
+        private const val ACTION_STOP = "com.unsupportedpastels.hermesandroid.voice.STOP"
+        private const val EXTRA_STATE = "state"
+        private const val WAKE_LOCK_TAG = "hermes:voice-conversation"
+        private const val WAKE_LOCK_TIMEOUT_MILLIS = 60L * 60L * 1000L
+
+        /** Start/refresh the service with the current loop phase label. */
+        fun start(context: Context, stateLabel: String) {
+            val intent = Intent(context, VoiceConversationService::class.java)
+                .putExtra(EXTRA_STATE, stateLabel)
+            context.startForegroundService(intent)
+        }
+
+        fun stop(context: Context) {
+            VoiceServiceBridge.running = false
+            context.stopService(Intent(context, VoiceConversationService::class.java))
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceEchoFilter.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceEchoFilter.kt
@@ -1,0 +1,80 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+/**
+ * Self-capture guard for the playback-phase full-duplex listener, ported from
+ * the server's `is_tts_echo` (tools/voice_mode.py, #75780): without acoustic
+ * echo cancellation, speaker bleed can trip the barge trigger and get
+ * transcribed nearly verbatim from the reply Hermes just spoke, creating a
+ * TTS → STT → TTS feedback loop. A barge transcript that closely matches the
+ * just-spoken text is discarded instead of submitted.
+ *
+ * Similarity is a character-level ratio (works across languages without
+ * word tokenization). The whole-string check catches short replies; because a
+ * barge capture is usually a short FRAGMENT of a longer reply, a window sized
+ * to the transcript also slides across the spoken text. One divergence from
+ * the Python original: the ratio here is LCS-based (difflib's matching-blocks
+ * metric has no JVM twin), which reads slightly *higher* for shuffled text —
+ * i.e. this port fails closed toward discarding echo.
+ */
+object VoiceEchoFilter {
+    /** Similarity at or above this = self-capture (server default). */
+    const val DEFAULT_SIMILARITY_THRESHOLD = 0.6
+
+    /** Below this normalized length the window fallback is skipped: a genuine
+     * short interjection ("yes") trivially matches some window of a long
+     * reply that also contains it. */
+    const val MIN_FRAGMENT_LENGTH_FOR_ECHO = 10
+
+    /** Bound the O(n·m) comparisons; barge fragments are short anyway. */
+    private const val MAX_COMPARE_CHARS = 1_500
+
+    fun isTtsEcho(
+        transcript: String,
+        spokenText: String?,
+        threshold: Double = DEFAULT_SIMILARITY_THRESHOLD,
+    ): Boolean = bestSimilarity(transcript, spokenText) >= threshold
+
+    /** Highest whole-or-windowed similarity in 0..1 (0.0 for empty inputs). */
+    fun bestSimilarity(transcript: String, spokenText: String?): Double {
+        if (transcript.isEmpty() || spokenText.isNullOrEmpty()) return 0.0
+        val a = normalize(transcript).take(MAX_COMPARE_CHARS)
+        val b = normalize(spokenText).take(MAX_COMPARE_CHARS)
+        if (a.isEmpty() || b.isEmpty()) return 0.0
+        var best = similarity(a, b)
+        if (a.length < MIN_FRAGMENT_LENGTH_FOR_ECHO || a.length >= b.length) return best
+        // Slide a transcript-sized window across the spoken text. The stride
+        // (vs. the original's step of 1) keeps this cheap; a true echo still
+        // overlaps some window almost completely.
+        val stride = (a.length / 8).coerceAtLeast(1)
+        var start = 0
+        while (start <= b.length - a.length) {
+            best = maxOf(best, similarity(a, b.substring(start, start + a.length)))
+            start += stride
+        }
+        return best
+    }
+
+    private fun normalize(text: String): String =
+        text.replace(Regex("\\s+"), " ").trim().lowercase()
+
+    /** 2·LCS/(|a|+|b|) — the character-level analogue of difflib's ratio. */
+    private fun similarity(a: String, b: String): Double {
+        if (a.isEmpty() || b.isEmpty()) return 0.0
+        var previous = IntArray(b.length + 1)
+        var current = IntArray(b.length + 1)
+        for (i in 1..a.length) {
+            for (j in 1..b.length) {
+                current[j] = if (a[i - 1] == b[j - 1]) {
+                    previous[j - 1] + 1
+                } else {
+                    maxOf(previous[j], current[j - 1])
+                }
+            }
+            val swap = previous
+            previous = current
+            current = swap
+        }
+        val lcs = previous[b.length]
+        return 2.0 * lcs / (a.length + b.length)
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicy.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicy.kt
@@ -3,6 +3,13 @@ package com.unsupportedpastels.hermesandroid.voice
 internal object VoiceInputPolicy {
     const val MAX_RESULT_CHARS = 4_096
 
+    fun canUseServerConversation(
+        capabilities: VoiceCapabilities,
+        config: VoiceServerConfig,
+    ): Boolean = capabilities.canDictateViaServer &&
+        capabilities.canReadAloud &&
+        config.sttEnabled
+
     fun scopeKey(
         serverOrigin: String?,
         profile: String,

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicy.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicy.kt
@@ -1,0 +1,27 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+internal object VoiceInputPolicy {
+    const val MAX_RESULT_CHARS = 4_096
+
+    fun scopeKey(
+        serverOrigin: String?,
+        profile: String,
+        durableSessionId: String,
+    ): String = listOf(serverOrigin.orEmpty(), profile, durableSessionId)
+        .joinToString("|") { value -> "${value.length}:$value" }
+
+    fun bestResult(results: List<String>?): String? = results
+        ?.asSequence()
+        ?.map { it.trim() }
+        ?.firstOrNull(String::isNotEmpty)
+        ?.take(MAX_RESULT_CHARS)
+
+    fun mergeDraft(current: String, recognized: String): String {
+        val bounded = recognized.trim().take(MAX_RESULT_CHARS)
+        return when {
+            bounded.isEmpty() -> current
+            current.isEmpty() || current.last().isWhitespace() -> current + bounded
+            else -> "$current $bounded"
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceServerConfig.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceServerConfig.kt
@@ -1,0 +1,144 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * How a completed voice utterance leaves the composer.
+ *
+ * Mirrors the server `voice.submit_mode` setting: `direct` submits immediately,
+ * `draft` leaves an editable transcript. HAM is beholden to the gateway, so this
+ * server-authoritative value — not a client-invented toggle — decides whether a
+ * dictated turn is staged or sent.
+ */
+enum class VoiceSubmitMode {
+    Direct,
+    Draft,
+    ;
+
+    companion object {
+        fun parse(raw: String?): VoiceSubmitMode =
+            when (raw?.trim()?.lowercase()) {
+                "draft" -> Draft
+                "direct" -> Direct
+                else -> Direct
+            }
+    }
+}
+
+/**
+ * Client-side mirror of the released `hermes serve` `voice` config section
+ * (config_defaults.py "voice"). Voice behaviour — recording caps, silence
+ * auto-stop, barge-in trip points, stop phrases, auto-TTS — is driven by these
+ * server values so HAM never forks the audited voice contract.
+ *
+ * Parsing is shape-safe: the server tolerates `voice` being a bool/str instead
+ * of a dict (voice.py), and any individual field may be missing or the wrong
+ * type. A malformed or absent value falls back to the corresponding [DEFAULT]
+ * field rather than throwing.
+ */
+data class VoiceServerConfig(
+    val submitMode: VoiceSubmitMode,
+    val maxRecordingSeconds: Int,
+    val autoTts: Boolean,
+    val silenceThreshold: Int,
+    val silenceDurationSeconds: Double,
+    val bargeInEnabled: Boolean,
+    val bargeInGraceSeconds: Double,
+    val bargeInThresholdMultiplier: Double,
+    val stopPhrases: List<String>,
+    /** Root `tts.provider` — which server TTS backend is configured. */
+    val ttsProvider: String? = null,
+    /** Root `tts.elevenlabs.voice_id` — current ElevenLabs voice selection. */
+    val elevenLabsVoiceId: String? = null,
+    /** Root `stt.provider` — which server STT backend is configured. */
+    val sttProvider: String? = null,
+    /** Root `stt.enabled`. */
+    val sttEnabled: Boolean = true,
+) {
+    companion object {
+        /** Matches the released server defaults verbatim (config_defaults.py). */
+        val DEFAULT = VoiceServerConfig(
+            submitMode = VoiceSubmitMode.Direct,
+            maxRecordingSeconds = 120,
+            autoTts = false,
+            silenceThreshold = 200,
+            silenceDurationSeconds = 3.0,
+            bargeInEnabled = true,
+            bargeInGraceSeconds = 0.5,
+            bargeInThresholdMultiplier = 3.0,
+            stopPhrases = listOf("stop"),
+        )
+
+        private const val MIN_RECORDING_SECONDS = 1
+        private const val MAX_RECORDING_SECONDS = 600
+        private const val MAX_SILENCE_THRESHOLD = 32_767
+        private const val MAX_STOP_PHRASES = 16
+        private const val MAX_STOP_PHRASE_CHARS = 64
+
+        /** Extract the `voice`/`tts`/`stt` sections from a full `/api/config` document. */
+        fun fromConfigRoot(root: JsonObject?): VoiceServerConfig {
+            val base = fromVoiceSection(root?.get("voice") as? JsonObject)
+            if (root == null) return base
+            val tts = root["tts"] as? JsonObject
+            val stt = root["stt"] as? JsonObject
+            val elevenLabs = tts?.get("elevenlabs") as? JsonObject
+            return base.copy(
+                ttsProvider = tts?.string("provider")?.trim()?.lowercase()?.take(64),
+                elevenLabsVoiceId = elevenLabs?.string("voice_id")?.trim()?.take(128),
+                sttProvider = stt?.string("provider")?.trim()?.lowercase()?.take(64),
+                sttEnabled = stt?.bool("enabled", true) ?: true,
+            )
+        }
+
+        fun fromVoiceSection(voice: JsonObject?): VoiceServerConfig {
+            if (voice == null) return DEFAULT
+            return VoiceServerConfig(
+                submitMode = VoiceSubmitMode.parse(
+                    voice.string("submit_mode") ?: DEFAULT.submitMode.name,
+                ),
+                maxRecordingSeconds = voice.int("max_recording_seconds", DEFAULT.maxRecordingSeconds)
+                    .coerceIn(MIN_RECORDING_SECONDS, MAX_RECORDING_SECONDS),
+                autoTts = voice.bool("auto_tts", DEFAULT.autoTts),
+                silenceThreshold = voice.int("silence_threshold", DEFAULT.silenceThreshold)
+                    .coerceIn(0, MAX_SILENCE_THRESHOLD),
+                silenceDurationSeconds = voice.double("silence_duration", DEFAULT.silenceDurationSeconds)
+                    .coerceIn(0.0, 60.0),
+                bargeInEnabled = voice.bool("barge_in", DEFAULT.bargeInEnabled),
+                bargeInGraceSeconds = voice.double("barge_in_grace_seconds", DEFAULT.bargeInGraceSeconds)
+                    .coerceIn(0.0, 10.0),
+                bargeInThresholdMultiplier = voice.double(
+                    "barge_in_threshold_multiplier",
+                    DEFAULT.bargeInThresholdMultiplier,
+                ).coerceIn(1.0, 20.0),
+                stopPhrases = parseStopPhrases(voice["stop_phrases"] as? JsonArray),
+            )
+        }
+
+        private fun parseStopPhrases(array: JsonArray?): List<String> {
+            if (array == null) return DEFAULT.stopPhrases
+            return array
+                .mapNotNull { it.jsonPrimitive.contentOrNull?.trim()?.lowercase() }
+                .filter { it.isNotEmpty() && it.length <= MAX_STOP_PHRASE_CHARS }
+                .distinct()
+                .take(MAX_STOP_PHRASES)
+        }
+
+        private fun JsonObject.string(key: String): String? =
+            (this[key] as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull
+
+        private fun JsonObject.bool(key: String, fallback: Boolean): Boolean =
+            (this[key] as? kotlinx.serialization.json.JsonPrimitive)?.booleanOrNull ?: fallback
+
+        private fun JsonObject.int(key: String, fallback: Int): Int =
+            (this[key] as? kotlinx.serialization.json.JsonPrimitive)?.intOrNull ?: fallback
+
+        private fun JsonObject.double(key: String, fallback: Double): Double =
+            (this[key] as? kotlinx.serialization.json.JsonPrimitive)?.doubleOrNull ?: fallback
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceSettingsSection.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceSettingsSection.kt
@@ -1,0 +1,238 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+/** One row from `GET /api/audio/elevenlabs/voices`. */
+data class ElevenLabsVoice(
+    val voiceId: String,
+    val name: String,
+    val label: String,
+)
+
+/**
+ * Everything the Voice settings section needs. Null when the connected server
+ * has no audio routes — the section is hidden entirely (fail-closed), never
+ * shown as an error. Writes are server-authoritative: the callbacks return
+ * false on failure and the UI rolls its optimistic state back.
+ */
+data class VoiceSettings(
+    val capabilities: VoiceCapabilities,
+    val config: VoiceServerConfig,
+    val setAutoTts: suspend (Boolean) -> Boolean,
+    val setElevenLabsVoice: suspend (String) -> Boolean,
+    val loadVoices: suspend () -> List<ElevenLabsVoice>,
+    /** Client-side opt-in: keep an active voice conversation running screen-off. */
+    val screenOffContinuationEnabled: Boolean = false,
+    val setScreenOffContinuation: (Boolean) -> Unit = {},
+)
+
+/**
+ * Voice section for the settings screen: truthful contract/provider status,
+ * the server-backed auto-speak toggle, and the ElevenLabs voice picker (shown
+ * only when the route exists, a key is configured, and ElevenLabs is the
+ * active TTS provider).
+ */
+@Composable
+fun VoiceSettingsSection(
+    settings: VoiceSettings,
+    modifier: Modifier = Modifier,
+) {
+    if (!settings.capabilities.audioRoutesPresent) return
+    val scope = rememberCoroutineScope()
+    val config = settings.config
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text("Voice", style = MaterialTheme.typography.titleMedium)
+
+        StatusRow(
+            label = "Server dictation",
+            value = when {
+                !config.sttEnabled -> "Disabled on server"
+                config.sttProvider != null -> "Via ${config.sttProvider}"
+                else -> "Available"
+            },
+        )
+        StatusRow(
+            label = "Read aloud",
+            value = config.ttsProvider?.let { "Via $it" } ?: "Available",
+        )
+
+        // Server-backed auto-speak (voice.auto_tts) with optimistic rollback.
+        var autoTts by remember(config.autoTts) { mutableStateOf(config.autoTts) }
+        var autoTtsError by remember { mutableStateOf(false) }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Speak replies automatically", style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    if (autoTtsError) "Couldn't update the server setting" else "New replies in the open session are read aloud",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (autoTtsError) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                )
+            }
+            Switch(
+                checked = autoTts,
+                onCheckedChange = { enabled ->
+                    autoTtsError = false
+                    autoTts = enabled
+                    scope.launch {
+                        if (!settings.setAutoTts(enabled)) {
+                            autoTts = !enabled
+                            autoTtsError = true
+                        }
+                    }
+                },
+                modifier = Modifier.semantics {
+                    contentDescription = "Speak replies automatically"
+                },
+            )
+        }
+
+        if (settings.capabilities.canPickElevenLabsVoice &&
+            config.ttsProvider == "elevenlabs"
+        ) {
+            ElevenLabsVoicePicker(settings)
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Continue voice with screen off", style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    "Keeps the microphone and a persistent notification active while a " +
+                        "voice conversation runs, using extra battery. Android's mic " +
+                        "indicator stays visible; Stop in the notification always ends it.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(
+                checked = settings.screenOffContinuationEnabled,
+                onCheckedChange = settings.setScreenOffContinuation,
+                modifier = Modifier.semantics {
+                    contentDescription = "Continue voice with screen off"
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatusRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            value,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@Composable
+private fun ElevenLabsVoicePicker(settings: VoiceSettings) {
+    val scope = rememberCoroutineScope()
+    var voices by remember { mutableStateOf<List<ElevenLabsVoice>>(emptyList()) }
+    var selectedId by remember(settings.config.elevenLabsVoiceId) {
+        mutableStateOf(settings.config.elevenLabsVoiceId)
+    }
+    var expanded by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        voices = settings.loadVoices()
+    }
+    if (voices.isEmpty()) return
+
+    val selectedLabel = voices.firstOrNull { it.voiceId == selectedId }
+        ?.let { it.label.ifBlank { it.name } }
+        ?: selectedId.orEmpty()
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+    ) {
+        OutlinedTextField(
+            value = selectedLabel,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("ElevenLabs voice") },
+            isError = error,
+            supportingText = if (error) {
+                { Text("Couldn't update the server setting") }
+            } else {
+                null
+            },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(androidx.compose.material3.MenuAnchorType.PrimaryNotEditable)
+                .fillMaxWidth()
+                .semantics { contentDescription = "ElevenLabs voice" },
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            voices.forEach { voice ->
+                DropdownMenuItem(
+                    text = { Text(voice.label.ifBlank { voice.name }) },
+                    onClick = {
+                        expanded = false
+                        error = false
+                        val previous = selectedId
+                        selectedId = voice.voiceId
+                        scope.launch {
+                            if (!settings.setElevenLabsVoice(voice.voiceId)) {
+                                selectedId = previous
+                                error = true
+                            }
+                        }
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceStopPhrases.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceStopPhrases.kt
@@ -1,0 +1,20 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+/** Characters stripped from both ends before matching — mirrors the server's
+ * `transcript.strip().lower().strip(".,!?;: \t\n\"'")` in tools/voice_mode.py. */
+private const val STRIP_CHARS = ".,!?;: \t\n\"'"
+
+/**
+ * True when [transcript] is EXACTLY a configured stop phrase. Ported verbatim
+ * from the server's `is_voice_stop_phrase`: deliberately strict — the whole
+ * utterance, lowercased with surrounding punctuation stripped, must equal a
+ * phrase, so "stop doing that and try again" still reaches the agent.
+ * [stopPhrases] comes from server `voice.stop_phrases` (already normalized
+ * lowercase by [VoiceServerConfig]); an empty list disables spoken stop.
+ */
+fun isVoiceStopPhrase(transcript: String, stopPhrases: List<String>): Boolean {
+    if (transcript.isEmpty() || stopPhrases.isEmpty()) return false
+    val cleaned = transcript.trim().lowercase().trim { it in STRIP_CHARS }
+    if (cleaned.isEmpty()) return false
+    return cleaned in stopPhrases
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceTranscription.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/VoiceTranscription.kt
@@ -1,0 +1,13 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+/**
+ * Result of `POST /api/audio/transcribe`. An empty [transcript] is a normal
+ * outcome — the server returns `ok:true` with `transcript:""` for silence — so
+ * callers treat it as "no speech" and re-listen rather than as an error.
+ */
+data class TranscriptionResult(
+    val transcript: String,
+    val provider: String?,
+) {
+    val isEmpty: Boolean get() = transcript.isBlank()
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/MainActivityVoicePreferenceTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/MainActivityVoicePreferenceTest.kt
@@ -1,0 +1,19 @@
+package com.unsupportedpastels.hermesandroid
+
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class MainActivityVoicePreferenceTest {
+    @Test
+    fun screenOffConsentKeyUsesNormalizedServerOrigin() {
+        val first = voiceScreenOffPreferenceKey(ServerOrigin.parse("HTTPS://one.example/"))
+        val equivalent = voiceScreenOffPreferenceKey(ServerOrigin.parse("https://one.example"))
+        val second = voiceScreenOffPreferenceKey(ServerOrigin.parse("https://two.example"))
+
+        assertEquals(first, equivalent)
+        assertNotEquals(first, second)
+        assertNotEquals(first, voiceScreenOffPreferenceKey(null))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/SessionListMergeTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/SessionListMergeTest.kt
@@ -1,0 +1,63 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import com.unsupportedpastels.hermesandroid.app.DurableSessionId
+import com.unsupportedpastels.hermesandroid.app.SessionSummary
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SessionListMergeTest {
+
+    private val draft = SessionSummary(
+        id = DurableSessionId("draft-1"),
+        title = "New chat",
+        isLocalDraft = true,
+    )
+    private val server1 = SessionSummary(DurableSessionId("stored-1"), "Alpha")
+    private val server2 = SessionSummary(DurableSessionId("stored-2"), "Beta")
+
+    @Test
+    fun `pending draft survives server session list refresh`() {
+        val merged = mergeServerSessionsPreservingDrafts(
+            serverSessions = listOf(server1, server2),
+            currentSessions = listOf(draft, server1),
+            pendingDrafts = setOf(draft.id),
+        )
+        assertEquals(listOf(draft, server1, server2), merged)
+    }
+
+    @Test
+    fun `draft already promoted to server list is not duplicated`() {
+        val promoted = draft.copy(isLocalDraft = false)
+        val merged = mergeServerSessionsPreservingDrafts(
+            serverSessions = listOf(promoted, server1),
+            currentSessions = listOf(draft, server1),
+            pendingDrafts = setOf(draft.id),
+        )
+        assertEquals(listOf(promoted, server1), merged)
+    }
+
+    @Test
+    fun `non-pending local rows are not resurrected`() {
+        val staleDraft = SessionSummary(
+            id = DurableSessionId("draft-9"),
+            title = "Old draft",
+            isLocalDraft = true,
+        )
+        val merged = mergeServerSessionsPreservingDrafts(
+            serverSessions = listOf(server1),
+            currentSessions = listOf(staleDraft, server1),
+            pendingDrafts = emptySet(),
+        )
+        assertEquals(listOf(server1), merged)
+    }
+
+    @Test
+    fun `no drafts passes server list through unchanged`() {
+        val merged = mergeServerSessionsPreservingDrafts(
+            serverSessions = listOf(server1, server2),
+            currentSessions = listOf(server1),
+            pendingDrafts = emptySet(),
+        )
+        assertEquals(listOf(server1, server2), merged)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/AudioRecordBargeRecorderTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/AudioRecordBargeRecorderTest.kt
@@ -1,0 +1,25 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class AudioRecordBargeRecorderTest {
+    @Test
+    fun pcmIsWrappedAsMonoPcm16Wave() {
+        val pcm = byteArrayOf(1, 2, 3, 4)
+        val wav = pcm16MonoToWav(pcm, sampleRateHz = 16_000)
+        val header = ByteBuffer.wrap(wav).order(ByteOrder.LITTLE_ENDIAN)
+
+        assertEquals(48, wav.size)
+        assertArrayEquals("RIFF".toByteArray(), wav.copyOfRange(0, 4))
+        assertEquals(36 + pcm.size, header.getInt(4))
+        assertArrayEquals("WAVE".toByteArray(), wav.copyOfRange(8, 12))
+        assertEquals(16_000, header.getInt(24))
+        assertEquals(32_000, header.getInt(28))
+        assertEquals(4, header.getInt(40))
+        assertArrayEquals(pcm, wav.copyOfRange(44, wav.size))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/AutoSpeakPolicyTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/AutoSpeakPolicyTest.kt
@@ -1,0 +1,80 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AutoSpeakPolicyTest {
+    private fun view(finalText: String?, finalIndex: Int, count: Int, running: Boolean = false) =
+        VoiceReplyView(
+            turnRunning = running,
+            streamingText = null,
+            streamingIndex = -1,
+            finalAssistantText = finalText,
+            finalAssistantIndex = finalIndex,
+            messageCount = count,
+        )
+
+    @Test
+    fun firstObservationTreatsEverythingAsHistory() {
+        val policy = AutoSpeakPolicy()
+        // Opening a session with an existing reply: never spoken.
+        assertNull(policy.nextToSpeak(view("old reply", 11, 12)))
+        // Unchanged state stays silent.
+        assertNull(policy.nextToSpeak(view("old reply", 11, 12)))
+    }
+
+    @Test
+    fun replyArrivingThroughIncrementalGrowthSpeaksOnce() {
+        val policy = AutoSpeakPolicy()
+        assertNull(policy.nextToSpeak(view("old reply", 1, 2)))
+        // A turn adds user + assistant rows incrementally.
+        assertNull(policy.nextToSpeak(view("old reply", 1, 4, running = true)))
+        val target = policy.nextToSpeak(view("new reply", 3, 4))
+        assertEquals(AutoSpeakTarget(3, "new reply"), target)
+        policy.markSpoken(3)
+        assertNull(policy.nextToSpeak(view("new reply", 3, 4)))
+    }
+
+    @Test
+    fun listShrinkRemarksEverythingAsHistory() {
+        // Regression: reopening a session resumes/replaces the transcript; a
+        // transient short list must not make the reloaded reply look new.
+        val policy = AutoSpeakPolicy()
+        assertNull(policy.nextToSpeak(view("old reply", 11, 12)))
+        // Resume transiently replaces the list with a short one…
+        assertNull(policy.nextToSpeak(view(null, -1, 1)))
+        // …then the full transcript returns. Still history.
+        assertNull(policy.nextToSpeak(view("old reply", 11, 12)))
+    }
+
+    @Test
+    fun bulkGrowthIsALoadNotNews() {
+        val policy = AutoSpeakPolicy()
+        assertNull(policy.nextToSpeak(view(null, -1, 0)))
+        // Twelve rows at once = transcript load, not a new reply.
+        assertNull(policy.nextToSpeak(view("old reply", 11, 12)))
+    }
+
+    @Test
+    fun backlogCollapsesToNewestReply() {
+        val policy = AutoSpeakPolicy()
+        assertNull(policy.nextToSpeak(view(null, -1, 0)))
+        assertNull(policy.nextToSpeak(view(null, -1, 2, running = true)))
+        // Two replies finalized while a clip was playing; only the newest speaks.
+        assertEquals(
+            AutoSpeakTarget(3, "second"),
+            policy.nextToSpeak(view("second", 3, 4)),
+        )
+        policy.markSpoken(3)
+        // The older reply (index 1) can never be spoken afterwards.
+        assertNull(policy.nextToSpeak(view("first", 1, 4)))
+    }
+
+    @Test
+    fun blankOrMissingReplyIsSkipped() {
+        val policy = AutoSpeakPolicy()
+        assertNull(policy.nextToSpeak(view(null, -1, 0)))
+        assertNull(policy.nextToSpeak(view(null, -1, 2)))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/BargeInDetectorTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/BargeInDetectorTest.kt
@@ -1,0 +1,135 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BargeInDetectorTest {
+    private fun detector(
+        trigger: Int = 600,
+        graceMillis: Long = 500L,
+        consecutive: Int = 3,
+    ) = BargeInDetector(trigger, graceMillis, consecutive)
+
+    @Test
+    fun sustainedSpeechAfterGraceTriggersOnce() {
+        val d = detector()
+        // Quiet calibration, then sustained speech-level amplitude.
+        assertFalse(d.onSample(0, 300))
+        assertFalse(d.onSample(200, 300))
+        assertFalse(d.onSample(600, 8_000))
+        assertFalse(d.onSample(700, 8_000))
+        assertTrue(d.onSample(800, 8_000))
+        // Never re-triggers.
+        assertFalse(d.onSample(900, 8_000))
+    }
+
+    @Test
+    fun ambientCalibrationRaisesTheTripPoint() {
+        val d = detector()
+        // Noisy room: ambient peaks at 1500 during calibration.
+        d.onSample(0, 1_500)
+        d.onSample(200, 1_500)
+        assertEquals(4_500, d.effectiveTriggerAmplitude)
+        // Ambient-level noise after grace never triggers.
+        for (i in 0..50) {
+            assertFalse(d.onSample(600L + i * 100, 1_500))
+        }
+        // Real speech above the raised trip point still does.
+        assertFalse(d.onSample(6_000, 9_000))
+        assertFalse(d.onSample(6_100, 9_000))
+        assertTrue(d.onSample(6_200, 9_000))
+    }
+
+    @Test
+    fun quietRoomStillRequiresSpeechLevelAmplitude() {
+        val d = detector()
+        d.onSample(0, 50)
+        // Configured trigger is 600, but 700 is not speech on the peak scale;
+        // the absolute minimum keeps breaths from cutting the reply.
+        for (i in 0..20) {
+            assertFalse(d.onSample(600L + i * 100, 700))
+        }
+        assertTrue(d.effectiveTriggerAmplitude >= 2_500)
+    }
+
+    @Test
+    fun shortSpikeDoesNotTrigger() {
+        val d = detector()
+        assertFalse(d.onSample(600, 20_000))
+        assertFalse(d.onSample(700, 100))
+        assertFalse(d.onSample(800, 20_000))
+        assertFalse(d.onSample(900, 100))
+    }
+
+    @Test
+    fun loudCalibrationBleedIsBoundedSoSpeechStaysDetectable() {
+        val d = detector()
+        d.onSample(0, 15_000) // loud TTS onset during grace
+        assertEquals(30_000, d.effectiveTriggerAmplitude)
+        assertFalse(d.onSample(600, 31_000))
+        assertFalse(d.onSample(700, 31_000))
+        assertTrue(d.onSample(800, 31_000))
+    }
+
+    @Test
+    fun silenceFloorTracksAmbientWithinBounds() {
+        val quiet = detector().apply { onSample(0, 100) }
+        assertEquals(400, quiet.silenceFloorAmplitude)
+        val noisy = detector().apply { onSample(0, 2_000) }
+        assertEquals(3_500, noisy.silenceFloorAmplitude)
+        val loud = detector().apply { onSample(0, 20_000) }
+        assertEquals(6_000, loud.silenceFloorAmplitude)
+    }
+
+    @Test
+    fun playbackBleedCalibratesTheTripPointAboveItself() {
+        val d = detector()
+        d.onSample(0, 100) // quiet ambient calibration
+        // Playback begins; its first 500ms are grace + bleed calibration.
+        assertFalse(d.onSample(1_000, 7_000, playbackActive = true))
+        assertFalse(d.onSample(1_200, 7_000, playbackActive = true))
+        assertFalse(d.onSample(1_400, 7_000, playbackActive = true))
+        // Trip point is now above the measured bleed (7000 × 1.5 = 10500).
+        assertEquals(10_500, d.playbackTriggerAmplitude)
+        // Continued bleed at the same level never triggers.
+        for (i in 0..30) {
+            assertFalse(d.onSample(1_600L + i * 100, 7_000, playbackActive = true))
+        }
+        // Real speech over playback (louder than bleed) still barges after ~500ms.
+        var triggered = false
+        for (i in 0..10) {
+            if (d.onSample(5_000L + i * 100, 11_500, playbackActive = true)) triggered = true
+        }
+        assertTrue(triggered)
+    }
+
+    @Test
+    fun quietPlaybackStillUsesTheMinimumClamp() {
+        val d = detector()
+        d.onSample(0, 100)
+        // Very quiet playback bleed (1000) — clamp floor stays at the minimum.
+        assertFalse(d.onSample(1_000, 1_000, playbackActive = true))
+        assertFalse(d.onSample(1_300, 1_000, playbackActive = true))
+        assertEquals(4_600, d.playbackTriggerAmplitude)
+        // Sub-minimum sound during playback never triggers.
+        for (i in 0..20) {
+            assertFalse(d.onSample(1_600L + i * 100, 4_000, playbackActive = true))
+        }
+    }
+
+    @Test
+    fun triggerAmplitudeScalesFloorByServerMultiplier() {
+        assertEquals(600, VoiceServerConfig.DEFAULT.bargeTriggerAmplitude())
+        // A zero silence floor still yields a positive trip point.
+        val zeroFloor = VoiceServerConfig.DEFAULT.copy(silenceThreshold = 0)
+        assertTrue(zeroFloor.bargeTriggerAmplitude() >= 1)
+        // The trip point never exceeds the 16-bit amplitude ceiling.
+        val loud = VoiceServerConfig.DEFAULT.copy(
+            silenceThreshold = 32_000,
+            bargeInThresholdMultiplier = 20.0,
+        )
+        assertEquals(32_767, loud.bargeTriggerAmplitude())
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DictationControllerTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DictationControllerTest.kt
@@ -1,0 +1,98 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DictationControllerTest {
+    @Test
+    fun happyPathIdleToRecordingToTranscribingToIdle() {
+        val controller = DictationController()
+        assertEquals(DictationState.Idle, controller.state.value)
+
+        assertTrue(controller.beginRecording())
+        assertTrue(controller.state.value is DictationState.Recording)
+
+        assertTrue(controller.finishRecording())
+        assertEquals(DictationState.Transcribing, controller.state.value)
+
+        controller.onTranscriptionComplete()
+        assertEquals(DictationState.Idle, controller.state.value)
+    }
+
+    @Test
+    fun cannotReachTranscribingWithoutRecording() {
+        val controller = DictationController()
+        assertFalse(controller.finishRecording())
+        assertEquals(DictationState.Idle, controller.state.value)
+    }
+
+    @Test
+    fun cannotBeginWhileAlreadyActive() {
+        val controller = DictationController()
+        assertTrue(controller.beginRecording())
+        assertFalse(controller.beginRecording())
+    }
+
+    @Test
+    fun levelAndElapsedOnlyApplyWhileRecording() {
+        val controller = DictationController()
+        controller.onAudioLevel(0.8f)
+        controller.onElapsed(500L)
+        assertEquals(DictationState.Idle, controller.state.value)
+
+        controller.beginRecording()
+        controller.onAudioLevel(2.0f) // coerced to 1.0
+        controller.onElapsed(500L)
+        val recording = controller.state.value as DictationState.Recording
+        assertEquals(1.0f, recording.level, 0.0f)
+        assertEquals(500L, recording.elapsedMillis)
+    }
+
+    @Test
+    fun elapsedReportsWhenRecordingCapReached() {
+        val controller = DictationController(maxRecordingMillis = 1_000L)
+        controller.beginRecording()
+        assertFalse(controller.onElapsed(999L))
+        assertTrue(controller.onElapsed(1_000L))
+    }
+
+    @Test
+    fun cancelFromAnyPhaseReturnsToIdle() {
+        val controller = DictationController()
+        controller.beginRecording()
+        controller.cancel()
+        assertEquals(DictationState.Idle, controller.state.value)
+
+        controller.beginRecording()
+        controller.finishRecording()
+        controller.cancel()
+        assertEquals(DictationState.Idle, controller.state.value)
+    }
+
+    @Test
+    fun failureLatchesUntilDismissedAndAllowsRetry() {
+        val controller = DictationController()
+        controller.beginRecording()
+        controller.fail(DictationFailure.PermissionDenied)
+        assertEquals(DictationState.Failed(DictationFailure.PermissionDenied), controller.state.value)
+
+        // A dismissed failure can immediately restart.
+        assertTrue(controller.beginRecording())
+    }
+
+    @Test
+    fun dismissErrorClearsToIdle() {
+        val controller = DictationController()
+        controller.fail(DictationFailure.TranscriptionFailed)
+        controller.dismissError()
+        assertEquals(DictationState.Idle, controller.state.value)
+    }
+
+    @Test
+    fun defaultRecordingCapMatchesServerDefault() {
+        // 120s from VoiceServerConfig.DEFAULT.maxRecordingSeconds.
+        assertEquals(120_000L, DictationController().maxRecordingMillis)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DictationMicButtonTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DictationMicButtonTest.kt
@@ -1,0 +1,99 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.Manifest
+import android.app.Application
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class DictationMicButtonTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private class FakeRecorder(
+        private val recording: DictationRecording? =
+            DictationRecording("data:audio/mp4;base64,AAAA", "audio/mp4"),
+    ) : DictationRecorder {
+        override val mimeType = "audio/mp4"
+        var cancelled = false
+        override fun start() = true
+        override fun sampleAmplitude() = 10_000 // stays above the silence threshold
+        override fun sampleLevel() = 0.3f
+        override fun stopAndEncode() = recording
+        override fun cancel() { cancelled = true }
+    }
+
+    private fun grantMic() {
+        shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .grantPermissions(Manifest.permission.RECORD_AUDIO)
+    }
+
+    @Test
+    fun idleShowsDictateAffordance() {
+        composeRule.setContent {
+            DictationMicButton(
+                dictation = ComposerDictation(VoiceServerConfig.DEFAULT) { _, _ ->
+                    Result.success(TranscriptionResult("hi", "whisper"))
+                },
+                enabled = true,
+                onAppendTranscript = {},
+                recorderFactory = { FakeRecorder() },
+            )
+        }
+        composeRule.onNodeWithContentDescription("Dictate message").assertIsDisplayed()
+    }
+
+    @Test
+    fun tapStartsRecording() {
+        grantMic()
+        composeRule.setContent {
+            DictationMicButton(
+                dictation = ComposerDictation(VoiceServerConfig.DEFAULT) { _, _ ->
+                    Result.success(TranscriptionResult("hi", "whisper"))
+                },
+                enabled = true,
+                onAppendTranscript = {},
+                recorderFactory = { FakeRecorder() },
+            )
+        }
+
+        // Quick tap (the accessible activation path) starts a hands-free recording.
+        composeRule.onNodeWithContentDescription("Dictate message").performClick()
+        composeRule.onNodeWithContentDescription("Stop dictation and insert").assertIsDisplayed()
+    }
+
+    @Test
+    fun tapTwiceTranscribesAndAppendsWithoutSending() = runTest {
+        grantMic()
+        var appended: String? = null
+        composeRule.setContent {
+            DictationMicButton(
+                dictation = ComposerDictation(VoiceServerConfig.DEFAULT) { _, _ ->
+                    Result.success(TranscriptionResult("hello world", "whisper"))
+                },
+                enabled = true,
+                onAppendTranscript = { appended = it },
+                recorderFactory = { FakeRecorder() },
+            )
+        }
+
+        composeRule.onNodeWithContentDescription("Dictate message").performClick()
+        composeRule.onNodeWithContentDescription("Stop dictation and insert").performClick()
+        composeRule.waitForIdle()
+        composeRule.waitUntil(timeoutMillis = 5_000) { appended != null }
+
+        assertEquals("hello world", appended)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DictationMicButtonTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DictationMicButtonTest.kt
@@ -7,8 +7,12 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -95,5 +99,31 @@ class DictationMicButtonTest {
         composeRule.waitUntil(timeoutMillis = 5_000) { appended != null }
 
         assertEquals("hello world", appended)
+    }
+
+    @Test
+    fun leavingCompositionCancelsRecorder() {
+        grantMic()
+        var visible by mutableStateOf(true)
+        var recorder: FakeRecorder? = null
+        composeRule.setContent {
+            if (visible) {
+                DictationMicButton(
+                    dictation = ComposerDictation(VoiceServerConfig.DEFAULT) { _, _ ->
+                        Result.success(TranscriptionResult("hello", "whisper"))
+                    },
+                    enabled = true,
+                    onAppendTranscript = {},
+                    recorderFactory = { FakeRecorder().also { recorder = it } },
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Dictate message").performClick()
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { visible = false }
+        composeRule.waitForIdle()
+
+        assertTrue(recorder?.cancelled == true)
     }
 }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DictationProviderPolicyTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DictationProviderPolicyTest.kt
@@ -1,0 +1,70 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DictationProviderPolicyTest {
+    @Test
+    fun automaticPrefersServerForProviderFidelity() {
+        val order = DictationProviderPolicy.orderedProviders(
+            DictationProviderPreference.Automatic,
+            serverAvailable = true,
+            onDeviceSupported = true,
+        )
+        assertEquals(listOf(DictationProvider.Server, DictationProvider.OnDevice), order)
+    }
+
+    @Test
+    fun onDevicePreferenceLeadsWithOnDeviceButKeepsServerFallback() {
+        val order = DictationProviderPolicy.orderedProviders(
+            DictationProviderPreference.OnDevice,
+            serverAvailable = true,
+            onDeviceSupported = true,
+        )
+        assertEquals(listOf(DictationProvider.OnDevice, DictationProvider.Server), order)
+    }
+
+    @Test
+    fun serverUnavailableFallsBackToOnDevice() {
+        assertEquals(
+            DictationProvider.OnDevice,
+            DictationProviderPolicy.preferred(
+                DictationProviderPreference.Automatic,
+                serverAvailable = false,
+                onDeviceSupported = true,
+            ),
+        )
+    }
+
+    @Test
+    fun onDeviceUnsupportedFallsBackToServer() {
+        assertEquals(
+            DictationProvider.Server,
+            DictationProviderPolicy.preferred(
+                DictationProviderPreference.OnDevice,
+                serverAvailable = true,
+                onDeviceSupported = false,
+            ),
+        )
+    }
+
+    @Test
+    fun neitherAvailableMeansDictationHidden() {
+        assertEquals(
+            emptyList<DictationProvider>(),
+            DictationProviderPolicy.orderedProviders(
+                DictationProviderPreference.Automatic,
+                serverAvailable = false,
+                onDeviceSupported = false,
+            ),
+        )
+        assertNull(
+            DictationProviderPolicy.preferred(
+                DictationProviderPreference.Automatic,
+                serverAvailable = false,
+                onDeviceSupported = false,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/ReadAloudTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/ReadAloudTest.kt
@@ -1,0 +1,78 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class ReadAloudTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private class FakeSpeechEngine : SpeechEngine {
+        override suspend fun play(
+            audio: SpeechAudio,
+            onStarted: () -> Unit,
+            onFinished: () -> Unit,
+            onError: () -> Unit,
+        ) {
+            onStarted() // start and keep playing
+        }
+
+        override fun stop() {}
+        override fun release() {}
+    }
+
+    private val readAloud = MessageReadAloud { _ ->
+        Result.success(SpeechAudio(byteArrayOf(1, 2, 3), "audio/mpeg"))
+    }
+
+    @Composable
+    private fun session(): ReadAloudSession =
+        rememberReadAloudSession(readAloud, sessionId = "sess", engineFactory = { FakeSpeechEngine() })!!
+
+    @Test
+    fun idleShowsReadAloudAffordance() {
+        composeRule.setContent {
+            MessageSpeakerButton(session(), "message:0", "Hello world", enabled = true)
+        }
+        composeRule.onNodeWithContentDescription("Read message aloud").assertIsDisplayed()
+    }
+
+    @Test
+    fun tapStartsPlaybackAndTogglesToStop() {
+        composeRule.setContent {
+            MessageSpeakerButton(session(), "message:0", "Hello world", enabled = true)
+        }
+        composeRule.onNodeWithContentDescription("Read message aloud").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Stop reading aloud").assertIsDisplayed()
+    }
+
+    @Test
+    fun onlyOneMessagePlaysAtATime() {
+        composeRule.setContent {
+            val shared = session()
+            Row {
+                MessageSpeakerButton(shared, "message:0", "First", enabled = true)
+                MessageSpeakerButton(shared, "message:1", "Second", enabled = true)
+            }
+        }
+        // Start message:0 (first of the two "Read message aloud" nodes).
+        composeRule.onAllNodesWithContentDescription("Read message aloud")[0].performClick()
+        composeRule.waitForIdle()
+        // message:0 now shows "Stop reading aloud"; message:1 remains, but disabled.
+        composeRule.onNodeWithContentDescription("Read message aloud").assertIsNotEnabled()
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/ReadAloudTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/ReadAloudTest.kt
@@ -9,6 +9,12 @@ import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,12 +27,15 @@ class ReadAloudTest {
     val composeRule = createComposeRule()
 
     private class FakeSpeechEngine : SpeechEngine {
+        var playCalls = 0
+
         override suspend fun play(
             audio: SpeechAudio,
             onStarted: () -> Unit,
             onFinished: () -> Unit,
             onError: () -> Unit,
         ) {
+            playCalls++
             onStarted() // start and keep playing
         }
 
@@ -74,5 +83,35 @@ class ReadAloudTest {
         composeRule.waitForIdle()
         // message:0 now shows "Stop reading aloud"; message:1 remains, but disabled.
         composeRule.onNodeWithContentDescription("Read message aloud").assertIsNotEnabled()
+    }
+
+    @Test
+    fun staleSynthesisForSameMessageCannotStartAfterRestart() = runTest {
+        val firstResult = CompletableDeferred<Result<SpeechAudio>>()
+        val secondResult = CompletableDeferred<Result<SpeechAudio>>()
+        var synthesisCalls = 0
+        val engine = FakeSpeechEngine()
+        val session = ReadAloudSession(
+            controller = SpeechPlaybackController(),
+            scope = this,
+            engine = engine,
+            synthesize = {
+                val result = if (synthesisCalls++ == 0) firstResult else secondResult
+                withContext(NonCancellable) { result.await() }
+            },
+        )
+
+        session.toggle("message:0", "Hello")
+        advanceUntilIdle()
+        session.stop()
+        session.toggle("message:0", "Hello")
+        advanceUntilIdle()
+
+        secondResult.complete(Result.success(SpeechAudio(byteArrayOf(2), "audio/mpeg")))
+        advanceUntilIdle()
+        firstResult.complete(Result.success(SpeechAudio(byteArrayOf(1), "audio/mpeg")))
+        advanceUntilIdle()
+
+        assertEquals(1, engine.playCalls)
     }
 }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SilenceAutoStopTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SilenceAutoStopTest.kt
@@ -1,0 +1,119 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SilenceAutoStopTest {
+    private fun autoStop(
+        configured: Int = 200,
+        silenceMillis: Long = 1_000L,
+        maxMillis: Long = 120_000L,
+        noSpeechMillis: Long = 8_000L,
+    ) = SilenceAutoStop(
+        configuredThreshold = configured,
+        silenceMillis = silenceMillis,
+        maxMillis = maxMillis,
+        noSpeechTimeoutMillis = noSpeechMillis,
+    )
+
+    /** Drive with 100ms samples; returns the first non-Continue decision and its time. */
+    private fun run(
+        detector: SilenceAutoStop,
+        samples: List<Int>,
+    ): Pair<SilenceAutoStopDecision, Long>? {
+        samples.forEachIndexed { index, amplitude ->
+            val elapsed = index * 100L
+            val decision = detector.feed(elapsed, amplitude)
+            if (decision != SilenceAutoStopDecision.Continue) return decision to elapsed
+        }
+        return null
+    }
+
+    @Test
+    fun speechThenSilenceStopsDespiteNoisyAmbientFloor() {
+        // Ambient peaks ~1500 — far above the configured 200 — then speech at
+        // ~15000, then back to ambient. The old raw comparison never stopped.
+        val ambient = List(6) { 1_500 }
+        val speech = List(10) { 15_000 }
+        val quiet = List(15) { 1_500 }
+        val result = run(autoStop(), ambient + speech + quiet)
+        assertEquals(SilenceAutoStopDecision.Stop, result?.first)
+    }
+
+    @Test
+    fun quietRoomSpeechEndsAfterConfiguredSilence() {
+        val ambient = List(6) { 100 }
+        val speech = List(5) { 12_000 }
+        val quiet = List(12) { 100 }
+        val result = run(autoStop(), ambient + speech + quiet)
+        assertEquals(SilenceAutoStopDecision.Stop, result?.first)
+        // Silence run: 1s after the speech ends (plus one sample of slack).
+        val stoppedAt = result!!.second
+        val speechEndedAt = (6 + 5) * 100L
+        assert(stoppedAt - speechEndedAt in 900..1_200) { "stopped at $stoppedAt" }
+    }
+
+    @Test
+    fun pureAmbientNoiseResolvesEmptyWithoutUpload() {
+        val result = run(autoStop(noSpeechMillis = 2_000L), List(40) { 1_500 })
+        assertEquals(SilenceAutoStopDecision.StopEmpty, result?.first)
+        assertEquals(2_000L, result?.second)
+    }
+
+    @Test
+    fun intraSentencePausesShorterThanSilenceWindowDoNotStop() {
+        val ambient = List(6) { 800 }
+        val phrase1 = List(8) { 14_000 }
+        val shortPause = List(5) { 800 } // 500ms < 1s window
+        val phrase2 = List(8) { 14_000 }
+        val quiet = List(15) { 800 }
+        val result = run(autoStop(), ambient + phrase1 + shortPause + phrase2 + quiet)
+        assertEquals(SilenceAutoStopDecision.Stop, result?.first)
+        // Must stop after phrase 2, not inside the short pause.
+        val stopAt = result!!.second
+        assert(stopAt >= (6 + 8 + 5 + 8) * 100L) { "stopped too early at $stopAt" }
+    }
+
+    @Test
+    fun roomToneStraddlingConfiguredFloorStillStops() {
+        // Regression: real device trace (SM-F971U1). Warm-up calibration reads
+        // ambient=86 so the floor stays at the configured 200, while true room
+        // tone bounces 190–340 with occasional ~2–3k blips. A fixed-floor reset
+        // rule never accumulated the 3s of silence.
+        val detector = autoStop(configured = 200, silenceMillis = 3_000L)
+        val calibration = List(6) { 86 }
+        val speech = List(15) { 11_765 }
+        val roomTone = listOf(
+            331, 309, 197, 261, 232, 314, 190, 340, 1_909, 239,
+            232, 197, 261, 340, 3_128, 195, 261, 232, 314, 190,
+            197, 261, 232, 314, 190, 340, 239, 232, 197, 261,
+            340, 195, 261, 232, 314, 190, 197, 261, 232, 314,
+            190, 340, 239, 232, 197, 261, 340, 195, 261, 232,
+        )
+        val result = run(detector, calibration + speech + roomTone)
+        assertEquals(SilenceAutoStopDecision.Stop, result?.first)
+        // Stops within roughly the configured window plus blip drain, not never.
+        assert(result!!.second <= (6 + 15 + 40) * 100L) { "stopped at ${result.second}" }
+    }
+
+    @Test
+    fun recordingCapAlwaysStops() {
+        val result = run(
+            autoStop(maxMillis = 1_000L),
+            List(40) { 20_000 }, // continuous speech
+        )
+        assertEquals(SilenceAutoStopDecision.Stop, result?.first)
+        assertEquals(1_000L, result?.second)
+    }
+
+    @Test
+    fun loudRoomFloorIsBoundedSoSpeechStaysDetectable() {
+        // Calibration sees very loud ambient (e.g. music at 10k). The floor is
+        // clamped, so 20k speech still registers and its end still stops.
+        val ambient = List(6) { 10_000 }
+        val speech = List(8) { 25_000 }
+        val quiet = List(15) { 3_000 }
+        val result = run(autoStop(), ambient + speech + quiet)
+        assertEquals(SilenceAutoStopDecision.Stop, result?.first)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SpeechDeltaFeederTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SpeechDeltaFeederTest.kt
@@ -1,0 +1,52 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SpeechDeltaFeederTest {
+    @Test
+    fun emitsAppendOnlyDeltasPreservingWhitespace() {
+        val feeder = SpeechDeltaFeeder()
+        assertEquals("Hello", feeder.nextDelta("Hello"))
+        assertEquals(" world.\n", feeder.nextDelta("Hello world.\n"))
+        assertNull(feeder.nextDelta("Hello world.\n"))
+    }
+
+    @Test
+    fun replacementPausesFeedingUntilFinal() {
+        val feeder = SpeechDeltaFeeder()
+        assertEquals("Hello wor", feeder.nextDelta("Hello wor"))
+        // The message was rewritten — not an extension of what was spoken.
+        assertNull(feeder.nextDelta("Goodbye"))
+        // Later extensions stay paused too; no duplicated speech.
+        assertNull(feeder.nextDelta("Goodbye friend"))
+    }
+
+    @Test
+    fun finalReconciliationFeedsCleanSuffix() {
+        val feeder = SpeechDeltaFeeder()
+        feeder.nextDelta("Hello")
+        assertEquals(" world.", feeder.reconcileFinal("Hello world."))
+    }
+
+    @Test
+    fun unreconcilableFinalFeedsNothing() {
+        val feeder = SpeechDeltaFeeder()
+        feeder.nextDelta("Hello world")
+        assertNull(feeder.reconcileFinal("Completely different reply."))
+    }
+
+    @Test
+    fun finalIdenticalToFedTextFeedsNothing() {
+        val feeder = SpeechDeltaFeeder()
+        feeder.nextDelta("Hello world.")
+        assertNull(feeder.reconcileFinal("Hello world."))
+    }
+
+    @Test
+    fun emptyStreamThenFinalFeedsWholeReply() {
+        val feeder = SpeechDeltaFeeder()
+        assertEquals("Full reply at once.", feeder.reconcileFinal("Full reply at once."))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SpeechPlaybackControllerTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SpeechPlaybackControllerTest.kt
@@ -1,0 +1,77 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpeechPlaybackControllerTest {
+    @Test
+    fun startsIdle() {
+        val controller = SpeechPlaybackController()
+        assertEquals(SpeechPlaybackState.Idle, controller.state.value)
+        assertNull(controller.activeKey)
+    }
+
+    @Test
+    fun prepareThenPlayThenComplete() {
+        val controller = SpeechPlaybackController()
+        controller.beginPreparing("msg-1")
+        assertEquals(SpeechPlaybackState.Preparing("msg-1"), controller.state.value)
+        assertTrue(controller.isActiveFor("msg-1"))
+
+        assertTrue(controller.markPlaying("msg-1"))
+        assertTrue(controller.isPlaying("msg-1"))
+
+        controller.complete()
+        assertEquals(SpeechPlaybackState.Idle, controller.state.value)
+    }
+
+    @Test
+    fun onlyOneTargetPlaysAtATime() {
+        val controller = SpeechPlaybackController()
+        controller.beginPreparing("msg-1")
+        controller.markPlaying("msg-1")
+
+        // A new target supersedes the old one.
+        controller.beginPreparing("msg-2")
+        assertEquals(SpeechPlaybackState.Preparing("msg-2"), controller.state.value)
+        assertFalse(controller.isPlaying("msg-1"))
+
+        // A late "playing" from the superseded target is ignored.
+        assertFalse(controller.markPlaying("msg-1"))
+        assertTrue(controller.markPlaying("msg-2"))
+    }
+
+    @Test
+    fun stopReturnsToIdle() {
+        val controller = SpeechPlaybackController()
+        controller.beginPreparing("msg-1")
+        controller.markPlaying("msg-1")
+        controller.stop()
+        assertEquals(SpeechPlaybackState.Idle, controller.state.value)
+    }
+
+    @Test
+    fun staleFailureDoesNotClobberActiveTarget() {
+        val controller = SpeechPlaybackController()
+        controller.beginPreparing("msg-2")
+        controller.fail("msg-1", SpeechPlaybackFailure.Playback)
+        // The active target survives a stale failure.
+        assertEquals(SpeechPlaybackState.Preparing("msg-2"), controller.state.value)
+    }
+
+    @Test
+    fun failureLatchesAndDismisses() {
+        val controller = SpeechPlaybackController()
+        controller.beginPreparing("msg-1")
+        controller.fail("msg-1", SpeechPlaybackFailure.Synthesis)
+        assertEquals(
+            SpeechPlaybackState.Failed("msg-1", SpeechPlaybackFailure.Synthesis),
+            controller.state.value,
+        )
+        controller.dismissError()
+        assertEquals(SpeechPlaybackState.Idle, controller.state.value)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SpeechStreamRunTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SpeechStreamRunTest.kt
@@ -1,0 +1,266 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private class FakeSpeechSocket : SpeechStreamSocket {
+    val sent = mutableListOf<String>()
+    var closed = false
+    private val inbound = Channel<SpeechSocketFrame?>(Channel.UNLIMITED)
+
+    fun serverSends(frame: SpeechSocketFrame) {
+        inbound.trySend(frame)
+    }
+
+    fun serverCloses() {
+        inbound.trySend(null)
+    }
+
+    override suspend fun sendText(text: String) {
+        if (closed) throw IllegalStateException("closed")
+        sent += text
+    }
+
+    override suspend fun receiveFrame(): SpeechSocketFrame? = inbound.receive()
+
+    override suspend fun close() {
+        closed = true
+        inbound.trySend(null)
+    }
+}
+
+private class RecordingSink : PcmSpeechSink {
+    var startedRate: Int? = null
+    var startResult = true
+    var finished = false
+    var stopped = false
+    val written = mutableListOf<ByteArray>()
+
+    override fun start(sampleRateHz: Int, channels: Int): Boolean {
+        startedRate = sampleRateHz
+        return startResult
+    }
+
+    override suspend fun write(pcm: ByteArray) {
+        written += pcm
+    }
+
+    override suspend fun finish() {
+        finished = true
+    }
+
+    override fun stop() {
+        stopped = true
+    }
+}
+
+private fun startFrame(rate: Int = 24_000, channels: Int = 1) =
+    SpeechSocketFrame.Text("""{"type":"start","sample_rate":$rate,"channels":$channels}""")
+
+class SpeechStreamRunTest {
+    @Test
+    fun playbackNotificationIsArmedWhenSinkStartsBeforePcmWrite() {
+        var notified = false
+        val sink = FirstAudioNotifyingSink(RecordingSink()) { notified = true }
+
+        assertFalse(notified)
+        assertTrue(sink.start(24_000, 1))
+        assertTrue(notified)
+
+        // The callback is one-shot; writing PCM must not change its ordering or
+        // invoke it a second time.
+        kotlinx.coroutines.test.runTest {
+            sink.write(byteArrayOf(1, 2))
+        }
+        assertTrue(notified)
+    }
+
+    @Test
+    fun completesAfterStartPcmEnd() = runTest {
+        val socket = FakeSpeechSocket()
+        val sink = RecordingSink()
+        val run = SpeechStreamRun(socket, sink)
+
+        socket.serverSends(startFrame())
+        socket.serverSends(SpeechSocketFrame.Binary(byteArrayOf(1, 2, 3, 4)))
+        socket.serverSends(SpeechSocketFrame.Text("""{"type":"end"}"""))
+
+        assertEquals(SpeechStreamOutcome.Completed, run.pump())
+        assertEquals(24_000, sink.startedRate)
+        assertEquals(1, sink.written.size)
+        assertTrue(sink.finished)
+        assertTrue(socket.closed)
+    }
+
+    @Test
+    fun feedsTextAndDoneFrames() = runTest {
+        val socket = FakeSpeechSocket()
+        val run = SpeechStreamRun(socket, RecordingSink())
+
+        run.feedText("Hello ")
+        run.feedText("world.")
+        run.finishText()
+
+        assertEquals(
+            listOf("""{"text":"Hello "}""", """{"text":"world."}""", """{"done":true}"""),
+            socket.sent,
+        )
+    }
+
+    @Test
+    fun fallbackFrameBeforeAudioIsFallback() = runTest {
+        val socket = FakeSpeechSocket()
+        val sink = RecordingSink()
+        val run = SpeechStreamRun(socket, sink)
+
+        socket.serverSends(SpeechSocketFrame.Text("""{"type":"fallback"}"""))
+        assertEquals(SpeechStreamOutcome.Fallback, run.pump())
+        assertFalse(sink.finished)
+    }
+
+    @Test
+    fun dropBeforeAudioIsFallback() = runTest {
+        val socket = FakeSpeechSocket()
+        val run = SpeechStreamRun(socket, RecordingSink())
+
+        socket.serverCloses()
+        assertEquals(SpeechStreamOutcome.Fallback, run.pump())
+    }
+
+    @Test
+    fun dropAfterAudioIsCompletedPartialNeverReplay() = runTest {
+        val socket = FakeSpeechSocket()
+        val sink = RecordingSink()
+        val run = SpeechStreamRun(socket, sink)
+
+        socket.serverSends(startFrame())
+        socket.serverSends(SpeechSocketFrame.Binary(byteArrayOf(1, 2)))
+        socket.serverCloses()
+
+        assertEquals(SpeechStreamOutcome.CompletedPartial, run.pump())
+        assertTrue(sink.stopped)
+    }
+
+    @Test
+    fun stopResolvesAsStoppedAndSendsStopFrame() = runTest {
+        val socket = FakeSpeechSocket()
+        val sink = RecordingSink()
+        val run = SpeechStreamRun(socket, sink)
+
+        val outcome = launch { assertEquals(SpeechStreamOutcome.Stopped, run.pump()) }
+        socket.serverSends(startFrame())
+        run.stop()
+        outcome.join()
+        assertTrue(sink.stopped)
+        assertTrue(socket.sent.contains("""{"stop":true}"""))
+    }
+
+    @Test
+    fun rejectsStereoStart() = runTest {
+        val socket = FakeSpeechSocket()
+        val run = SpeechStreamRun(socket, RecordingSink())
+        socket.serverSends(startFrame(channels = 2))
+        assertEquals(SpeechStreamOutcome.Fallback, run.pump())
+    }
+
+    @Test
+    fun rejectsAbsurdSampleRate() = runTest {
+        val socket = FakeSpeechSocket()
+        val run = SpeechStreamRun(socket, RecordingSink())
+        socket.serverSends(startFrame(rate = 1_000_000))
+        assertEquals(SpeechStreamOutcome.Fallback, run.pump())
+    }
+
+    @Test
+    fun unplayableSinkFallsBackBeforeAudio() = runTest {
+        val socket = FakeSpeechSocket()
+        val sink = RecordingSink().apply { startResult = false }
+        val run = SpeechStreamRun(socket, sink)
+        socket.serverSends(startFrame())
+        assertEquals(SpeechStreamOutcome.Fallback, run.pump())
+    }
+
+    @Test
+    fun oversizedPcmFrameAbortsWithoutReplayAfterAudio() = runTest {
+        val socket = FakeSpeechSocket()
+        val run = SpeechStreamRun(socket, RecordingSink())
+        socket.serverSends(startFrame())
+        socket.serverSends(SpeechSocketFrame.Binary(byteArrayOf(5, 6)))
+        socket.serverSends(
+            SpeechSocketFrame.Binary(ByteArray(SpeechStreamProtocol.MAX_PCM_FRAME_BYTES + 1)),
+        )
+        assertEquals(SpeechStreamOutcome.CompletedPartial, run.pump())
+    }
+
+    @Test
+    fun pcmBeforeStartIsProtocolViolation() = runTest {
+        val socket = FakeSpeechSocket()
+        val run = SpeechStreamRun(socket, RecordingSink())
+        socket.serverSends(SpeechSocketFrame.Binary(byteArrayOf(1, 2)))
+        assertEquals(SpeechStreamOutcome.Fallback, run.pump())
+    }
+
+    @Test
+    fun endBeforeAnyAudioFallsBack() = runTest {
+        val socket = FakeSpeechSocket()
+        val run = SpeechStreamRun(socket, RecordingSink())
+        socket.serverSends(SpeechSocketFrame.Text("""{"type":"end"}"""))
+        assertEquals(SpeechStreamOutcome.Fallback, run.pump())
+    }
+
+    @Test
+    fun unknownFramesAreIgnored() = runTest {
+        val socket = FakeSpeechSocket()
+        val sink = RecordingSink()
+        val run = SpeechStreamRun(socket, sink)
+        socket.serverSends(SpeechSocketFrame.Text("""{"type":"telemetry","x":1}"""))
+        socket.serverSends(startFrame())
+        socket.serverSends(SpeechSocketFrame.Binary(byteArrayOf(9, 9)))
+        socket.serverSends(SpeechSocketFrame.Text("""{"type":"end"}"""))
+        assertEquals(SpeechStreamOutcome.Completed, run.pump())
+    }
+
+    @Test
+    fun progressTimeoutBeforeAudioFallsBack() = runTest {
+        val socket = FakeSpeechSocket()
+        val run = SpeechStreamRun(socket, RecordingSink(), progressTimeoutMillis = 1_000L)
+        // Nothing ever arrives; virtual time advances past the watchdog.
+        assertEquals(SpeechStreamOutcome.Fallback, run.pump())
+    }
+
+    @Test
+    fun socketTeardownDuringSendDoesNotCancelTheCaller() = runTest {
+        // Regression: the server answered `fallback` and the pump closed the
+        // socket while feedText was still suspended in send — the resulting
+        // CancellationException belongs to the socket and must not propagate
+        // into (and silently kill) the calling voice loop.
+        val socket = object : SpeechStreamSocket {
+            override suspend fun sendText(text: String) {
+                throw kotlinx.coroutines.CancellationException("socket session cancelled")
+            }
+
+            override suspend fun receiveFrame(): SpeechSocketFrame? = null
+
+            override suspend fun close() = Unit
+        }
+        val run = SpeechStreamRun(socket, RecordingSink())
+        run.feedText("hello")
+        run.finishText()
+        // Reaching here without CancellationException is the assertion.
+        assertTrue(true)
+    }
+
+    @Test
+    fun feedAfterStopIsIgnored() = runTest {
+        val socket = FakeSpeechSocket()
+        val run = SpeechStreamRun(socket, RecordingSink())
+        run.stop()
+        run.feedText("late text")
+        assertEquals(listOf("""{"stop":true}"""), socket.sent)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SpeechSynthesisTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SpeechSynthesisTest.kt
@@ -1,0 +1,85 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import com.unsupportedpastels.hermesandroid.connection.HermesConnectionException
+import com.unsupportedpastels.hermesandroid.connection.HttpHermesConnectionClient
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpeechSynthesisTest {
+    @Test
+    fun decodeRoundTripsEncode() {
+        val bytes = byteArrayOf(1, 2, 3, 4, 5)
+        val url = encodeAudioDataUrl(bytes, "audio/mpeg")
+        val decoded = decodeAudioDataUrl(url)!!
+        assertArrayEquals(bytes, decoded.bytes)
+        assertEquals("audio/mpeg", decoded.mimeType)
+    }
+
+    @Test
+    fun decodeRejectsNonDataAndNonBase64Urls() {
+        assertNull(decodeAudioDataUrl("https://example.com/a.mp3"))
+        assertNull(decodeAudioDataUrl("data:audio/mpeg,notbase64"))
+        assertNull(decodeAudioDataUrl("data:audio/mpeg;base64,%%%invalid%%%"))
+    }
+
+    @Test
+    fun decodeDefaultsMimeWhenHeaderBlank() {
+        val decoded = decodeAudioDataUrl("data:;base64,AAAA")!!
+        assertEquals("audio/mpeg", decoded.mimeType)
+    }
+
+    @Test
+    fun speakPostsTextAndDecodesAudio() = runTest {
+        val payload = encodeAudioDataUrl(byteArrayOf(9, 8, 7), "audio/wav")
+        val engine = MockEngine { request ->
+            assertEquals("/api/audio/speak", request.url.encodedPath)
+            assertEquals("work", request.url.parameters["profile"])
+            assertTrue((request.body as TextContent).text.contains("\"text\""))
+            respond(
+                """{"ok": true, "data_url": "$payload", "mime_type": "audio/wav", "provider": "eleven"}""",
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+
+        val audio = HttpHermesConnectionClient(HttpClient(engine) { install(HttpTimeout) })
+            .speakText(
+                ServerOrigin.parse("https://hermes.example"),
+                accessToken = "t",
+                profile = "work",
+                text = "Hello there",
+            )
+
+        assertArrayEquals(byteArrayOf(9, 8, 7), audio.bytes)
+        assertEquals("audio/wav", audio.mimeType)
+    }
+
+    @Test
+    fun speakSurfacesHttpErrors() = runTest {
+        val engine = MockEngine { respond("no", status = HttpStatusCode.ServiceUnavailable) }
+        try {
+            HttpHermesConnectionClient(HttpClient(engine) { install(HttpTimeout) })
+                .speakText(
+                    ServerOrigin.parse("https://hermes.example"),
+                    accessToken = "t",
+                    profile = "default",
+                    text = "hi",
+                )
+            throw AssertionError("Expected HermesConnectionException")
+        } catch (expected: HermesConnectionException) {
+            assertTrue(expected.message!!.contains("503"))
+        }
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SpeechTextTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/SpeechTextTest.kt
@@ -1,0 +1,194 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Mirrors apps/desktop/src/lib/speech-text.test.ts one-for-one. */
+class SpeechTextTest {
+    @Test
+    fun summarizesFencedCodeBlocks() {
+        assertEquals(
+            "Here is code: code block omitted Done.",
+            sanitizeTextForSpeech("Here is code:\n```ts\nconst x = 1\n```\nDone."),
+        )
+    }
+
+    @Test
+    fun keepsProseAndInlineCodeReadable() {
+        assertEquals(
+            "Use git status after the change.",
+            sanitizeTextForSpeech("Use `git status` after the change."),
+        )
+    }
+
+    @Test
+    fun skipsTableDataPreservingSurroundingText() {
+        val text = """
+            Here is the quick takeaway: the totals remain unchanged.
+
+            | Item | Value | Notes |
+            | --- | ---: | --- |
+            | Example A | 10 | first row |
+            | Example B | 20 | second row |
+
+            Full detail stays visible on screen.
+        """.trimIndent()
+        assertEquals(
+            "Here is the quick takeaway: the totals remain unchanged. Full detail stays visible on screen.",
+            sanitizeTextForSpeech(text),
+        )
+    }
+
+    @Test
+    fun doesNotStripProseContainingAPipe() {
+        val text = "Use the summary first | keep the table on screen when it matters."
+        assertEquals(text, sanitizeTextForSpeech(text))
+    }
+
+    @Test
+    fun doesNotDuplicatePunctuationAcrossParagraphBreaks() {
+        assertEquals(
+            "First sentence. Second sentence.",
+            sanitizeTextForSpeech("First sentence.\n\nSecond sentence."),
+        )
+    }
+
+    @Test
+    fun doesNotDuplicatePunctuationAfterEmphasisQuoteOrParen() {
+        assertEquals(
+            "First sentence. Second sentence.",
+            sanitizeTextForSpeech("**First sentence.**\n\nSecond sentence."),
+        )
+        assertEquals(
+            "“First sentence.” Second sentence.",
+            sanitizeTextForSpeech("“First sentence.”\n\nSecond sentence."),
+        )
+        assertEquals(
+            "(First sentence.) Second sentence.",
+            sanitizeTextForSpeech("(First sentence.)\n\nSecond sentence."),
+        )
+    }
+
+    @Test
+    fun skipsTablesWithoutLeadingAndTrailingPipes() {
+        val text = """
+            Main takeaway: total is unchanged.
+
+            Item | Value
+            --- | ---:
+            Example A | 10
+            Example B | 20
+
+            Done.
+        """.trimIndent()
+        assertEquals("Main takeaway: total is unchanged. Done.", sanitizeTextForSpeech(text))
+    }
+
+    @Test
+    fun skipsTablesNestedInsideBlockquotes() {
+        val text = """
+            Before the table.
+
+            > | Item | Value |
+            > | --- | ---: |
+            > | Example A | 10 |
+            > | Example B | 20 |
+
+            After the table.
+        """.trimIndent()
+        assertEquals("Before the table. After the table.", sanitizeTextForSpeech(text))
+    }
+
+    @Test
+    fun allowsMarkerPaddingPlusThreeSpacesInBlockquotedTables() {
+        val text = """
+            Before the table.
+
+            >    | Item | Value |
+            >    | --- | ---: |
+            >    | Example A | 10 |
+
+            After the table.
+        """.trimIndent()
+        assertEquals("Before the table. After the table.", sanitizeTextForSpeech(text))
+    }
+
+    @Test
+    fun skipsExplicitSingleColumnTables() {
+        val text = """
+            Before the table.
+
+            | Item |
+            | --- |
+            | Example A |
+
+            After the table.
+        """.trimIndent()
+        assertEquals("Before the table. After the table.", sanitizeTextForSpeech(text))
+    }
+
+    @Test
+    fun preservesRowsOutsideATableBlockquote() {
+        val text = """
+            > | Item | Value |
+            > | --- | ---: |
+            > | Example A | 10 |
+            Outside | prose
+        """.trimIndent()
+        assertEquals("Outside | prose", sanitizeTextForSpeech(text))
+    }
+
+    @Test
+    fun preservesMalformedTablesWithMismatchedColumnCounts() {
+        val text = """
+            Heading | Detail
+            --- | --- | ---
+            Keep this prose.
+        """.trimIndent()
+        assertTrue(sanitizeTextForSpeech(text).contains("Heading | Detail"))
+    }
+
+    @Test
+    fun skipsGfmBodyRowsWhoseCellCountsDifferFromHeader() {
+        val text = """
+            Before the table.
+
+            | Item | Value |
+            | --- | ---: |
+            | Example A |
+            | Example B | 20 | ignored |
+
+            After the table.
+        """.trimIndent()
+        assertEquals("Before the table. After the table.", sanitizeTextForSpeech(text))
+    }
+
+    @Test
+    fun skipsTablesContainingEscapedPipes() {
+        val text = """
+            Before the table.
+
+            | Item \| detail | Value |
+            | --- | ---: |
+            | Example A | 10 |
+
+            After the table.
+        """.trimIndent()
+        assertEquals("Before the table. After the table.", sanitizeTextForSpeech(text))
+    }
+
+    @Test
+    fun preservesIndentedCodeThatResemblesATable() {
+        val text = "    Item | Value\n    --- | ---\n    Example A | 10"
+        assertTrue(sanitizeTextForSpeech(text).contains("Item | Value"))
+    }
+
+    @Test
+    fun stripsFencedCodeAndUrlAndEmoji() {
+        assertEquals(
+            "See link for details.",
+            sanitizeTextForSpeech("See https://example.com/x for details. 🎉"),
+        )
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceCapabilitiesTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceCapabilitiesTest.kt
@@ -1,0 +1,43 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceCapabilitiesTest {
+    @Test
+    fun okProbeWithKeyEnablesEverythingIncludingPicker() {
+        val caps = VoiceCapabilityPolicy.fromVoicesProbe(200, elevenLabsAvailable = true)
+        assertTrue(caps.audioRoutesPresent)
+        assertTrue(caps.canDictateViaServer)
+        assertTrue(caps.canReadAloud)
+        assertTrue(caps.canStreamSpeech)
+        assertTrue(caps.canPickElevenLabsVoice)
+    }
+
+    @Test
+    fun okProbeWithoutKeyKeepsAudioButHidesPicker() {
+        val caps = VoiceCapabilityPolicy.fromVoicesProbe(200, elevenLabsAvailable = false)
+        assertTrue(caps.audioRoutesPresent)
+        assertTrue(caps.canReadAloud)
+        assertFalse(caps.canPickElevenLabsVoice)
+    }
+
+    @Test
+    fun routeNotFoundHidesAllVoice() {
+        for (code in intArrayOf(404, 405)) {
+            val caps = VoiceCapabilityPolicy.fromVoicesProbe(code, elevenLabsAvailable = true)
+            assertEquals(VoiceCapabilities.NONE, caps)
+            assertFalse(caps.canReadAloud)
+            assertFalse(caps.canDictateViaServer)
+        }
+    }
+
+    @Test
+    fun authOrServerErrorsFailClosed() {
+        for (code in intArrayOf(401, 403, 500, 502, 503)) {
+            assertEquals(VoiceCapabilities.NONE, VoiceCapabilityPolicy.fromVoicesProbe(code, true))
+        }
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceCapabilityProbeTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceCapabilityProbeTest.kt
@@ -1,0 +1,91 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import com.unsupportedpastels.hermesandroid.connection.HttpHermesConnectionClient
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceCapabilityProbeTest {
+    private val origin = ServerOrigin.parse("https://hermes.example")
+    private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+
+    @Test
+    fun probeHitsVoicesRouteWithProfileAndReportsAvailability() = runTest {
+        val engine = MockEngine { request ->
+            assertEquals("/api/audio/elevenlabs/voices", request.url.encodedPath)
+            assertEquals("work", request.url.parameters["profile"])
+            respond("""{"available": true, "voices": []}""", headers = jsonHeaders)
+        }
+
+        val caps = HttpHermesConnectionClient(HttpClient(engine))
+            .probeVoiceCapabilities(origin, accessToken = "t", profile = "work")
+
+        assertTrue(caps.audioRoutesPresent)
+        assertTrue(caps.canPickElevenLabsVoice)
+    }
+
+    @Test
+    fun probeWithoutKeyKeepsAudioRoutesButHidesPicker() = runTest {
+        val engine = MockEngine {
+            respond("""{"available": false, "voices": []}""", headers = jsonHeaders)
+        }
+
+        val caps = HttpHermesConnectionClient(HttpClient(engine))
+            .probeVoiceCapabilities(origin, accessToken = "t", profile = "default")
+
+        assertTrue(caps.audioRoutesPresent)
+        assertFalse(caps.canPickElevenLabsVoice)
+    }
+
+    @Test
+    fun probeOnOlderServerFailsClosed() = runTest {
+        val engine = MockEngine {
+            respond("Not Found", status = HttpStatusCode.NotFound)
+        }
+
+        val caps = HttpHermesConnectionClient(HttpClient(engine))
+            .probeVoiceCapabilities(origin, accessToken = "t", profile = "default")
+
+        assertEquals(VoiceCapabilities.NONE, caps)
+    }
+
+    @Test
+    fun voiceConfigLoadParsesServerSection() = runTest {
+        val engine = MockEngine { request ->
+            assertEquals("/api/config", request.url.encodedPath)
+            assertEquals("work", request.url.parameters["profile"])
+            respond(
+                """{"voice": {"submit_mode": "draft", "auto_tts": true, "stop_phrases": ["stop", "cancel"]}}""",
+                headers = jsonHeaders,
+            )
+        }
+
+        val config = HttpHermesConnectionClient(HttpClient(engine))
+            .loadVoiceServerConfig(origin, accessToken = "t", profile = "work")
+
+        assertEquals(VoiceSubmitMode.Draft, config.submitMode)
+        assertTrue(config.autoTts)
+        assertEquals(listOf("stop", "cancel"), config.stopPhrases)
+    }
+
+    @Test
+    fun voiceConfigLoadFailsSafeToDefaults() = runTest {
+        val engine = MockEngine {
+            respond("boom", status = HttpStatusCode.InternalServerError)
+        }
+
+        val config = HttpHermesConnectionClient(HttpClient(engine))
+            .loadVoiceServerConfig(origin, accessToken = "t", profile = "default")
+
+        assertEquals(VoiceServerConfig.DEFAULT, config)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationControllerTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationControllerTest.kt
@@ -1,0 +1,155 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceConversationControllerTest {
+    private fun controller(stopPhrases: List<String> = listOf("stop")) =
+        VoiceConversationController { stopPhrases }
+
+    @Test
+    fun startEntersListeningAndBumpsGeneration() {
+        val c = controller()
+        val before = c.generation
+        assertTrue(c.start())
+        assertTrue(c.state.value is VoiceConversationState.Listening)
+        assertTrue(c.generation > before)
+        // Double-start is rejected.
+        assertFalse(c.start())
+    }
+
+    @Test
+    fun fullTurnCycle() {
+        val c = controller()
+        c.start()
+        assertTrue(c.onUtteranceCaptured())
+        assertEquals(VoiceConversationState.Transcribing, c.state.value)
+        assertEquals(TranscriptDisposition.Submit, c.onTranscript("what's the weather"))
+        assertEquals(VoiceConversationState.Thinking, c.state.value)
+        assertTrue(c.onSpeechStarted())
+        assertEquals(VoiceConversationState.Speaking, c.state.value)
+        c.onSpeechFinished()
+        assertTrue(c.state.value is VoiceConversationState.Listening)
+    }
+
+    @Test
+    fun emptyTranscriptRearmsWithoutSubmit() {
+        val c = controller()
+        c.start()
+        c.onUtteranceCaptured()
+        assertEquals(TranscriptDisposition.Rearm, c.onTranscript("   "))
+        assertTrue(c.state.value is VoiceConversationState.Listening)
+    }
+
+    @Test
+    fun wholeUtteranceStopEndsWithoutSubmit() {
+        val c = controller()
+        c.start()
+        c.onUtteranceCaptured()
+        assertEquals(TranscriptDisposition.EndConversation, c.onTranscript("Stop."))
+        assertEquals(VoiceConversationState.Idle, c.state.value)
+    }
+
+    @Test
+    fun substantiveSentenceContainingStopSubmits() {
+        val c = controller()
+        c.start()
+        c.onUtteranceCaptured()
+        assertEquals(TranscriptDisposition.Submit, c.onTranscript("stop the docker container"))
+    }
+
+    @Test
+    fun transcriptionFailureShowsNoticeAndRearms() {
+        val c = controller()
+        c.start()
+        c.onUtteranceCaptured()
+        c.onTranscriptionFailed()
+        assertEquals(VoiceConversationNotice.TranscriptionFailed, c.notice.value)
+        assertTrue(c.state.value is VoiceConversationState.Listening)
+        // The notice clears on the next successful transcript.
+        c.onUtteranceCaptured()
+        c.onTranscript("hello")
+        assertNull(c.notice.value)
+    }
+
+    @Test
+    fun toolOnlyTurnRearmsWithoutSpeech() {
+        val c = controller()
+        c.start()
+        c.onUtteranceCaptured()
+        c.onTranscript("run the tests")
+        c.onTurnCompleteWithoutSpeech()
+        assertTrue(c.state.value is VoiceConversationState.Listening)
+    }
+
+    @Test
+    fun speechFailureShowsNoticeAndRearms() {
+        val c = controller()
+        c.start()
+        c.onUtteranceCaptured()
+        c.onTranscript("hi")
+        c.onSpeechFailed()
+        assertEquals(VoiceConversationNotice.SpeechFailed, c.notice.value)
+        assertTrue(c.state.value is VoiceConversationState.Listening)
+    }
+
+    @Test
+    fun bargeInDuringSpeakingReturnsToListening() {
+        val c = controller()
+        c.start()
+        c.onUtteranceCaptured()
+        c.onTranscript("hi")
+        c.onSpeechStarted()
+        assertTrue(c.onBargeIn())
+        assertTrue(c.state.value is VoiceConversationState.Listening)
+    }
+
+    @Test
+    fun bargeInWhileListeningIsRejected() {
+        val c = controller()
+        c.start()
+        assertFalse(c.onBargeIn())
+    }
+
+    @Test
+    fun endFromAnyPhaseGoesIdleAndInvalidatesGeneration() {
+        val c = controller()
+        c.start()
+        c.onUtteranceCaptured()
+        c.onTranscript("hello")
+        val generationBefore = c.generation
+        c.end()
+        assertEquals(VoiceConversationState.Idle, c.state.value)
+        assertTrue(c.generation > generationBefore)
+        // Stale engine callbacks after end are ignored.
+        assertFalse(c.onUtteranceCaptured())
+        assertFalse(c.onSpeechStarted())
+        c.onSpeechFinished()
+        assertEquals(VoiceConversationState.Idle, c.state.value)
+    }
+
+    @Test
+    fun staleTranscriptAfterEndDoesNotSubmit() {
+        val c = controller()
+        c.start()
+        c.onUtteranceCaptured()
+        c.end()
+        assertEquals(TranscriptDisposition.Rearm, c.onTranscript("late transcript"))
+        assertEquals(VoiceConversationState.Idle, c.state.value)
+    }
+
+    @Test
+    fun muteTogglesOnlyWhileActive() {
+        val c = controller()
+        c.setMuted(true)
+        assertFalse(c.muted.value)
+        c.start()
+        c.setMuted(true)
+        assertTrue(c.muted.value)
+        c.end()
+        assertFalse(c.muted.value)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationHostTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationHostTest.kt
@@ -1,0 +1,594 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import com.unsupportedpastels.hermesandroid.gateway.ChatMessage
+import com.unsupportedpastels.hermesandroid.gateway.ChatMessageRole
+import com.unsupportedpastels.hermesandroid.gateway.ChatSessionSnapshot
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private fun view(
+    turnRunning: Boolean = false,
+    streamingText: String? = null,
+    finalText: String? = null,
+    finalIndex: Int = -1,
+    messageCount: Int = 0,
+    streamingIndex: Int = if (streamingText != null) messageCount - 1 else -1,
+) = VoiceReplyView(turnRunning, streamingText, streamingIndex, finalText, finalIndex, messageCount)
+
+/** Test harness: scripted listen results, recorded submissions, fake speech. */
+private class Harness(
+    stopPhrases: List<String> = listOf("stop"),
+    val streamingAvailable: Boolean = false,
+) {
+    val controller = VoiceConversationController { stopPhrases }
+    val replies = MutableStateFlow(view())
+    val submissions = mutableListOf<String>()
+    val interruptedFlags = mutableListOf<Boolean>()
+    val restSpoken = mutableListOf<String>()
+    var transcribeResult: Result<TranscriptionResult> =
+        Result.success(TranscriptionResult("hello there", null))
+    var listenGate = CompletableDeferred<DictationRecording?>()
+
+    /** Mirrors the real ViewModel: sendMessage flips sending state synchronously. */
+    var onSubmit: (String) -> Unit = {}
+
+    var bargeEnabled = false
+
+    /** One element = one barge; a consumed trigger never re-fires. */
+    val bargeTrigger = Channel<Unit>(Channel.UNLIMITED)
+    var bargeCapture: DictationRecording? =
+        DictationRecording("data:audio/mp4;base64,QQ==", "audio/mp4")
+    var stopTurnCalls = 0
+    var listenCalls = 0
+    var playbackStops = 0
+    var holdPlayback = false
+    var playbackGate = CompletableDeferred<Unit>()
+    val streamSocket = FakeHostSpeechSocket()
+
+    fun engines(turnStartTimeoutMillis: Long = 10_000L) = VoiceConversationEngines(
+        listen = { _ ->
+            listenCalls++
+            listenGate.await()
+        },
+        transcribe = { _, _ -> transcribeResult },
+        submit = { text, interrupted ->
+            submissions += text
+            interruptedFlags += interrupted
+            onSubmit(text)
+        },
+        replies = replies,
+        openStream = { if (streamingAvailable) streamSocket else null },
+        sinkFactory = { HostRecordingSink() },
+        restSpeak = { text ->
+            restSpoken += text
+            Result.success(SpeechAudio(byteArrayOf(1), "audio/mpeg"))
+        },
+        playAudio = { _, onStarted, onFinished, _ ->
+            onStarted()
+            if (holdPlayback) playbackGate.await()
+            onFinished()
+        },
+        stopPlayback = { playbackStops++ },
+        stopTurn = {
+            stopTurnCalls++
+            // Mirrors the real seam: stopping the turn settles busy state.
+            replies.value = replies.value.copy(turnRunning = false)
+        },
+        monitorBargeIn = if (bargeEnabled) {
+            { onTrigger ->
+                bargeTrigger.receive()
+                onTrigger()
+                bargeCapture
+            }
+        } else {
+            null
+        },
+        turnStartTimeoutMillis = turnStartTimeoutMillis,
+        // advanceUntilIdle skips virtual time, so the pre-audio watchdog must
+        // not fire between scripted frames.
+        streamProgressTimeoutMillis = Long.MAX_VALUE,
+    )
+
+    fun utterance(dataUrl: String = "data:audio/mp4;base64,QQ==") {
+        val gate = listenGate
+        listenGate = CompletableDeferred()
+        gate.complete(DictationRecording(dataUrl, "audio/mp4"))
+    }
+
+    fun releasePlayback() {
+        if (!playbackGate.isCompleted) playbackGate.complete(Unit)
+    }
+}
+
+private class HostRecordingSink : PcmSpeechSink {
+    override fun start(sampleRateHz: Int, channels: Int): Boolean = true
+
+    override suspend fun write(pcm: ByteArray) = Unit
+
+    override suspend fun finish() = Unit
+
+    override fun stop() = Unit
+}
+
+private class FakeHostSpeechSocket : SpeechStreamSocket {
+    val sent = mutableListOf<String>()
+    private val inbound = kotlinx.coroutines.channels.Channel<SpeechSocketFrame?>(
+        kotlinx.coroutines.channels.Channel.UNLIMITED,
+    )
+
+    fun serverSends(frame: SpeechSocketFrame) {
+        inbound.trySend(frame)
+    }
+
+    fun serverCloses() {
+        inbound.trySend(null)
+    }
+
+    override suspend fun sendText(text: String) {
+        sent += text
+    }
+
+    override suspend fun receiveFrame(): SpeechSocketFrame? = inbound.receive()
+
+    override suspend fun close() {
+        inbound.trySend(null)
+    }
+}
+
+class VoiceConversationHostTest {
+    private fun Harness.startHost(
+        scope: kotlinx.coroutines.test.TestScope,
+    ): VoiceConversationHost {
+        // Prime the listen gate so the first turn waits for a scripted utterance.
+        listenGate = CompletableDeferred()
+        val host = VoiceConversationHost(controller, scope, engines())
+        host.start()
+        // Let the loop reach its await on the current gate before scripting.
+        scope.advanceUntilIdle()
+        return host
+    }
+
+    @Test
+    fun substantiveTranscriptSubmitsAndSpeaksViaRest() = runTest {
+        val h = Harness()
+        val host = h.startHost(this)
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 2) }
+        h.utterance()
+        advanceUntilIdle()
+        assertEquals(listOf("hello there"), h.submissions)
+        h.replies.value = view(
+            turnRunning = false,
+            finalText = "Here is the answer.",
+            finalIndex = 1,
+            messageCount = 2,
+        )
+        advanceUntilIdle()
+
+        assertEquals(listOf("Here is the answer."), h.restSpoken)
+        // Playback finished → re-armed for the next utterance.
+        assertTrue(h.controller.state.value is VoiceConversationState.Listening)
+        assertTrue(h.listenCalls >= 2)
+        host.end()
+    }
+
+    @Test
+    fun stopPhraseEndsLoopWithoutSubmitting() = runTest {
+        val h = Harness()
+        val host = h.startHost(this)
+        h.transcribeResult = Result.success(TranscriptionResult("Stop.", null))
+        h.utterance()
+        advanceUntilIdle()
+        assertTrue(h.submissions.isEmpty())
+        assertEquals(VoiceConversationState.Idle, h.controller.state.value)
+        assertFalse(host.isActive)
+    }
+
+    @Test
+    fun emptyTranscriptRearmsWithoutSubmit() = runTest {
+        val h = Harness()
+        val host = h.startHost(this)
+        h.transcribeResult = Result.success(TranscriptionResult("", null))
+        h.utterance()
+        advanceUntilIdle()
+        assertTrue(h.submissions.isEmpty())
+        assertTrue(h.controller.state.value is VoiceConversationState.Listening)
+        assertTrue(h.listenCalls >= 2)
+        host.end()
+    }
+
+    @Test
+    fun transcriptionFailureShowsNoticeAndRearms() = runTest {
+        val h = Harness()
+        val host = h.startHost(this)
+        h.transcribeResult = Result.failure(RuntimeException("boom"))
+        h.utterance()
+        advanceUntilIdle()
+        assertEquals(VoiceConversationNotice.TranscriptionFailed, h.controller.notice.value)
+        assertTrue(h.controller.state.value is VoiceConversationState.Listening)
+        host.end()
+    }
+
+    @Test
+    fun toolOnlyTurnRearmsWithoutSpeaking() = runTest {
+        val h = Harness()
+        val host = h.startHost(this)
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 2) }
+        h.utterance()
+        advanceUntilIdle()
+        // Turn completes with no new assistant text.
+        h.replies.value = view(turnRunning = false, messageCount = 2)
+        advanceUntilIdle()
+        assertTrue(h.restSpoken.isEmpty())
+        assertTrue(h.controller.state.value is VoiceConversationState.Listening)
+        host.end()
+    }
+
+    @Test
+    fun historicalReplyBeforeBaselineIsNeverSpoken() = runTest {
+        val h = Harness()
+        // Simulate an old assistant reply already in the transcript.
+        h.replies.value = view(finalText = "Old reply.", finalIndex = 0, messageCount = 1)
+        val host = h.startHost(this)
+        h.onSubmit = {
+            h.replies.value = view(
+                turnRunning = true,
+                finalText = "Old reply.",
+                finalIndex = 0,
+                messageCount = 3,
+            )
+        }
+        h.utterance()
+        advanceUntilIdle()
+        // Turn ends with no new final reply (e.g. errored) — old reply stays silent.
+        h.replies.value = view(
+            turnRunning = false,
+            finalText = "Old reply.",
+            finalIndex = 0,
+            messageCount = 3,
+        )
+        advanceUntilIdle()
+        assertTrue(h.restSpoken.isEmpty())
+        host.end()
+    }
+
+    @Test
+    fun turnThatNeverStartsRearms() = runTest {
+        val h = Harness()
+        val host = h.startHost(this)
+        h.utterance()
+        advanceUntilIdle()
+        // No turn activity ever appears; the start timeout re-arms the loop.
+        assertEquals(listOf("hello there"), h.submissions)
+        assertTrue(h.controller.state.value is VoiceConversationState.Listening)
+        host.end()
+    }
+
+    @Test
+    fun finalizedReplyStreamsAsOneShotAfterTurnSettles() = runTest {
+        val h = Harness(streamingAvailable = true)
+        val host = h.startHost(this)
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 2) }
+        h.utterance()
+        advanceUntilIdle()
+
+        // Nothing touches the speech socket while the turn is generating —
+        // an open speak-stream can starve the server producing the reply.
+        h.replies.value = view(turnRunning = true, streamingText = "Hello", messageCount = 2)
+        advanceUntilIdle()
+        assertTrue(h.streamSocket.sent.isEmpty())
+
+        h.replies.value = view(
+            turnRunning = false,
+            finalText = "Hello world.",
+            finalIndex = 1,
+            messageCount = 2,
+        )
+        // Server plays the audio and ends the stream.
+        h.streamSocket.serverSends(
+            SpeechSocketFrame.Text("""{"type":"start","sample_rate":24000,"channels":1}"""),
+        )
+        h.streamSocket.serverSends(SpeechSocketFrame.Binary(byteArrayOf(1, 2)))
+        h.streamSocket.serverSends(SpeechSocketFrame.Text("""{"type":"end"}"""))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("""{"text":"Hello world."}""", """{"done":true}"""),
+            h.streamSocket.sent,
+        )
+        // Streamed audio played; REST fallback never used.
+        assertTrue(h.restSpoken.isEmpty())
+        assertTrue(h.controller.state.value is VoiceConversationState.Listening)
+        host.end()
+    }
+
+    @Test
+    fun streamFallbackBeforeAudioSpeaksOnceViaRest() = runTest {
+        val h = Harness(streamingAvailable = true)
+        val host = h.startHost(this)
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 2) }
+        h.utterance()
+        advanceUntilIdle()
+
+        h.streamSocket.serverSends(SpeechSocketFrame.Text("""{"type":"fallback"}"""))
+        h.replies.value = view(
+            turnRunning = false,
+            finalText = "Hello world.",
+            finalIndex = 1,
+            messageCount = 2,
+        )
+        advanceUntilIdle()
+
+        assertEquals(listOf("Hello world."), h.restSpoken)
+        host.end()
+    }
+
+    @Test
+    fun streamDropAfterAudioNeverReplaysViaRest() = runTest {
+        val h = Harness(streamingAvailable = true)
+        val host = h.startHost(this)
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 2) }
+        h.utterance()
+        advanceUntilIdle()
+
+        h.streamSocket.serverSends(
+            SpeechSocketFrame.Text("""{"type":"start","sample_rate":24000,"channels":1}"""),
+        )
+        h.streamSocket.serverSends(SpeechSocketFrame.Binary(byteArrayOf(1, 2)))
+        h.streamSocket.serverCloses()
+        h.replies.value = view(
+            turnRunning = false,
+            finalText = "Hello world.",
+            finalIndex = 1,
+            messageCount = 2,
+        )
+        advanceUntilIdle()
+
+        assertTrue(h.restSpoken.isEmpty())
+        assertTrue(h.controller.state.value is VoiceConversationState.Listening)
+        host.end()
+    }
+
+    @Test
+    fun endDuringListeningStopsEverything() = runTest {
+        val h = Harness()
+        val host = h.startHost(this)
+        advanceUntilIdle()
+        host.end()
+        advanceUntilIdle()
+        assertEquals(VoiceConversationState.Idle, h.controller.state.value)
+        assertTrue(h.playbackStops >= 1)
+        // A late utterance from a torn-down recorder never submits.
+        h.utterance()
+        advanceUntilIdle()
+        assertTrue(h.submissions.isEmpty())
+    }
+
+    @Test
+    fun mutedLoopHoldsWithoutCapturing() = runTest {
+        val h = Harness()
+        val host = h.startHost(this)
+        advanceUntilIdle()
+        val callsWhileListening = h.listenCalls
+        // Complete the pending listen while muted: the next turn must hold.
+        h.controller.setMuted(true)
+        h.transcribeResult = Result.success(TranscriptionResult("", null))
+        h.utterance()
+        advanceUntilIdle()
+        assertEquals(callsWhileListening, h.listenCalls)
+        h.controller.setMuted(false)
+        advanceUntilIdle()
+        assertTrue(h.listenCalls > callsWhileListening)
+        host.end()
+    }
+
+    @Test
+    fun historicalReplyResurfacedBySessionResumeIsNeverSpoken() = runTest {
+        val h = Harness(streamingAvailable = true)
+        // Two messages of history exist before the voice turn.
+        h.replies.value = view(finalText = "Old reply.", finalIndex = 1, messageCount = 2)
+        val host = h.startHost(this)
+        h.onSubmit = {
+            // Session resume re-marks the OLD reply as streaming while the new
+            // turn runs — its index (1) sits below the baseline (2).
+            h.replies.value = view(
+                turnRunning = true,
+                streamingText = "Old reply.",
+                streamingIndex = 1,
+                messageCount = 4,
+            )
+        }
+        h.utterance()
+        advanceUntilIdle()
+        // The old text must never reach the speech socket during the turn.
+        assertTrue(h.streamSocket.sent.isEmpty())
+
+        // Turn ends with no NEW finalized reply — the resurfaced old reply
+        // (index 1 < baseline 2) stays silent and the loop re-arms.
+        h.replies.value = view(
+            turnRunning = false,
+            finalText = "Old reply.",
+            finalIndex = 1,
+            messageCount = 4,
+        )
+        advanceUntilIdle()
+        assertTrue(h.streamSocket.sent.isEmpty())
+        assertTrue(h.restSpoken.isEmpty())
+        assertTrue(h.controller.state.value is VoiceConversationState.Listening)
+
+        host.end()
+    }
+
+    @Test
+    fun transientNotRunningFlapDoesNotEndTheTurnEarly() = runTest {
+        val h = Harness()
+        val host = h.startHost(this)
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 2) }
+        h.utterance()
+        advanceUntilIdle()
+
+        // Transcript reconciliation transiently replaces the optimistic
+        // messages: "no turn, no reply" for a moment (observed on device).
+        h.replies.value = view(turnRunning = false, messageCount = 1)
+        testScheduler.advanceTimeBy(100)
+        testScheduler.runCurrent()
+        // The turn resumes within the confirmation window…
+        h.replies.value = view(turnRunning = true, messageCount = 2)
+        advanceUntilIdle()
+        // …and finally settles with the real reply, which is spoken.
+        h.replies.value = view(
+            turnRunning = false,
+            finalText = "The real answer.",
+            finalIndex = 1,
+            messageCount = 2,
+        )
+        advanceUntilIdle()
+
+        assertEquals(listOf("The real answer."), h.restSpoken)
+        assertTrue(h.controller.state.value is VoiceConversationState.Listening)
+        host.end()
+    }
+
+    @Test
+    fun bargeCaptureMatchingSpokenReplyIsDiscardedAsEcho() = runTest {
+        val h = Harness()
+        h.bargeEnabled = true
+        val host = h.startHost(this)
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 2) }
+        h.utterance()
+        advanceUntilIdle()
+        // Turn 1 settles and its reply is spoken.
+        h.replies.value = view(
+            turnRunning = false,
+            finalText = "The build passed and all tests are green.",
+            finalIndex = 1,
+            messageCount = 2,
+        )
+        advanceUntilIdle()
+        assertEquals(listOf("The build passed and all tests are green."), h.restSpoken)
+
+        // Turn 2 submits normally…
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 4) }
+        h.transcribeResult = Result.success(TranscriptionResult("run it again", null))
+        h.holdPlayback = true
+        h.playbackGate = CompletableDeferred()
+        h.utterance()
+        advanceUntilIdle()
+        assertEquals(listOf("hello there", "run it again"), h.submissions)
+        h.replies.value = view(
+            turnRunning = false,
+            finalText = "The second build passed and all tests are green.",
+            finalIndex = 3,
+            messageCount = 4,
+        )
+        advanceUntilIdle()
+
+        // …then speaker bleed trips the barge and transcribes as the reply
+        // Hermes itself spoke. It must be discarded, never submitted.
+        h.transcribeResult = Result.success(
+            TranscriptionResult("the build passed and all tests are green", null),
+        )
+        h.bargeTrigger.trySend(Unit)
+        advanceUntilIdle()
+        h.releasePlayback()
+        advanceUntilIdle()
+
+        assertEquals(2, h.submissions.size)
+        // Echo classification must happen before any destructive cancellation:
+        // speaker bleed is not a user interruption.
+        assertEquals(0, h.stopTurnCalls)
+        // Local playback may already have been cut to let a real user take the
+        // floor, but the Hermes response itself must not be cancelled.
+        assertEquals(1, h.playbackStops)
+        host.end()
+    }
+
+    @Test
+    fun bargeDuringTurnStopsItAndSubmitsCaptureInterrupted() = runTest {
+        val h = Harness()
+        h.bargeEnabled = true
+        val host = h.startHost(this)
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 2) }
+        h.utterance()
+        advanceUntilIdle()
+        assertEquals(listOf("hello there"), h.submissions)
+
+        // The user talks over the reply; the captured utterance is substantive.
+        h.transcribeResult = Result.success(TranscriptionResult("actually use pytest", null))
+        h.bargeTrigger.trySend(Unit)
+        advanceUntilIdle()
+
+        assertTrue(h.stopTurnCalls >= 1)
+        assertEquals(listOf("hello there", "actually use pytest"), h.submissions)
+        assertEquals(listOf(false, true), h.interruptedFlags)
+        host.end()
+    }
+
+    @Test
+    fun bargeStopPhraseEndsLoopWithoutSubmitting() = runTest {
+        val h = Harness()
+        h.bargeEnabled = true
+        val host = h.startHost(this)
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 2) }
+        h.utterance()
+        advanceUntilIdle()
+
+        h.transcribeResult = Result.success(TranscriptionResult("stop", null))
+        h.bargeTrigger.trySend(Unit)
+        advanceUntilIdle()
+
+        assertEquals(listOf("hello there"), h.submissions)
+        assertEquals(VoiceConversationState.Idle, h.controller.state.value)
+        assertFalse(host.isActive)
+    }
+
+    @Test
+    fun bargeWithEmptyTranscriptRearmsWithoutInterruptedSubmit() = runTest {
+        val h = Harness()
+        h.bargeEnabled = true
+        val host = h.startHost(this)
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 2) }
+        h.utterance()
+        advanceUntilIdle()
+
+        h.transcribeResult = Result.success(TranscriptionResult("", null))
+        h.bargeTrigger.trySend(Unit)
+        advanceUntilIdle()
+
+        assertEquals(listOf("hello there"), h.submissions)
+        assertEquals(listOf(false), h.interruptedFlags)
+        assertTrue(h.controller.state.value is VoiceConversationState.Listening)
+        host.end()
+    }
+
+    @Test
+    fun snapshotMappingExtractsTurnAndReplyState() {
+        val snapshot = ChatSessionSnapshot(
+            messages = listOf(
+                ChatMessage(ChatMessageRole.User, "hi"),
+                ChatMessage(ChatMessageRole.Assistant, "old reply"),
+                ChatMessage(ChatMessageRole.User, "again"),
+                ChatMessage(ChatMessageRole.Assistant, "streaming…", isStreaming = true),
+            ),
+            isSending = true,
+        )
+        val mapped = snapshot.toVoiceReplyView()
+        assertTrue(mapped.turnRunning)
+        assertEquals("streaming…", mapped.streamingText)
+        assertEquals("old reply", mapped.finalAssistantText)
+        assertEquals(1, mapped.finalAssistantIndex)
+        assertEquals(4, mapped.messageCount)
+
+        val idle = ChatSessionSnapshot(messages = emptyList()).toVoiceReplyView()
+        assertFalse(idle.turnRunning)
+        assertNull(idle.streamingText)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationHostTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationHostTest.kt
@@ -3,6 +3,7 @@ package com.unsupportedpastels.hermesandroid.voice
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessage
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessageRole
 import com.unsupportedpastels.hermesandroid.gateway.ChatSessionSnapshot
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -49,6 +50,8 @@ private class Harness(
         DictationRecording("data:audio/mp4;base64,QQ==", "audio/mp4")
     var stopTurnCalls = 0
     var listenCalls = 0
+    var listenCancellationCount = 0
+    var bargeCancellationCount = 0
     var playbackStops = 0
     var holdPlayback = false
     var playbackGate = CompletableDeferred<Unit>()
@@ -57,7 +60,12 @@ private class Harness(
     fun engines(turnStartTimeoutMillis: Long = 10_000L) = VoiceConversationEngines(
         listen = { _ ->
             listenCalls++
-            listenGate.await()
+            try {
+                listenGate.await()
+            } catch (cancelled: CancellationException) {
+                listenCancellationCount++
+                throw cancelled
+            }
         },
         transcribe = { _, _ -> transcribeResult },
         submit = { text, interrupted ->
@@ -85,9 +93,14 @@ private class Harness(
         },
         monitorBargeIn = if (bargeEnabled) {
             { onTrigger ->
-                bargeTrigger.receive()
-                onTrigger()
-                bargeCapture
+                try {
+                    bargeTrigger.receive()
+                    onTrigger()
+                    bargeCapture
+                } catch (cancelled: CancellationException) {
+                    bargeCancellationCount++
+                    throw cancelled
+                }
             }
         } else {
             null
@@ -387,6 +400,34 @@ class VoiceConversationHostTest {
         h.controller.setMuted(false)
         advanceUntilIdle()
         assertTrue(h.listenCalls > callsWhileListening)
+        host.end()
+    }
+
+    @Test
+    fun mutingCancelsActiveListeningCapture() = runTest {
+        val h = Harness()
+        val host = h.startHost(this)
+
+        h.controller.setMuted(true)
+        advanceUntilIdle()
+
+        assertEquals(1, h.listenCancellationCount)
+        host.end()
+    }
+
+    @Test
+    fun mutingCancelsActiveBargeMonitor() = runTest {
+        val h = Harness()
+        h.bargeEnabled = true
+        val host = h.startHost(this)
+        h.onSubmit = { h.replies.value = view(turnRunning = true, messageCount = 2) }
+        h.utterance()
+        advanceUntilIdle()
+
+        h.controller.setMuted(true)
+        advanceUntilIdle()
+
+        assertEquals(1, h.bargeCancellationCount)
         host.end()
     }
 

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationServiceTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationServiceTest.kt
@@ -1,0 +1,56 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class VoiceConversationServiceTest {
+    @After
+    fun tearDown() {
+        VoiceServiceBridge.onStopRequested = null
+        VoiceServiceBridge.running = false
+    }
+
+    @Test
+    fun startCommandMarksServiceRunning() {
+        val controller = Robolectric.buildService(VoiceConversationService::class.java)
+        val service = controller.create().get()
+        val intent = Intent(service, VoiceConversationService::class.java)
+            .putExtra("state", "Listening")
+        service.onStartCommand(intent, 0, 1)
+        assertTrue(VoiceServiceBridge.running)
+        controller.destroy()
+        assertFalse(VoiceServiceBridge.running)
+    }
+
+    @Test
+    fun notificationStopActionEndsLoopThroughBridge() {
+        var loopStopped = false
+        VoiceServiceBridge.onStopRequested = { loopStopped = true }
+        val controller = Robolectric.buildService(VoiceConversationService::class.java)
+        val service = controller.create().get()
+        // Arm, then deliver the notification's Stop action.
+        service.onStartCommand(
+            Intent(service, VoiceConversationService::class.java).putExtra("state", "Speaking"),
+            0,
+            1,
+        )
+        service.onStartCommand(
+            Intent(service, VoiceConversationService::class.java)
+                .setAction("com.unsupportedpastels.hermesandroid.voice.STOP"),
+            0,
+            2,
+        )
+        assertTrue(loopStopped)
+        assertFalse(VoiceServiceBridge.running)
+        controller.destroy()
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationUiTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceConversationUiTest.kt
@@ -1,0 +1,118 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import android.Manifest
+import android.app.Application
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.unsupportedpastels.hermesandroid.gateway.ChatSessionSnapshot
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class VoiceConversationUiTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private class SilentRecorder : DictationRecorder {
+        override val mimeType = "audio/mp4"
+        override fun start() = true
+        override fun sampleAmplitude() = 0
+        override fun sampleLevel() = 0f
+        override fun stopAndEncode(): DictationRecording? = null
+        override fun cancel() = Unit
+    }
+
+    private class NoOpSpeechEngine : SpeechEngine {
+        override suspend fun play(
+            audio: SpeechAudio,
+            onStarted: () -> Unit,
+            onFinished: () -> Unit,
+            onError: () -> Unit,
+        ) {
+            onStarted()
+            onFinished()
+        }
+
+        override fun stop() = Unit
+
+        override fun release() = Unit
+    }
+
+    private fun grantMic() {
+        shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .grantPermissions(Manifest.permission.RECORD_AUDIO)
+    }
+
+    private fun conversation() = ComposerVoiceConversation(
+        serverConfig = VoiceServerConfig.DEFAULT,
+        transcribe = { _, _ -> Result.success(TranscriptionResult("", null)) },
+        openStream = { null },
+        synthesize = { Result.success(SpeechAudio(byteArrayOf(1), "audio/mpeg")) },
+    )
+
+    @Test
+    fun toggleStartsLoopAndShowsBarThenEndStops() {
+        grantMic()
+        val submissions = mutableListOf<String>()
+        composeRule.setContent {
+            val host = rememberVoiceConversationHost(
+                conversation = conversation(),
+                sessionId = "session-1",
+                chat = ChatSessionSnapshot(),
+                onSubmit = { text, _ -> submissions += text },
+                recorderFactory = { SilentRecorder() },
+                speechEngineFactory = { NoOpSpeechEngine() },
+            )
+            if (host != null) {
+                VoiceConversationBar(host = host)
+                VoiceConversationToggleButton(host = host, enabled = true)
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Start voice conversation").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Start voice conversation").performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag("Voice conversation bar").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Mute microphone").assertIsDisplayed()
+
+        // Both the bar's close and the active toggle expose "End voice conversation".
+        composeRule.onAllNodesWithContentDescription("End voice conversation")
+            .onFirst()
+            .performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Start voice conversation").assertIsDisplayed()
+        assertTrue(submissions.isEmpty())
+    }
+
+    @Test
+    fun barHiddenWhileIdle() {
+        composeRule.setContent {
+            val host = rememberVoiceConversationHost(
+                conversation = conversation(),
+                sessionId = "session-1",
+                chat = ChatSessionSnapshot(),
+                onSubmit = { _, _ -> },
+                recorderFactory = { SilentRecorder() },
+                speechEngineFactory = { NoOpSpeechEngine() },
+            )
+            if (host != null) {
+                VoiceConversationBar(host = host)
+                VoiceConversationToggleButton(host = host, enabled = true)
+            }
+        }
+        composeRule.onNodeWithTag("Voice conversation bar").assertDoesNotExist()
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceEchoFilterTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceEchoFilterTest.kt
@@ -1,0 +1,58 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceEchoFilterTest {
+    private val reply =
+        "The build finished successfully. All forty-two tests passed and the " +
+            "artifact was uploaded to the staging server for review."
+
+    @Test
+    fun verbatimSelfCaptureIsEcho() {
+        assertTrue(VoiceEchoFilter.isTtsEcho(reply, reply))
+    }
+
+    @Test
+    fun fragmentOfLongerReplyIsEcho() {
+        // The barge capture spans only the pre-roll plus time-to-silence — a
+        // clause from the middle of the reply, slightly mis-transcribed.
+        assertTrue(
+            VoiceEchoFilter.isTtsEcho(
+                "all forty two tests passed and the artifact was uploaded",
+                reply,
+            ),
+        )
+    }
+
+    @Test
+    fun genuineInterjectionIsNotEcho() {
+        assertFalse(VoiceEchoFilter.isTtsEcho("actually switch to the release build", reply))
+    }
+
+    @Test
+    fun shortGenuineInterjectionSkipsWindowFallback() {
+        // "yes" appears nowhere; even if a reply contained it, transcripts under
+        // the fragment minimum never use the window fallback.
+        assertFalse(VoiceEchoFilter.isTtsEcho("yes", reply))
+        assertFalse(VoiceEchoFilter.isTtsEcho("stop that", reply))
+    }
+
+    @Test
+    fun caseAndWhitespaceAreNormalized() {
+        assertTrue(
+            VoiceEchoFilter.isTtsEcho(
+                "  THE BUILD   finished SUCCESSFULLY. all forty-two tests passed and the artifact was uploaded to the staging server for review. ",
+                reply,
+            ),
+        )
+    }
+
+    @Test
+    fun emptyInputsAreNeverEcho() {
+        assertFalse(VoiceEchoFilter.isTtsEcho("", reply))
+        assertFalse(VoiceEchoFilter.isTtsEcho("hello", null))
+        assertFalse(VoiceEchoFilter.isTtsEcho("hello", ""))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicyTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicyTest.kt
@@ -1,8 +1,10 @@
 package com.unsupportedpastels.hermesandroid.voice
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VoiceInputPolicyTest {
@@ -45,5 +47,18 @@ class VoiceInputPolicyTest {
         assertEquals("existing new words", VoiceInputPolicy.mergeDraft("existing", "new words"))
         assertEquals("existing\nnew words", VoiceInputPolicy.mergeDraft("existing\n", "new words"))
         assertEquals("existing", VoiceInputPolicy.mergeDraft("existing", "   "))
+    }
+
+    @Test
+    fun serverDisabledSttHidesServerVoiceConversation() {
+        val capabilities = VoiceCapabilities(audioRoutesPresent = true, elevenLabsVoicesAvailable = false)
+
+        assertTrue(VoiceInputPolicy.canUseServerConversation(capabilities, VoiceServerConfig.DEFAULT))
+        assertFalse(
+            VoiceInputPolicy.canUseServerConversation(
+                capabilities,
+                VoiceServerConfig.DEFAULT.copy(sttEnabled = false),
+            ),
+        )
     }
 }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicyTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceInputPolicyTest.kt
@@ -1,0 +1,49 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class VoiceInputPolicyTest {
+    @Test
+    fun scopesPendingResultsByOriginProfileAndDurableSession() {
+        val baseline = VoiceInputPolicy.scopeKey("https://one.example", "default", "session-1")
+
+        assertEquals(baseline, VoiceInputPolicy.scopeKey("https://one.example", "default", "session-1"))
+        assertNotEquals(baseline, VoiceInputPolicy.scopeKey("https://two.example", "default", "session-1"))
+        assertNotEquals(baseline, VoiceInputPolicy.scopeKey("https://one.example", "work", "session-1"))
+        assertNotEquals(baseline, VoiceInputPolicy.scopeKey("https://one.example", "default", "session-2"))
+        assertNotEquals(
+            VoiceInputPolicy.scopeKey("https://one.example", "a|1:b", "session-1"),
+            VoiceInputPolicy.scopeKey("https://one.example|a", "b", "1:session-1"),
+        )
+    }
+
+    @Test
+    fun selectsFirstNonBlankResultAndTrimsIt() {
+        assertEquals(
+            "Send the release notes",
+            VoiceInputPolicy.bestResult(listOf("   ", "  Send the release notes  ", "ignored")),
+        )
+        assertNull(VoiceInputPolicy.bestResult(null))
+        assertNull(VoiceInputPolicy.bestResult(listOf("", "  ")))
+    }
+
+    @Test
+    fun boundsUntrustedRecognizerText() {
+        val result = VoiceInputPolicy.bestResult(
+            listOf("a".repeat(VoiceInputPolicy.MAX_RESULT_CHARS + 32)),
+        )
+
+        assertEquals(VoiceInputPolicy.MAX_RESULT_CHARS, result?.length)
+    }
+
+    @Test
+    fun appendsRecognitionWithoutOverwritingTheDraft() {
+        assertEquals("new words", VoiceInputPolicy.mergeDraft("", "new words"))
+        assertEquals("existing new words", VoiceInputPolicy.mergeDraft("existing", "new words"))
+        assertEquals("existing\nnew words", VoiceInputPolicy.mergeDraft("existing\n", "new words"))
+        assertEquals("existing", VoiceInputPolicy.mergeDraft("existing", "   "))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceServerConfigTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceServerConfigTest.kt
@@ -1,0 +1,106 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceServerConfigTest {
+    private fun parse(raw: String): VoiceServerConfig =
+        VoiceServerConfig.fromConfigRoot(Json.parseToJsonElement(raw) as? JsonObject)
+
+    @Test
+    fun absentVoiceSectionYieldsDefaults() {
+        assertEquals(VoiceServerConfig.DEFAULT, parse("""{"agent":{}}"""))
+    }
+
+    @Test
+    fun malformedVoiceSectionYieldsDefaults() {
+        // Server tolerates `voice` being a bool/str instead of a dict (voice.py).
+        assertEquals(VoiceServerConfig.DEFAULT, parse("""{"voice": true}"""))
+        assertEquals(VoiceServerConfig.DEFAULT, parse("""{"voice": "en-US-AriaNeural"}"""))
+    }
+
+    @Test
+    fun defaultsMatchReleasedServerDefaults() {
+        val defaults = VoiceServerConfig.DEFAULT
+        assertEquals(VoiceSubmitMode.Direct, defaults.submitMode)
+        assertEquals(120, defaults.maxRecordingSeconds)
+        assertEquals(false, defaults.autoTts)
+        assertEquals(200, defaults.silenceThreshold)
+        assertEquals(3.0, defaults.silenceDurationSeconds, 0.0)
+        assertTrue(defaults.bargeInEnabled)
+        assertEquals(0.5, defaults.bargeInGraceSeconds, 0.0)
+        assertEquals(3.0, defaults.bargeInThresholdMultiplier, 0.0)
+        assertEquals(listOf("stop"), defaults.stopPhrases)
+    }
+
+    @Test
+    fun fullSectionParsesEveryField() {
+        val config = parse(
+            """
+            {
+              "voice": {
+                "submit_mode": "draft",
+                "max_recording_seconds": 60,
+                "auto_tts": true,
+                "silence_threshold": 400,
+                "silence_duration": 2.5,
+                "barge_in": false,
+                "barge_in_grace_seconds": 0.75,
+                "barge_in_threshold_multiplier": 4.0,
+                "stop_phrases": ["Stop", "cancel", "STOP"]
+              }
+            }
+            """.trimIndent(),
+        )
+        assertEquals(VoiceSubmitMode.Draft, config.submitMode)
+        assertEquals(60, config.maxRecordingSeconds)
+        assertTrue(config.autoTts)
+        assertEquals(400, config.silenceThreshold)
+        assertEquals(2.5, config.silenceDurationSeconds, 0.0)
+        assertEquals(false, config.bargeInEnabled)
+        assertEquals(0.75, config.bargeInGraceSeconds, 0.0)
+        assertEquals(4.0, config.bargeInThresholdMultiplier, 0.0)
+        // Lower-cased and de-duplicated.
+        assertEquals(listOf("stop", "cancel"), config.stopPhrases)
+    }
+
+    @Test
+    fun submitModeIsCaseInsensitiveAndFallsBackToDirect() {
+        assertEquals(VoiceSubmitMode.Draft, VoiceSubmitMode.parse("DRAFT"))
+        assertEquals(VoiceSubmitMode.Direct, VoiceSubmitMode.parse("direct"))
+        assertEquals(VoiceSubmitMode.Direct, VoiceSubmitMode.parse("nonsense"))
+        assertEquals(VoiceSubmitMode.Direct, VoiceSubmitMode.parse(null))
+    }
+
+    @Test
+    fun outOfRangeNumbersAreCoercedIntoSafeBounds() {
+        val config = parse(
+            """
+            {"voice": {"max_recording_seconds": 100000, "silence_threshold": -5,
+             "barge_in_threshold_multiplier": 0.1}}
+            """.trimIndent(),
+        )
+        assertEquals(600, config.maxRecordingSeconds)
+        assertEquals(0, config.silenceThreshold)
+        assertEquals(1.0, config.bargeInThresholdMultiplier, 0.0)
+    }
+
+    @Test
+    fun wrongTypedFieldsFallBackPerField() {
+        // A single mistyped field must not discard the rest of the section.
+        val config = parse(
+            """{"voice": {"max_recording_seconds": "lots", "auto_tts": true}}""",
+        )
+        assertEquals(VoiceServerConfig.DEFAULT.maxRecordingSeconds, config.maxRecordingSeconds)
+        assertTrue(config.autoTts)
+    }
+
+    @Test
+    fun emptyStopPhrasesListDisablesStopWords() {
+        val config = parse("""{"voice": {"stop_phrases": []}}""")
+        assertEquals(emptyList<String>(), config.stopPhrases)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceSettingsSectionTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceSettingsSectionTest.kt
@@ -1,0 +1,66 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class VoiceSettingsSectionTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private fun settings(
+        accepted: Boolean,
+        capabilities: VoiceCapabilities = VoiceCapabilities(
+            audioRoutesPresent = true,
+            elevenLabsVoicesAvailable = false,
+        ),
+    ) = VoiceSettings(
+        capabilities = capabilities,
+        config = VoiceServerConfig.DEFAULT.copy(sttProvider = "local", ttsProvider = "edge"),
+        setAutoTts = { accepted },
+        setElevenLabsVoice = { accepted },
+        loadVoices = { emptyList() },
+    )
+
+    @Test
+    fun acceptedAutoTtsToggleStaysOn() {
+        composeRule.setContent { VoiceSettingsSection(settings(accepted = true)) }
+        composeRule.onNodeWithText("Voice").assertIsDisplayed()
+        composeRule.onNodeWithText("Via local").assertIsDisplayed()
+        composeRule.onNodeWithText("Via edge").assertIsDisplayed()
+
+        composeRule.onNodeWithContentDescription("Speak replies automatically").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Speak replies automatically").assertIsOn()
+    }
+
+    @Test
+    fun rejectedAutoTtsToggleRollsBackWithError() {
+        composeRule.setContent { VoiceSettingsSection(settings(accepted = false)) }
+        composeRule.onNodeWithContentDescription("Speak replies automatically").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Speak replies automatically").assertIsOff()
+        composeRule.onNodeWithText("Couldn't update the server setting").assertIsDisplayed()
+    }
+
+    @Test
+    fun hiddenEntirelyWithoutAudioRoutes() {
+        composeRule.setContent {
+            VoiceSettingsSection(
+                settings(accepted = true, capabilities = VoiceCapabilities.NONE),
+            )
+        }
+        composeRule.onNodeWithText("Voice").assertDoesNotExist()
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceStopPhrasesTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceStopPhrasesTest.kt
@@ -1,0 +1,43 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceStopPhrasesTest {
+    private val phrases = listOf("stop", "never mind", "goodbye")
+
+    @Test
+    fun matchesExactPhrase() {
+        assertTrue(isVoiceStopPhrase("stop", phrases))
+        assertTrue(isVoiceStopPhrase("never mind", phrases))
+        assertTrue(isVoiceStopPhrase("goodbye", phrases))
+    }
+
+    @Test
+    fun matchesDespiteCaseAndSurroundingPunctuation() {
+        assertTrue(isVoiceStopPhrase("Stop.", phrases))
+        assertTrue(isVoiceStopPhrase("  STOP!  ", phrases))
+        assertTrue(isVoiceStopPhrase("\"stop\"", phrases))
+        assertTrue(isVoiceStopPhrase("never mind...", phrases))
+    }
+
+    @Test
+    fun doesNotMatchSubstantiveSentencesContainingThePhrase() {
+        assertFalse(isVoiceStopPhrase("stop the container", phrases))
+        assertFalse(isVoiceStopPhrase("how do I stop a process", phrases))
+        assertFalse(isVoiceStopPhrase("stop doing that and try again", phrases))
+    }
+
+    @Test
+    fun emptyAndPunctuationOnlyUtterancesNeverMatch() {
+        assertFalse(isVoiceStopPhrase("", phrases))
+        assertFalse(isVoiceStopPhrase("   ", phrases))
+        assertFalse(isVoiceStopPhrase("...", phrases))
+    }
+
+    @Test
+    fun emptyPhraseListDisablesSpokenStop() {
+        assertFalse(isVoiceStopPhrase("stop", emptyList()))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceTranscriptionClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/VoiceTranscriptionClientTest.kt
@@ -1,0 +1,90 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import com.unsupportedpastels.hermesandroid.connection.HermesConnectionException
+import com.unsupportedpastels.hermesandroid.connection.HttpHermesConnectionClient
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceTranscriptionClientTest {
+    private val origin = ServerOrigin.parse("https://hermes.example")
+    private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+
+    private fun client(engine: MockEngine) =
+        HttpHermesConnectionClient(HttpClient(engine) { install(HttpTimeout) })
+
+    @Test
+    fun transcribePostsDataUrlAndParsesTranscript() = runTest {
+        val engine = MockEngine { request ->
+            assertEquals("/api/audio/transcribe", request.url.encodedPath)
+            assertEquals("work", request.url.parameters["profile"])
+            val body = (request.body as TextContent).text
+            assertTrue(body.contains("\"data_url\""))
+            assertTrue(body.contains("data:audio/mp4;base64,AAAA"))
+            assertTrue(body.contains("\"mime_type\":\"audio/mp4\""))
+            respond(
+                """{"ok": true, "transcript": "  hello there  ", "provider": "whisper"}""",
+                headers = jsonHeaders,
+            )
+        }
+
+        val result = client(engine).transcribeAudio(
+            origin,
+            accessToken = "t",
+            profile = "work",
+            dataUrl = "data:audio/mp4;base64,AAAA",
+            mimeType = "audio/mp4",
+        )
+
+        assertEquals("hello there", result.transcript)
+        assertEquals("whisper", result.provider)
+        assertEquals(false, result.isEmpty)
+    }
+
+    @Test
+    fun emptyTranscriptIsSilenceNotError() = runTest {
+        val engine = MockEngine {
+            respond("""{"ok": true, "transcript": "", "provider": "whisper"}""", headers = jsonHeaders)
+        }
+
+        val result = client(engine).transcribeAudio(
+            origin,
+            accessToken = "t",
+            profile = "default",
+            dataUrl = "data:audio/mp4;base64,AAAA",
+            mimeType = null,
+        )
+
+        assertTrue(result.isEmpty)
+    }
+
+    @Test
+    fun httpErrorSurfacesAsConnectionException() = runTest {
+        val engine = MockEngine {
+            respond("nope", status = HttpStatusCode.BadRequest)
+        }
+
+        try {
+            client(engine).transcribeAudio(
+                origin,
+                accessToken = "t",
+                profile = "default",
+                dataUrl = "data:audio/mp4;base64,AAAA",
+                mimeType = null,
+            )
+            throw AssertionError("Expected HermesConnectionException")
+        } catch (expected: HermesConnectionException) {
+            assertTrue(expected.message!!.contains("400"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add server-backed dictation, read-aloud, auto-speak, and hands-free voice conversation support using the released Hermes `/api/audio/...` contracts.
- Add streaming speech transport, profile-scoped voice capability/config discovery, voice settings, stop phrases, and optional screen-off foreground-service continuation.
- Add full-duplex Android capture with `AudioRecord`, explicit Acoustic Echo Canceler/Noise Suppressor attachment, voice-communication routing, and built-in-speaker selection for responsive barge-in.
- Keep voice recordings, generated audio, transcripts in flight, credentials, tickets, and prompts out of offline persistence and logs.

## Security and privacy

- Microphone access remains runtime-permission gated and user initiated.
- Voice routes use the authenticated, origin-scoped Hermes transport and fresh WebSocket tickets for speech streaming.
- The voice foreground service is non-exported, microphone-typed, `START_NOT_STICKY`, and exposes only a phase label plus a Stop action.
- Audio and temporary recordings remain in memory or short-lived app cache and are not written to transcript cache, notifications, or analytics.

## Test plan

- [x] `./gradlew testDebugUnitTest lintDebug assembleDebug`
- [x] `git diff --check`
- [x] Samsung deployment with the exact debug APK
- [x] Samsung AEC/NS capability verification: `aecAvailable=true`, `aecEnabled=true`, `nsAvailable=true`, `nsEnabled=true`
- [x] Samsung speakerphone route verification
- [x] Samsung voice exchange verification after moving playback to the built-in speaker

## Verification note

The production voice diagnostic sinks are disabled in the committed build. The Samsung capability and route diagnostics were collected during verification builds, then removed before the final quiet APK was built and installed.
