### PR TITLE
test(ui): wait for artifact preview dialog

### DIFF
--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
@@ -246,6 +246,7 @@ class HermesAppTest {
         composeRule.onNodeWithText("Play").assertIsDisplayed()
         composeRule.onNodeWithContentDescription("Filter artifacts: Image").performClick()
         composeRule.onNodeWithContentDescription("Zoom image preview.png").performClick()
+        composeRule.waitForIdle()
         composeRule.onNodeWithText("Close").assertIsDisplayed()
     }
 


### PR DESCRIPTION
Adds an explicit Compose idle wait after opening the image artifact preview before asserting the Close action. This removes a CI-only timing race in sessionDetailsSummarizeArtifactsAndOpenArtifactBrowser; no product behavior changes.