### PR TITLE
feat(settings): overhaul settings and model picker

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
@@ -355,6 +355,10 @@ internal fun HermesAppHost(
             connectionViewModel?.setProfileReasoningEffort(effort)
                 ?: Result.failure(IllegalStateException("Profile settings unavailable"))
         },
+        onSetModelReasoningOverride = { selection, effort ->
+            connectionViewModel?.setProfileModelReasoningOverride(selection, effort)
+                ?: Result.failure(IllegalStateException("Profile settings unavailable"))
+        },
         onLogout = { connectionViewModel?.logout() },
         onSignIn = onSignIn,
         onOpenProject = onOpenProject,

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
@@ -534,10 +534,36 @@ interface HermesConnectionClient {
         model: String,
     ): String? = null
 
+    /**
+     * Load every per-model reasoning override configured for [profile], resolved
+     * against the models in [options] so the picker can show each model's current
+     * effort. Keys are matched spelling-tolerantly (dots↔dashes, provider prefix).
+     */
+    suspend fun loadProfileReasoningOverrides(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+        options: ModelOptions,
+    ): Map<ModelSelection, String> = emptyMap()
+
     suspend fun setProfileReasoningEffort(
         serverOrigin: ServerOrigin,
         accessToken: String,
         profile: String,
+        effort: String,
+    ): Unit = throw UnsupportedOperationException()
+
+    /**
+     * Set (or clear) a per-model reasoning-effort override for future chats.
+     * Writes `agent.reasoning_overrides.<provider/model>` via the deep-merging
+     * `PUT /api/config`, so it preserves the global default and every other
+     * model's override. Passing effort "none" disables thinking for that model.
+     */
+    suspend fun setProfileModelReasoningOverride(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+        selection: ModelSelection,
         effort: String,
     ): Unit = throw UnsupportedOperationException()
 
@@ -1004,6 +1030,46 @@ class HttpHermesConnectionClient(
             )
     }
 
+    override suspend fun loadProfileReasoningOverrides(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+        options: ModelOptions,
+    ): Map<ModelSelection, String> {
+        val response = client.get("${serverOrigin.value}/api/config") {
+            bearerAuth(accessToken)
+            parameter("profile", profile.take(64))
+        }
+        val body = response.readBodyTextBounded()
+        if (!response.status.isSuccess()) {
+            throw HermesConnectionException("Hermes config returned HTTP ${response.status.value}")
+        }
+        val root = json.parseToJsonElement(body) as? JsonObject
+            ?: throw HermesConnectionException("Hermes config response was invalid")
+        val agent = root["agent"] as? JsonObject ?: return emptyMap()
+        val overrides = agent["reasoning_overrides"] as? JsonObject ?: return emptyMap()
+        val overrideKeys = overrides.entries.associate { (key, value) ->
+            key.trim().lowercase() to value.jsonPrimitive.contentOrNull
+        }
+        val result = LinkedHashMap<ModelSelection, String>()
+        options.providers.forEach { provider ->
+            provider.models.forEach { model ->
+                // The server keys overrides off the model string itself (which
+                // already carries its own provider prefix, e.g.
+                // "anthropic/claude-opus-5"), matched spelling-tolerantly. The
+                // portal provider slug is NOT part of the key.
+                val normalizedModel = model.trim().lowercase()
+                val candidateKeys = reasoningBareModelVariants(model) + normalizedModel
+                val raw = candidateKeys.firstNotNullOfOrNull { key -> overrideKeys[key] }
+                val canonical = canonicalProfileReasoningEffort(raw)
+                if (canonical != null) {
+                    result[ModelSelection(provider.slug, model)] = canonical
+                }
+            }
+        }
+        return result
+    }
+
     override suspend fun setProfileReasoningEffort(
         serverOrigin: ServerOrigin,
         accessToken: String,
@@ -1029,6 +1095,47 @@ class HttpHermesConnectionClient(
         response.readBodyTextBounded()
         if (!response.status.isSuccess()) {
             throw HermesConnectionException("Hermes reasoning default update returned HTTP ${response.status.value}")
+        }
+    }
+
+    override suspend fun setProfileModelReasoningOverride(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+        selection: ModelSelection,
+        effort: String,
+    ) {
+        val boundedProfile = profile.trim().takeIf { it.isNotEmpty() && it.length <= 64 }
+            ?: throw HermesConnectionException("Hermes reasoning profile is invalid")
+        val canonicalEffort = canonicalProfileReasoningEffort(effort)
+            ?: throw HermesConnectionException("Hermes reasoning effort is invalid")
+        val model = selection.model.trim().takeIf { it.isNotEmpty() && it.length <= 256 }
+            ?: throw HermesConnectionException("Hermes reasoning model is invalid")
+        // The server keys reasoning_overrides off the MODEL string itself
+        // (resolve_per_model_reasoning_effort / _canonical_model_variants), not
+        // provider/model — the model already carries its own provider prefix
+        // (e.g. "anthropic/claude-opus-5"); the selection's provider is the
+        // portal slug (e.g. "nous") and must not be prepended.
+        val overrideKey = model
+        val response = client.put("${serverOrigin.value}/api/config") {
+            bearerAuth(accessToken)
+            parameter("profile", boundedProfile)
+            contentType(ContentType.Application.Json)
+            setBody(buildJsonObject {
+                put("config", buildJsonObject {
+                    put("agent", buildJsonObject {
+                        put("reasoning_overrides", buildJsonObject {
+                            put(overrideKey, canonicalEffort)
+                        })
+                    })
+                })
+            }.toString())
+        }
+        response.readBodyTextBounded()
+        if (!response.status.isSuccess()) {
+            throw HermesConnectionException(
+                "Hermes reasoning override update returned HTTP ${response.status.value}",
+            )
         }
     }
 

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
@@ -534,6 +534,13 @@ interface HermesConnectionClient {
         model: String,
     ): String? = null
 
+    /** Load the profile-wide reasoning default without applying a model override. */
+    suspend fun loadProfileReasoningDefault(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+    ): String? = null
+
     /**
      * Load every per-model reasoning override configured for [profile], resolved
      * against the models in [options] so the picker can show each model's current
@@ -1030,6 +1037,27 @@ class HttpHermesConnectionClient(
             )
     }
 
+    override suspend fun loadProfileReasoningDefault(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+    ): String? {
+        val response = client.get("${serverOrigin.value}/api/config") {
+            bearerAuth(accessToken)
+            parameter("profile", profile.take(64))
+        }
+        val body = response.readBodyTextBounded()
+        if (!response.status.isSuccess()) {
+            throw HermesConnectionException("Hermes config returned HTTP ${response.status.value}")
+        }
+        val root = json.parseToJsonElement(body) as? JsonObject
+            ?: throw HermesConnectionException("Hermes config response was invalid")
+        val agent = root["agent"] as? JsonObject ?: return null
+        return canonicalProfileReasoningEffort(
+            agent["reasoning_effort"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+
     override suspend fun loadProfileReasoningOverrides(
         serverOrigin: ServerOrigin,
         accessToken: String,
@@ -1056,11 +1084,15 @@ class HttpHermesConnectionClient(
             provider.models.forEach { model ->
                 // The server keys overrides off the model string itself (which
                 // already carries its own provider prefix, e.g.
-                // "anthropic/claude-opus-5"), matched spelling-tolerantly. The
-                // portal provider slug is NOT part of the key.
+                // "anthropic/claude-opus-5"). For bare catalog IDs, also accept
+                // the provider-qualified spelling used by existing configs.
                 val normalizedModel = model.trim().lowercase()
-                val candidateKeys = reasoningBareModelVariants(model) + normalizedModel
-                val raw = candidateKeys.firstNotNullOfOrNull { key -> overrideKeys[key] }
+                val bareVariants = reasoningBareModelVariants(model)
+                val providerQualifiedVariants = bareVariants.map { bare ->
+                    "${provider.slug.trim().lowercase()}/$bare"
+                }
+                val candidateKeys = listOf(normalizedModel) + providerQualifiedVariants + bareVariants
+                val raw = candidateKeys.distinct().firstNotNullOfOrNull { key -> overrideKeys[key] }
                 val canonical = canonicalProfileReasoningEffort(raw)
                 if (canonical != null) {
                     result[ModelSelection(provider.slug, model)] = canonical

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -1574,6 +1574,7 @@ class HermesConnectionViewModel(
                 defaultModelOptions = null,
                 currentModelInfo = null,
                 profileReasoningEffort = null,
+                profileModelReasoningOverrides = emptyMap(),
                 managementLoading = true,
                 managementError = null,
             )
@@ -1614,6 +1615,18 @@ class HermesConnectionViewModel(
                         } catch (_: Exception) {
                             null
                         }
+                    }
+                    val profileModelReasoningOverrides = try {
+                        client.loadProfileReasoningOverrides(
+                            serverOrigin = origin,
+                            accessToken = token,
+                            profile = selected,
+                            options = options,
+                        )
+                    } catch (cancelled: CancellationException) {
+                        throw cancelled
+                    } catch (_: Exception) {
+                        emptyMap()
                     }
                     // The durable rows must belong to the profile that is about to
                     // become selected; validating a bulk-delete selection against
@@ -1678,6 +1691,7 @@ class HermesConnectionViewModel(
                         defaultModelOptions = options,
                         currentModelInfo = currentInfo?.takeIf { it.profile == selected },
                         profileReasoningEffort = profileReasoningEffort,
+                        profileModelReasoningOverrides = profileModelReasoningOverrides,
                         chatSessions = updatedChats,
                         managementLoading = false,
                     )
@@ -1792,6 +1806,42 @@ class HermesConnectionViewModel(
                 "Profile settings changed while saving reasoning default"
             }
             mutableSnapshots.value = mutableSnapshots.value.copy(profileReasoningEffort = canonicalEffort)
+            Result.success(Unit)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            Result.failure(error)
+        }
+    }
+
+    suspend fun setProfileModelReasoningOverride(
+        selection: ModelSelection,
+        effort: String,
+    ): Result<Unit> {
+        return try {
+            val canonicalEffort = canonicalReasoningEffort(effort)
+                ?: throw HermesConnectionException("Reasoning effort is invalid")
+            val origin = checkNotNull(activeOrigin) { "No Hermes server configured" }
+            val expectedGeneration = generation
+            val profile = mutableSnapshots.value.selectedProfile
+            val token = checkNotNull(accessTokenForRequest(origin, expectedGeneration)) { "Sign in required" }
+            client.setProfileModelReasoningOverride(origin, token, profile, selection, canonicalEffort)
+            currentCoroutineContext().ensureActive()
+            check(isCurrentOrigin(origin, expectedGeneration) && mutableSnapshots.value.selectedProfile == profile) {
+                "Profile settings changed while saving reasoning override"
+            }
+            val current = mutableSnapshots.value
+            val updatedOverrides = current.profileModelReasoningOverrides + (selection to canonicalEffort)
+            mutableSnapshots.value = current.copy(
+                profileModelReasoningOverrides = updatedOverrides,
+                // Keep the global summary in sync when the override targets the
+                // currently-selected default model, so the card reflects it.
+                profileReasoningEffort = if (current.defaultModelOptions?.current == selection) {
+                    canonicalEffort
+                } else {
+                    current.profileReasoningEffort
+                },
+            )
             Result.success(Unit)
         } catch (cancelled: CancellationException) {
             throw cancelled

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -1574,6 +1574,7 @@ class HermesConnectionViewModel(
                 defaultModelOptions = null,
                 currentModelInfo = null,
                 profileReasoningEffort = null,
+                profileReasoningDefault = null,
                 profileModelReasoningOverrides = emptyMap(),
                 managementLoading = true,
                 managementError = null,
@@ -1615,6 +1616,17 @@ class HermesConnectionViewModel(
                         } catch (_: Exception) {
                             null
                         }
+                    }
+                    val profileReasoningDefault = try {
+                        client.loadProfileReasoningDefault(
+                            serverOrigin = origin,
+                            accessToken = token,
+                            profile = selected,
+                        )
+                    } catch (cancelled: CancellationException) {
+                        throw cancelled
+                    } catch (_: Exception) {
+                        null
                     }
                     val profileModelReasoningOverrides = try {
                         client.loadProfileReasoningOverrides(
@@ -1691,6 +1703,7 @@ class HermesConnectionViewModel(
                         defaultModelOptions = options,
                         currentModelInfo = currentInfo?.takeIf { it.profile == selected },
                         profileReasoningEffort = profileReasoningEffort,
+                        profileReasoningDefault = profileReasoningDefault,
                         profileModelReasoningOverrides = profileModelReasoningOverrides,
                         chatSessions = updatedChats,
                         managementLoading = false,
@@ -1805,7 +1818,15 @@ class HermesConnectionViewModel(
             check(isCurrentOrigin(origin, expectedGeneration) && mutableSnapshots.value.selectedProfile == profile) {
                 "Profile settings changed while saving reasoning default"
             }
-            mutableSnapshots.value = mutableSnapshots.value.copy(profileReasoningEffort = canonicalEffort)
+            val current = mutableSnapshots.value
+            val currentSelection = current.defaultModelOptions?.current
+            val effectiveCurrentEffort = currentSelection
+                ?.let { current.profileModelReasoningOverrides[it] }
+                ?: canonicalEffort
+            mutableSnapshots.value = current.copy(
+                profileReasoningDefault = canonicalEffort,
+                profileReasoningEffort = effectiveCurrentEffort,
+            )
             Result.success(Unit)
         } catch (cancelled: CancellationException) {
             throw cancelled

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesGateway.kt
@@ -141,6 +141,9 @@ data class HermesGatewaySnapshot(
     val defaultModelOptions: ModelOptions? = null,
     val currentModelInfo: CurrentModelInfo? = null,
     val profileReasoningEffort: String? = null,
+    /** Per-model reasoning effort overrides for the selected profile, keyed by
+     *  the picker's ModelSelection. Empty when none are configured. */
+    val profileModelReasoningOverrides: Map<ModelSelection, String> = emptyMap(),
     val managementLoading: Boolean = false,
     val managementError: String? = null,
     val searchQuery: String = "",

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesGateway.kt
@@ -140,7 +140,10 @@ data class HermesGatewaySnapshot(
     val selectedProfile: String = "default",
     val defaultModelOptions: ModelOptions? = null,
     val currentModelInfo: CurrentModelInfo? = null,
+    /** Effective effort for the selected model, including its override when present. */
     val profileReasoningEffort: String? = null,
+    /** Profile-wide fallback used by models without a per-model override. */
+    val profileReasoningDefault: String? = null,
     /** Per-model reasoning effort overrides for the selected profile, keyed by
      *  the picker's ModelSelection. Empty when none are configured. */
     val profileModelReasoningOverrides: Map<ModelSelection, String> = emptyMap(),

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/navigation/Routes.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/navigation/Routes.kt
@@ -18,5 +18,32 @@ data class ProjectRoute(val projectId: ProjectId) : NavKey
 @Serializable
 data object ServerSettingsRoute : NavKey
 
+/**
+ * Settings sub-section destinations. [ServerSettingsRoute] is the hub; each of
+ * these is pushed onto the same back stack and rendered in the detail pane so
+ * compact windows get native push/pop and Back, and expanded windows keep the
+ * adaptive list/detail behaviour.
+ */
+@Serializable
+data object SettingsServersRoute : NavKey
+
+@Serializable
+data object SettingsConnectionRoute : NavKey
+
+@Serializable
+data object SettingsModelRoute : NavKey
+
+@Serializable
+data object SettingsVoiceRoute : NavKey
+
+@Serializable
+data object SettingsOfflineRoute : NavKey
+
+@Serializable
+data object SettingsJobsRoute : NavKey
+
+@Serializable
+data object SettingsAccountRoute : NavKey
+
 @Serializable
 data class SessionDetailRoute(val durableSessionId: DurableSessionId) : NavKey

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
@@ -4131,7 +4131,7 @@ internal fun ServerSettingsScreen(
             current = scopedModelOptions?.current,
             recents = recentModels,
             reasoningOverrides = snapshot.profileModelReasoningOverrides,
-            profileDefaultEffort = snapshot.profileReasoningEffort,
+            profileDefaultEffort = snapshot.profileReasoningDefault,
             query = modelQuery,
             onQueryChange = { modelQuery = it.take(128) },
             onDismiss = { modelPickerOpen = false },

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
@@ -80,6 +80,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
 
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -126,6 +127,7 @@ import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
 import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.ArrowUpward
 import androidx.compose.material.icons.outlined.Check
@@ -150,6 +152,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -229,7 +232,6 @@ import com.unsupportedpastels.hermesandroid.voice.ComposerVoiceConversation
 import com.unsupportedpastels.hermesandroid.voice.VoiceSettings
 import com.unsupportedpastels.hermesandroid.voice.VoiceSettingsSection
 import com.unsupportedpastels.hermesandroid.voice.MessageReadAloud
-import com.unsupportedpastels.hermesandroid.voice.MessageSpeakerButton
 import com.unsupportedpastels.hermesandroid.voice.VoiceConversationBar
 import com.unsupportedpastels.hermesandroid.voice.VoiceConversationState
 import com.unsupportedpastels.hermesandroid.voice.VoiceConversationToggleButton
@@ -257,6 +259,7 @@ import com.unsupportedpastels.hermesandroid.gateway.CronJobAction
 import com.unsupportedpastels.hermesandroid.gateway.HermesGatewaySnapshot
 import com.unsupportedpastels.hermesandroid.gateway.HostDirectoryListing
 import com.unsupportedpastels.hermesandroid.gateway.ModelProviderOption
+import com.unsupportedpastels.hermesandroid.gateway.ModelOptions
 import com.unsupportedpastels.hermesandroid.gateway.ModelSelection
 import com.unsupportedpastels.hermesandroid.gateway.ModelSwitchResult
 import com.unsupportedpastels.hermesandroid.gateway.RuntimeAccess
@@ -269,6 +272,13 @@ import com.unsupportedpastels.hermesandroid.navigation.HomeRoute
 import com.unsupportedpastels.hermesandroid.navigation.ProjectRoute
 import com.unsupportedpastels.hermesandroid.navigation.SessionDetailRoute
 import com.unsupportedpastels.hermesandroid.navigation.ServerSettingsRoute
+import com.unsupportedpastels.hermesandroid.navigation.SettingsServersRoute
+import com.unsupportedpastels.hermesandroid.navigation.SettingsConnectionRoute
+import com.unsupportedpastels.hermesandroid.navigation.SettingsModelRoute
+import com.unsupportedpastels.hermesandroid.navigation.SettingsVoiceRoute
+import com.unsupportedpastels.hermesandroid.navigation.SettingsOfflineRoute
+import com.unsupportedpastels.hermesandroid.navigation.SettingsJobsRoute
+import com.unsupportedpastels.hermesandroid.navigation.SettingsAccountRoute
 import com.unsupportedpastels.hermesandroid.session.SavedSessionFilter
 import com.unsupportedpastels.hermesandroid.session.SessionListFilter
 import com.unsupportedpastels.hermesandroid.share.SharePayload
@@ -360,6 +370,7 @@ fun HermesApp(
         ModelSwitchResult(accepted = false)
     },
     onSetProfileReasoningEffort: suspend (String) -> Result<Unit> = { Result.success(Unit) },
+    onSetModelReasoningOverride: suspend (ModelSelection, String) -> Result<Unit> = { _, _ -> Result.success(Unit) },
     onLogout: suspend () -> Unit = {},
     onSignIn: () -> Unit = {},
     onOpenProject: (ProjectId) -> Unit = {},
@@ -637,6 +648,20 @@ fun HermesApp(
         backStack.add(ServerSettingsRoute)
         Unit
     }
+    val openSettingsSection = { section: SettingsSection ->
+        backStack.add(
+            when (section) {
+                SettingsSection.Servers -> SettingsServersRoute
+                SettingsSection.Connection -> SettingsConnectionRoute
+                SettingsSection.Model -> SettingsModelRoute
+                SettingsSection.Voice -> SettingsVoiceRoute
+                SettingsSection.Offline -> SettingsOfflineRoute
+                SettingsSection.Jobs -> SettingsJobsRoute
+                SettingsSection.Account -> SettingsAccountRoute
+            },
+        )
+        Unit
+    }
     val navigateHome = {
         while (backStack.size > 1) backStack.removeLastOrNull()
         Unit
@@ -645,7 +670,7 @@ fun HermesApp(
         if (observedServerOrigin != serverOrigin) {
             while (
                 backStack.size > 1 &&
-                backStack.lastOrNull() !is ServerSettingsRoute
+                !backStack.lastOrNull().isSettingsRoute()
             ) {
                 backStack.removeLastOrNull()
             }
@@ -703,7 +728,7 @@ fun HermesApp(
                     selectedProjectId = selectedProjectId,
                     projectIcons = projectIcons,
                     canStartNewTask = snapshot.authenticationState == AuthenticationState.Authenticated,
-                    settingsSelected = backStack.lastOrNull() is ServerSettingsRoute,
+                    settingsSelected = backStack.lastOrNull().isSettingsRoute(),
                     onProjectSelected = navigateToProject,
                     onChooseProjectIcon = { iconPickerProjectId = it.value },
                     onCreateProject = { projectCreatorOpen = true },
@@ -728,6 +753,44 @@ fun HermesApp(
                         projectDockState = ProjectDockState.Hidden
                         onProjectDockStateChanged(ProjectDockState.Hidden)
                     },
+                )
+            }
+            val renderSettingsSection: @Composable (SettingsSection) -> Unit = { section ->
+                // During first-time setup the catalog is empty and the hub only
+                // offers Servers, so a successful save or Back should land on Home
+                // rather than an otherwise-empty settings hub.
+                val sectionBack =
+                    if (section == SettingsSection.Servers && effectiveServerCatalog.entries.isEmpty()) {
+                        navigateHome
+                    } else {
+                        navigateBack
+                    }
+                ServerSettingsScreen(
+                    serverOrigin = serverOrigin,
+                    serverCatalog = effectiveServerCatalog,
+                    snapshot = snapshot,
+                    showBack = !supportsListDetail,
+                    onBack = sectionBack,
+                    onSave = onSaveServerOrigin,
+                    onSaveEntry = saveServerEntry,
+                    onUpdateServerLabel = updateServerLabel,
+                    onSelectServer = onSelectServerOrigin,
+                    onRemoveServer = onRemoveServerOrigin,
+                    transcriptCachingEnabled = transcriptCachingEnabled,
+                    onTranscriptCachingChanged = onTranscriptCachingChanged,
+                    onClearOfflineCache = onClearOfflineCache,
+                    onLoadManagementSettings = onLoadManagementSettings,
+                    onSetProfileDefaultModel = onSetProfileDefaultModel,
+                    onSetProfileReasoningEffort = onSetProfileReasoningEffort,
+                    onSetModelReasoningOverride = onSetModelReasoningOverride,
+                    voiceSettings = voiceSettings,
+                    onRefreshCronJobs = onRefreshCronJobs,
+                    onCronJobAction = onCronJobAction,
+                    onRunCronJob = onRunCronJob,
+                    onToggleCronJobRuns = onToggleCronJobRuns,
+                    onLogout = onLogout,
+                    visibleSections = setOf(section),
+                    title = section.title,
                 )
             }
             Box(
@@ -981,32 +1044,43 @@ fun HermesApp(
                 }
             }
             entry<ServerSettingsRoute>(
-                metadata = ListDetailSceneStrategy.detailPane(),
+                metadata = ListDetailSceneStrategy.listPane(
+                    detailPlaceholder = { SessionPlaceholder() },
+                ) + ListDetailSceneStrategy.preferredPaneSize(width = 0.4f),
             ) {
-                ServerSettingsScreen(
-                    serverOrigin = serverOrigin,
-                    serverCatalog = effectiveServerCatalog,
-                    snapshot = snapshot,
+                val authed = snapshot.authenticationState == AuthenticationState.Authenticated
+                val available = if (authed) {
+                    SettingsSection.entries.toSet()
+                } else {
+                    setOf(SettingsSection.Servers)
+                }
+                SettingsHubScreen(
+                    availableSections = available,
                     showBack = !supportsListDetail,
                     onBack = navigateBack,
-                    onSave = onSaveServerOrigin,
-                    onSaveEntry = saveServerEntry,
-                    onUpdateServerLabel = updateServerLabel,
-                    onSelectServer = onSelectServerOrigin,
-                    onRemoveServer = onRemoveServerOrigin,
-                    transcriptCachingEnabled = transcriptCachingEnabled,
-                    onTranscriptCachingChanged = onTranscriptCachingChanged,
-                    onClearOfflineCache = onClearOfflineCache,
-                    onLoadManagementSettings = onLoadManagementSettings,
-                    onSetProfileDefaultModel = onSetProfileDefaultModel,
-                    onSetProfileReasoningEffort = onSetProfileReasoningEffort,
-                    voiceSettings = voiceSettings,
-                    onRefreshCronJobs = onRefreshCronJobs,
-                    onCronJobAction = onCronJobAction,
-                    onRunCronJob = onRunCronJob,
-                    onToggleCronJobRuns = onToggleCronJobRuns,
-                    onLogout = onLogout,
+                    onOpenSection = openSettingsSection,
                 )
+            }
+            entry<SettingsServersRoute>(metadata = ListDetailSceneStrategy.detailPane()) {
+                renderSettingsSection(SettingsSection.Servers)
+            }
+            entry<SettingsConnectionRoute>(metadata = ListDetailSceneStrategy.detailPane()) {
+                renderSettingsSection(SettingsSection.Connection)
+            }
+            entry<SettingsModelRoute>(metadata = ListDetailSceneStrategy.detailPane()) {
+                renderSettingsSection(SettingsSection.Model)
+            }
+            entry<SettingsVoiceRoute>(metadata = ListDetailSceneStrategy.detailPane()) {
+                renderSettingsSection(SettingsSection.Voice)
+            }
+            entry<SettingsOfflineRoute>(metadata = ListDetailSceneStrategy.detailPane()) {
+                renderSettingsSection(SettingsSection.Offline)
+            }
+            entry<SettingsJobsRoute>(metadata = ListDetailSceneStrategy.detailPane()) {
+                renderSettingsSection(SettingsSection.Jobs)
+            }
+            entry<SettingsAccountRoute>(metadata = ListDetailSceneStrategy.detailPane()) {
+                renderSettingsSection(SettingsSection.Account)
             }
             },
                 )
@@ -3475,6 +3549,94 @@ private fun MissingProjectScreen() {
     }
 }
 
+/**
+ * The distinct areas of the settings surface. Each maps to a hub row and a
+ * section route so the settings screen renders one focused area at a time
+ * instead of a single long scroll.
+ */
+internal enum class SettingsSection(val title: String, val summary: String) {
+    Servers("Servers", "Add, switch, or remove Hermes servers"),
+    Connection("Connection & profile", "Version, sign-in, and active profile"),
+    Model("Default model", "Model and reasoning for new chats"),
+    Voice("Voice", "Dictation and hands-free conversation"),
+    Offline("Offline & privacy", "Save conversations for offline reading"),
+    Jobs("Scheduled jobs", "Cron jobs running on this server"),
+    Account("Account", "Sign out of this server"),
+}
+
+/** True for the settings hub or any of its section routes. */
+private fun NavKey?.isSettingsRoute(): Boolean = when (this) {
+    ServerSettingsRoute,
+    SettingsServersRoute,
+    SettingsConnectionRoute,
+    SettingsModelRoute,
+    SettingsVoiceRoute,
+    SettingsOfflineRoute,
+    SettingsJobsRoute,
+    SettingsAccountRoute,
+    -> true
+    else -> false
+}
+
+/**
+ * Settings landing: a compact list of sections instead of one giant scroll.
+ * Each row navigates to its own section route; [availableSections] hides rows
+ * (Connection/Model/Voice/Offline/Jobs/Account) that require an authenticated
+ * connection.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SettingsHubScreen(
+    availableSections: Set<SettingsSection>,
+    showBack: Boolean,
+    onBack: () -> Unit,
+    onOpenSection: (SettingsSection) -> Unit,
+) {
+    Scaffold(
+        contentWindowInsets = WindowInsets.safeDrawing,
+        topBar = {
+            TopAppBar(
+                title = { Text("Settings") },
+                navigationIcon = {
+                    if (showBack) {
+                        TextButton(onClick = dropUnlessResumed { onBack() }) { Text("Back") }
+                    }
+                },
+                actions = {
+                    if (!showBack) {
+                        TextButton(onClick = dropUnlessResumed { onBack() }) { Text("Close") }
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .consumeWindowInsets(innerPadding)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            SettingsSection.entries
+                .filter { it in availableSections }
+                .forEach { section ->
+                    ListItem(
+                        headlineContent = { Text(section.title) },
+                        supportingContent = { Text(section.summary) },
+                        trailingContent = {
+                            Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null)
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onOpenSection(section) }
+                            .semantics { contentDescription = "Open ${section.title} settings" },
+                    )
+                    HorizontalDivider()
+                }
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 internal fun ServerSettingsScreen(
@@ -3498,12 +3660,15 @@ internal fun ServerSettingsScreen(
         ModelSwitchResult(accepted = false)
     },
     onSetProfileReasoningEffort: suspend (String) -> Result<Unit> = { Result.success(Unit) },
+    onSetModelReasoningOverride: suspend (ModelSelection, String) -> Result<Unit> = { _, _ -> Result.success(Unit) },
     onRefreshCronJobs: () -> Unit = {},
     onCronJobAction: (String, CronJobAction) -> Unit = { _, _ -> },
     onRunCronJob: (String) -> Unit = {},
     onToggleCronJobRuns: (String) -> Unit = {},
     onLogout: suspend () -> Unit = {},
     voiceSettings: VoiceSettings? = null,
+    visibleSections: Set<SettingsSection> = SettingsSection.entries.toSet(),
+    title: String = "Hermes server",
 ) {
     var value by rememberSaveable(serverOrigin?.value) {
         mutableStateOf(serverOrigin?.value.orEmpty())
@@ -3518,10 +3683,17 @@ internal fun ServerSettingsScreen(
     val coroutineScope = rememberCoroutineScope()
     var modelQuery by rememberSaveable { mutableStateOf("") }
     var pendingExpensive by remember { mutableStateOf<ModelSelection?>(null) }
-    var pendingDefault by remember { mutableStateOf<ModelSelection?>(null) }
-    var pendingProfileReasoning by remember { mutableStateOf<String?>(null) }
-    var profileReasoningMenuOpen by remember { mutableStateOf(false) }
-    var profileReasoningSaveError by remember { mutableStateOf<String?>(null) }
+    var modelPickerOpen by rememberSaveable { mutableStateOf(false) }
+    var recentModels by rememberSaveable(
+        stateSaver = listSaver(
+            save = { it.flatMap { sel -> listOf(sel.provider, sel.model) } },
+            restore = { flat ->
+                flat.chunked(2).mapNotNull { pair ->
+                    pair.takeIf { it.size == 2 }?.let { ModelSelection(it[0], it[1]) }
+                }
+            },
+        ),
+    ) { mutableStateOf(emptyList<ModelSelection>()) }
     var expensiveMessage by remember { mutableStateOf<String?>(null) }
     LaunchedEffect(serverOrigin, snapshot.authenticationState) {
         if (serverOrigin != null && snapshot.authenticationState == AuthenticationState.Authenticated) {
@@ -3546,7 +3718,7 @@ internal fun ServerSettingsScreen(
         contentWindowInsets = WindowInsets.safeDrawing,
         topBar = {
             TopAppBar(
-                title = { Text("Hermes server") },
+                title = { Text(title) },
                 navigationIcon = {
                     if (showBack) {
                         TextButton(
@@ -3586,363 +3758,332 @@ internal fun ServerSettingsScreen(
                     .padding(horizontal = 24.dp, vertical = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                Text("Servers", style = MaterialTheme.typography.titleMedium)
-                if (serverCatalog.entries.isEmpty()) {
-                    Text(
-                        "Add a Hermes server to get started.",
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                } else {
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        serverCatalog.entries.forEach { entry ->
-                            val selected = entry.origin == serverCatalog.activeOrigin
-                            ListItem(
-                                headlineContent = {
-                                    Text(
-                                        entry.displayLabel,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
-                                },
-                                supportingContent = {
-                                    Text(
-                                        entry.origin.value,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
-                                },
-                                trailingContent = {
-                                    Row(verticalAlignment = Alignment.CenterVertically) {
-                                        TextButton(
-                                            onClick = {
-                                                editingOrigin = entry.origin
-                                                value = entry.origin.value
-                                                label = entry.label
-                                                saveError = null
-                                            },
-                                            modifier = Modifier.semantics {
-                                                contentDescription = "Edit ${entry.origin.value}"
-                                            },
-                                        ) {
-                                            Text("Edit")
-                                        }
-                                        IconButton(
-                                            onClick = { pendingRemoval = entry },
-                                            enabled = !selected,
-                                            modifier = Modifier.semantics {
-                                                contentDescription = "Remove ${entry.origin.value}"
-                                            },
-                                        ) {
-                                            Icon(Icons.Outlined.Delete, contentDescription = null)
-                                        }
-                                    }
-                                },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .semantics {
-                                        this.selected = selected
-                                        contentDescription = if (selected) {
-                                            "Selected ${entry.origin.value}"
-                                        } else {
-                                            "Select ${entry.origin.value}"
-                                        }
-                                    }
-                                    .clickable(enabled = !selected) {
-                                        coroutineScope.launch {
-                                            val result = onSelectServer(entry.origin)
-                                            if (result.isFailure) {
-                                                saveError = "Could not switch server. Try again."
+                if (SettingsSection.Servers in visibleSections) {
+                    Text("Servers", style = MaterialTheme.typography.titleMedium)
+                    if (serverCatalog.entries.isEmpty()) {
+                        Text(
+                            "Add a Hermes server to get started.",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    } else {
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            serverCatalog.entries.forEach { entry ->
+                                val selected = entry.origin == serverCatalog.activeOrigin
+                                ListItem(
+                                    headlineContent = {
+                                        Text(
+                                            entry.displayLabel,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                    },
+                                    supportingContent = {
+                                        Text(
+                                            entry.origin.value,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                    },
+                                    trailingContent = {
+                                        Row(verticalAlignment = Alignment.CenterVertically) {
+                                            TextButton(
+                                                onClick = {
+                                                    editingOrigin = entry.origin
+                                                    value = entry.origin.value
+                                                    label = entry.label
+                                                    saveError = null
+                                                },
+                                                modifier = Modifier.semantics {
+                                                    contentDescription = "Edit ${entry.origin.value}"
+                                                },
+                                            ) {
+                                                Text("Edit")
+                                            }
+                                            IconButton(
+                                                onClick = { pendingRemoval = entry },
+                                                enabled = !selected,
+                                                modifier = Modifier.semantics {
+                                                    contentDescription = "Remove ${entry.origin.value}"
+                                                },
+                                            ) {
+                                                Icon(Icons.Outlined.Delete, contentDescription = null)
                                             }
                                         }
                                     },
-                            )
-                            if (selected) {
-                                Text(
-                                    "Active server",
-                                    color = MaterialTheme.colorScheme.primary,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    modifier = Modifier.padding(start = 16.dp),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .semantics {
+                                            this.selected = selected
+                                            contentDescription = if (selected) {
+                                                "Selected ${entry.origin.value}"
+                                            } else {
+                                                "Select ${entry.origin.value}"
+                                            }
+                                        }
+                                        .clickable(enabled = !selected) {
+                                            coroutineScope.launch {
+                                                val result = onSelectServer(entry.origin)
+                                                if (result.isFailure) {
+                                                    saveError = "Could not switch server. Try again."
+                                                }
+                                            }
+                                        },
                                 )
+                                if (selected) {
+                                    Text(
+                                        "Active server",
+                                        color = MaterialTheme.colorScheme.primary,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        modifier = Modifier.padding(start = 16.dp),
+                                    )
+                                }
                             }
                         }
                     }
-                }
-                if (serverCatalog.entries.isNotEmpty()) {
-                    TextButton(
-                        onClick = {
-                            editingOrigin = null
-                            value = ""
-                            label = ""
+                    if (serverCatalog.entries.isNotEmpty()) {
+                        TextButton(
+                            onClick = {
+                                editingOrigin = null
+                                value = ""
+                                label = ""
+                                saveError = null
+                            },
+                            enabled = !isSaving,
+                        ) {
+                            Text("Add server")
+                        }
+                    }
+                    Text(
+                        if (editingOrigin == null) "Add a server or edit its local label." else "Edit server label",
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        "Enter the HTTP or HTTPS origin of your unchanged Hermes Serve instance.",
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    OutlinedTextField(
+                        value = value,
+                        onValueChange = {
+                            value = it
                             saveError = null
                         },
-                        enabled = !isSaving,
-                    ) {
-                        Text("Add server")
-                    }
-                }
-                Text(
-                    if (editingOrigin == null) "Add a server or edit its local label." else "Edit server label",
-                    style = MaterialTheme.typography.bodyLarge,
-                )
-                Text(
-                    "Enter the HTTP or HTTPS origin of your unchanged Hermes Serve instance.",
-                    style = MaterialTheme.typography.bodyLarge,
-                )
-                OutlinedTextField(
-                    value = value,
-                    onValueChange = {
-                        value = it
-                        saveError = null
-                    },
-                    label = { Text("Server origin") },
-                    supportingText = {
-                        Text(
-                            validationMessage
-                                ?: "HTTP or HTTPS origin only — no path, credentials, query, or ticket.",
-                        )
-                    },
-                    isError = validationMessage != null,
-                    enabled = !isSaving && editingOrigin == null,
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .semantics { contentDescription = "Server origin input" },
-                )
-                OutlinedTextField(
-                    value = label,
-                    onValueChange = {
-                        label = it.take(MAX_SERVER_LABEL_CHARS)
-                        saveError = null
-                    },
-                    label = { Text("Display label (optional)") },
-                    supportingText = { Text("Stored only on this device") },
-                    enabled = !isSaving,
-                    singleLine = true,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .semantics { contentDescription = "Display label input" },
-                )
-                saveError?.let { message ->
-                    Text(
-                        message,
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Button(
-                        enabled = parsedOrigin != null && !isSaving,
-                        onClick = {
-                            val origin = editingOrigin ?: parsedOrigin ?: return@Button
-                            val entry = runCatching {
-                                ServerCatalogEntry(origin = origin, label = label.trim())
-                            }.getOrElse {
-                                saveError = "That server label is not valid."
-                                return@Button
-                            }
-                            coroutineScope.launch {
-                                isSaving = true
-                                saveError = null
-                                val result = if (editingOrigin != null) {
-                                    onUpdateServerLabel(entry)
-                                } else {
-                                    onSaveEntry(entry)
-                                }
-                                isSaving = false
-                                if (result.isSuccess) {
-                                    if (serverCatalog.entries.isEmpty()) {
-                                        onBack()
-                                    } else {
-                                        editingOrigin = null
-                                        value = ""
-                                        label = ""
-                                    }
-                                } else {
-                                    saveError = "Could not save server. Try again."
-                                }
-                            }
+                        label = { Text("Server origin") },
+                        supportingText = {
+                            Text(
+                                validationMessage
+                                    ?: "HTTP or HTTPS origin only — no path, credentials, query, or ticket.",
+                            )
                         },
-                    ) {
-                        Text(if (isSaving) "Saving…" else "Save")
-                    }
-                    TextButton(
+                        isError = validationMessage != null,
+                        enabled = !isSaving && editingOrigin == null,
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .semantics { contentDescription = "Server origin input" },
+                    )
+                    OutlinedTextField(
+                        value = label,
+                        onValueChange = {
+                            label = it.take(MAX_SERVER_LABEL_CHARS)
+                            saveError = null
+                        },
+                        label = { Text("Display label (optional)") },
+                        supportingText = { Text("Stored only on this device") },
                         enabled = !isSaving,
-                        onClick = dropUnlessResumed { onBack() },
-                    ) {
-                        Text("Cancel")
+                        singleLine = true,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .semantics { contentDescription = "Display label input" },
+                    )
+                    saveError?.let { message ->
+                        Text(
+                            message,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(
+                            enabled = parsedOrigin != null && !isSaving,
+                            onClick = {
+                                val origin = editingOrigin ?: parsedOrigin ?: return@Button
+                                val entry = runCatching {
+                                    ServerCatalogEntry(origin = origin, label = label.trim())
+                                }.getOrElse {
+                                    saveError = "That server label is not valid."
+                                    return@Button
+                                }
+                                coroutineScope.launch {
+                                    isSaving = true
+                                    saveError = null
+                                    val result = if (editingOrigin != null) {
+                                        onUpdateServerLabel(entry)
+                                    } else {
+                                        onSaveEntry(entry)
+                                    }
+                                    isSaving = false
+                                    if (result.isSuccess) {
+                                        if (serverCatalog.entries.isEmpty()) {
+                                            onBack()
+                                        } else {
+                                            editingOrigin = null
+                                            value = ""
+                                            label = ""
+                                        }
+                                    } else {
+                                        saveError = "Could not save server. Try again."
+                                    }
+                                }
+                            },
+                        ) {
+                            Text(if (isSaving) "Saving…" else "Save")
+                        }
+                        TextButton(
+                            enabled = !isSaving,
+                            onClick = dropUnlessResumed { onBack() },
+                        ) {
+                            Text("Cancel")
+                        }
                     }
                 }
-                HorizontalDivider()
-                OperationalOverviewItem(
-                    snapshot = snapshot,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                if (snapshot.authenticationState == AuthenticationState.Authenticated) {
+                if (SettingsSection.Connection in visibleSections) {
                     HorizontalDivider()
-                    Text("Connection", style = MaterialTheme.typography.titleMedium)
-                    Text("Hermes ${snapshot.serverVersion ?: "unknown"} · Authenticated")
-                    if (snapshot.profiles.isNotEmpty()) {
-                        Text("Profile", style = MaterialTheme.typography.labelLarge)
-                        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            snapshot.profiles.forEach { profile ->
-                                FilterChip(
-                                    selected = profile == snapshot.selectedProfile,
-                                    onClick = { onLoadManagementSettings(profile) },
-                                    label = { Text(profile) },
-                                )
+                    OperationalOverviewItem(
+                        snapshot = snapshot,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    if (snapshot.authenticationState == AuthenticationState.Authenticated) {
+                        HorizontalDivider()
+                        Text("Connection", style = MaterialTheme.typography.titleMedium)
+                        Text("Hermes ${snapshot.serverVersion ?: "unknown"} · Authenticated")
+                        if (snapshot.profiles.isNotEmpty()) {
+                            Text("Profile", style = MaterialTheme.typography.labelLarge)
+                            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                snapshot.profiles.forEach { profile ->
+                                    FilterChip(
+                                        selected = profile == snapshot.selectedProfile,
+                                        onClick = { onLoadManagementSettings(profile) },
+                                        label = { Text(profile) },
+                                    )
+                                }
                             }
                         }
                     }
+                }
+                if (snapshot.authenticationState == AuthenticationState.Authenticated) {
                     val scopedModelOptions = snapshot.defaultModelOptions
                         ?.takeIf { it.profile == snapshot.selectedProfile }
                     val scopedCurrentModelInfo = snapshot.currentModelInfo
                         ?.takeIf { it.profile == snapshot.selectedProfile }
-                    scopedCurrentModelInfo?.let { info ->
-                        Text("Current profile model", style = MaterialTheme.typography.titleMedium)
-                        val currentLabel = listOfNotNull(info.provider, info.model).joinToString(" / ")
-                        if (currentLabel.isNotBlank()) Text(currentLabel)
-                        info.effectiveContextLength?.let { length ->
-                            Text("Effective context: $length tokens")
-                        }
-                    }
-                    Text("Default model for new chats", style = MaterialTheme.typography.titleMedium)
-                    scopedModelOptions?.current?.let { current ->
-                        Text("${current.provider} / ${current.model}")
-                    }
-                    OutlinedTextField(
-                        value = modelQuery,
-                        onValueChange = { modelQuery = it.take(128) },
-                        label = { Text("Search profile models") },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        scopedModelOptions?.providers.orEmpty().forEach { provider ->
-                            provider.models
-                                .filter { modelQuery.isBlank() || it.contains(modelQuery.trim(), ignoreCase = true) }
-                                .take(8)
-                                .forEach { model ->
-                                    val selection = ModelSelection(provider.slug, model)
-                                    FilterChip(
-                                        selected = pendingDefault == selection,
-                                        onClick = { pendingDefault = selection },
-                                        label = { Text("${provider.name} · $model") },
-                                    )
-                                }
-                        }
-                    }
-                    pendingDefault?.let { selection ->
-                        Button(onClick = {
-                            coroutineScope.launch {
-                                val result = onSetProfileDefaultModel(selection, false)
-                                if (result.confirmationRequired) {
-                                    pendingExpensive = selection
-                                    expensiveMessage = result.confirmationMessage
-                                } else if (result.accepted) {
-                                    pendingDefault = null
-                                }
+                    if (SettingsSection.Model in visibleSections) {
+                        scopedCurrentModelInfo?.let { info ->
+                            Text("Current profile model", style = MaterialTheme.typography.titleMedium)
+                            val currentLabel = listOfNotNull(info.provider, info.model).joinToString(" / ")
+                            if (currentLabel.isNotBlank()) Text(currentLabel)
+                            info.effectiveContextLength?.let { length ->
+                                Text("Effective context: $length tokens")
                             }
-                        }) { Text("Set default") }
-                    }
-                    val reasoningCapabilityAvailable = scopedCurrentModelInfo?.capabilities?.reasoning == true
-                    if (reasoningCapabilityAvailable) {
-                        Text("Reasoning default for future chats", style = MaterialTheme.typography.titleMedium)
-                        Text(
-                            "This changes future chats only; it does not change the active runtime.",
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            style = MaterialTheme.typography.bodySmall,
-                        )
-                        val reasoningLabel = pendingProfileReasoning
-                            ?: snapshot.profileReasoningEffort
-                            ?: "Provider default"
-                        Box {
-                            AssistChip(
-                                onClick = { profileReasoningMenuOpen = true },
-                                label = { Text(reasoningLabel) },
-                                modifier = Modifier.semantics {
-                                    contentDescription = "Choose future chat reasoning default"
-                                },
-                            )
-                            DropdownMenu(
-                                expanded = profileReasoningMenuOpen,
-                                onDismissRequest = { profileReasoningMenuOpen = false },
+                        }
+                        Text("Default model for new chats", style = MaterialTheme.typography.titleMedium)
+                        val currentDefault = scopedModelOptions?.current
+                        val currentDefaultCaps = scopedModelOptions?.capabilitiesFor(currentDefault)
+                        ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
-                                ValidReasoningEfforts.forEach { effort ->
-                                    DropdownMenuItem(
-                                        text = { Text(effort) },
-                                        onClick = {
-                                            pendingProfileReasoning = effort
-                                            profileReasoningMenuOpen = false
-                                            profileReasoningSaveError = null
-                                        },
+                                if (currentDefault != null) {
+                                    val providerName = scopedModelOptions.providers
+                                        .firstOrNull { it.slug == currentDefault.provider }
+                                        ?.name
+                                        ?: currentDefault.provider
+                                    Text(currentDefault.model, style = MaterialTheme.typography.titleMedium)
+                                    Text(
+                                        providerName,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
-                                }
-                            }
-                        }
-                        pendingProfileReasoning?.let { effort ->
-                            Button(
-                                onClick = {
-                                    coroutineScope.launch {
-                                        val result = onSetProfileReasoningEffort(effort)
-                                        if (result.isSuccess) {
-                                            pendingProfileReasoning = null
-                                            profileReasoningSaveError = null
-                                        } else {
-                                            profileReasoningSaveError =
-                                                "Could not save the future-chat reasoning default."
+                                    val caps = currentDefaultCaps?.let(::modelCapabilityLabels).orEmpty()
+                                    if (caps.isNotEmpty()) {
+                                        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                            caps.forEach { CapabilityBadge(it) }
                                         }
                                     }
-                                },
-                                modifier = Modifier.semantics {
-                                    contentDescription = "Save future chat reasoning default"
-                                },
-                            ) {
-                                Text("Set reasoning default")
+                                } else {
+                                    Text(
+                                        "No default model selected",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                                Button(
+                                    onClick = {
+                                        modelQuery = ""
+                                        modelPickerOpen = true
+                                    },
+                                    modifier = Modifier.semantics {
+                                        contentDescription = "Change default model"
+                                    },
+                                ) {
+                                    Text("Change model")
+                                }
                             }
                         }
-                        profileReasoningSaveError?.let { error ->
-                            Text(error, color = MaterialTheme.colorScheme.error)
+                    }
+                    if (SettingsSection.Voice in visibleSections) {
+                        voiceSettings?.let { settings ->
+                            VoiceSettingsSection(settings)
                         }
                     }
-                    voiceSettings?.let { settings ->
-                        VoiceSettingsSection(settings)
+                    if (SettingsSection.Offline in visibleSections) {
+                        Text("Offline & privacy", style = MaterialTheme.typography.titleMedium)
+                        Text(
+                            "Session titles are always kept so your list works offline. " +
+                                "Turn this on to also save recent conversations — encrypted on this " +
+                                "device — so you can read them without a connection. Off by default.",
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text("Save conversations for offline reading")
+                            Switch(
+                                checked = transcriptCachingEnabled,
+                                onCheckedChange = onTranscriptCachingChanged,
+                                modifier = Modifier.semantics {
+                                    contentDescription = "Save conversations for offline reading"
+                                },
+                            )
+                        }
+                        TextButton(onClick = onClearOfflineCache) { Text("Clear offline cache") }
                     }
-                    Text("Offline cache", style = MaterialTheme.typography.titleMedium)
-                    Text(
-                        "Session metadata is cached by default. Transcript tails are encrypted and opt-in.",
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text("Cache transcript tails")
-                        Switch(
-                            checked = transcriptCachingEnabled,
-                            onCheckedChange = onTranscriptCachingChanged,
+                    if (SettingsSection.Account in visibleSections) {
+                        TextButton(onClick = { coroutineScope.launch { onLogout() } }) { Text("Log out") }
+                        snapshot.managementError?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+                    }
+                    if (SettingsSection.Jobs in visibleSections) {
+                        CronJobsPanel(
+                            state = snapshot.cronJobsState,
+                            onRefresh = onRefreshCronJobs,
+                            actionJobId = snapshot.cronJobActionJobId,
+                            actionError = snapshot.cronJobActionError,
+                            onJobAction = onCronJobAction,
+                            cronServerOrigin = serverOrigin?.value,
+                            cronProfile = snapshot.selectedProfile,
+                            triggerCapability = snapshot.cronTriggerCapability,
+                            historyCapability = snapshot.cronHistoryCapability,
+                            runLoadingScopes = snapshot.cronRunLoadingScopes,
+                            runErrors = snapshot.cronRunErrors,
+                            runsByScope = snapshot.cronRunsByScope,
+                            onRunNow = onRunCronJob,
+                            onToggleRuns = onToggleCronJobRuns,
                         )
                     }
-                    TextButton(onClick = onClearOfflineCache) { Text("Clear offline cache") }
-                    TextButton(onClick = { coroutineScope.launch { onLogout() } }) { Text("Log out") }
-                    snapshot.managementError?.let { Text(it, color = MaterialTheme.colorScheme.error) }
-                    CronJobsPanel(
-                        state = snapshot.cronJobsState,
-                        onRefresh = onRefreshCronJobs,
-                        actionJobId = snapshot.cronJobActionJobId,
-                        actionError = snapshot.cronJobActionError,
-                        onJobAction = onCronJobAction,
-                        cronServerOrigin = serverOrigin?.value,
-                        cronProfile = snapshot.selectedProfile,
-                        triggerCapability = snapshot.cronTriggerCapability,
-                        historyCapability = snapshot.cronHistoryCapability,
-                        runLoadingScopes = snapshot.cronRunLoadingScopes,
-                        runErrors = snapshot.cronRunErrors,
-                        runsByScope = snapshot.cronRunsByScope,
-                        onRunNow = onRunCronJob,
-                        onToggleRuns = onToggleCronJobRuns,
-                    )
                 }
             }
         }
@@ -3982,6 +4123,37 @@ internal fun ServerSettingsScreen(
             },
         )
     }
+    if (modelPickerOpen) {
+        val scopedModelOptions = snapshot.defaultModelOptions
+            ?.takeIf { it.profile == snapshot.selectedProfile }
+        ModelPickerSheet(
+            options = scopedModelOptions,
+            current = scopedModelOptions?.current,
+            recents = recentModels,
+            reasoningOverrides = snapshot.profileModelReasoningOverrides,
+            profileDefaultEffort = snapshot.profileReasoningEffort,
+            query = modelQuery,
+            onQueryChange = { modelQuery = it.take(128) },
+            onDismiss = { modelPickerOpen = false },
+            onSetReasoning = { selection, effort ->
+                coroutineScope.launch { onSetModelReasoningOverride(selection, effort) }
+                Unit
+            },
+            onSelect = { selection ->
+                coroutineScope.launch {
+                    val result = onSetProfileDefaultModel(selection, false)
+                    if (result.confirmationRequired) {
+                        pendingExpensive = selection
+                        expensiveMessage = result.confirmationMessage
+                        modelPickerOpen = false
+                    } else if (result.accepted) {
+                        recentModels = (listOf(selection) + recentModels).distinct().take(5)
+                        modelPickerOpen = false
+                    }
+                }
+            },
+        )
+    }
     pendingExpensive?.let { selection ->
         AlertDialog(
             onDismissRequest = { pendingExpensive = null },
@@ -3989,11 +4161,284 @@ internal fun ServerSettingsScreen(
             text = { Text(expensiveMessage ?: "This model may have a high per-token cost.") },
             confirmButton = {
                 TextButton(onClick = {
-                    coroutineScope.launch { onSetProfileDefaultModel(selection, true) }
+                    coroutineScope.launch {
+                        val result = onSetProfileDefaultModel(selection, true)
+                        if (result.accepted) {
+                            recentModels = (listOf(selection) + recentModels).distinct().take(5)
+                        }
+                    }
                     pendingExpensive = null
                 }) { Text("Set default") }
             },
             dismissButton = { TextButton(onClick = { pendingExpensive = null }) { Text("Cancel") } },
+        )
+    }
+}
+
+/**
+ * A searchable, provider-grouped model picker in a modal bottom sheet. Recently
+ * used models pin to the top for one-tap re-selection; the rest are grouped by
+ * provider. Tapping a row expands it inline to reveal per-model controls —
+ * Thinking on/off and a reasoning-effort scale for reasoning-capable models,
+ * plus a Fast toggle where supported — mirroring the desktop's model edit menu.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ModelPickerSheet(
+    options: ModelOptions?,
+    current: ModelSelection?,
+    recents: List<ModelSelection>,
+    reasoningOverrides: Map<ModelSelection, String>,
+    profileDefaultEffort: String?,
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onSetReasoning: (ModelSelection, String) -> Unit,
+    onSelect: (ModelSelection) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var filters by rememberSaveable(
+        stateSaver = listSaver(
+            save = { it.map(ModelCapabilityFilter::name) },
+            restore = { it.map(ModelCapabilityFilter::valueOf).toSet() },
+        ),
+    ) { mutableStateOf(emptySet<ModelCapabilityFilter>()) }
+    var expandedRow by rememberSaveable { mutableStateOf<String?>(null) }
+    val groups = remember(options, query, filters) { modelProviderGroups(options, query, filters) }
+    val recentOptions = remember(recents, options, query, filters) {
+        if (query.isNotBlank() || filters.isNotEmpty()) {
+            emptyList()
+        } else {
+            recentModelOptions(recents, options)
+        }
+    }
+    fun rowKey(selection: ModelSelection) = "${selection.provider}/${selection.model}"
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Choose a model", style = MaterialTheme.typography.titleLarge)
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                label = { Text("Search models") },
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = "Search models" },
+            )
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ModelCapabilityFilter.entries.forEach { filter ->
+                    val active = filter in filters
+                    val label = when (filter) {
+                        ModelCapabilityFilter.Reasoning -> "Reasoning"
+                        ModelCapabilityFilter.Fast -> "Fast"
+                    }
+                    FilterChip(
+                        selected = active,
+                        onClick = {
+                            filters = if (active) filters - filter else filters + filter
+                        },
+                        label = { Text(label) },
+                        leadingIcon = if (active) {
+                            { Icon(Icons.Outlined.Check, contentDescription = null, modifier = Modifier.size(18.dp)) }
+                        } else {
+                            null
+                        },
+                        modifier = Modifier.semantics {
+                            selected = active
+                            contentDescription = "Filter by $label capability"
+                        },
+                    )
+                }
+            }
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 420.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                if (recentOptions.isNotEmpty()) {
+                    item(key = "recent-header") {
+                        Text(
+                            "Recently used",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(vertical = 4.dp),
+                        )
+                    }
+                    items(recentOptions, key = { "recent:${rowKey(it.selection)}" }) { option ->
+                        val key = rowKey(option.selection)
+                        ModelPickerRow(
+                            option = option,
+                            selected = option.selection == current,
+                            expanded = expandedRow == key,
+                            effortOverride = reasoningOverrides[option.selection],
+                            profileDefaultEffort = profileDefaultEffort,
+                            onToggleExpand = { expandedRow = if (expandedRow == key) null else key },
+                            onSelect = { onSelect(option.selection) },
+                            onSetReasoning = { effort -> onSetReasoning(option.selection, effort) },
+                        )
+                    }
+                }
+                if (groups.isEmpty()) {
+                    item(key = "empty") {
+                        Text(
+                            "No models match your search.",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(vertical = 8.dp),
+                        )
+                    }
+                }
+                groups.forEach { group ->
+                    item(key = "provider:${group.slug}") {
+                        Text(
+                            group.name,
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
+                        )
+                    }
+                    items(group.models, key = { rowKey(it.selection) }) { option ->
+                        val key = rowKey(option.selection)
+                        ModelPickerRow(
+                            option = option,
+                            selected = option.selection == current,
+                            expanded = expandedRow == key,
+                            effortOverride = reasoningOverrides[option.selection],
+                            profileDefaultEffort = profileDefaultEffort,
+                            onToggleExpand = { expandedRow = if (expandedRow == key) null else key },
+                            onSelect = { onSelect(option.selection) },
+                            onSetReasoning = { effort -> onSetReasoning(option.selection, effort) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ModelPickerRow(
+    option: ModelOption,
+    selected: Boolean,
+    expanded: Boolean,
+    effortOverride: String?,
+    profileDefaultEffort: String?,
+    onToggleExpand: () -> Unit,
+    onSelect: () -> Unit,
+    onSetReasoning: (String) -> Unit,
+) {
+    val labels = remember(option.capabilities) { modelCapabilityLabels(option.capabilities) }
+    val reasoningCapable = option.capabilities.reasoning == true
+    Column(modifier = Modifier.fillMaxWidth()) {
+        ListItem(
+            headlineContent = { Text(option.selection.model) },
+            supportingContent = if (labels.isEmpty()) {
+                null
+            } else {
+                { Text(labels.joinToString(" · ")) }
+            },
+            trailingContent = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (selected) {
+                        Icon(Icons.Outlined.Check, contentDescription = "Current model")
+                    }
+                    if (reasoningCapable) {
+                        Icon(
+                            if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+                            contentDescription = if (expanded) {
+                                "Hide options for ${option.selection.model}"
+                            } else {
+                                "Show options for ${option.selection.model}"
+                            },
+                            modifier = Modifier
+                                .size(24.dp)
+                                .clickable(onClick = onToggleExpand),
+                        )
+                    }
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onSelect)
+                .semantics {
+                    this.selected = selected
+                    contentDescription = "Select ${option.providerName} ${option.selection.model}"
+                },
+        )
+        if (expanded && reasoningCapable) {
+            val thinkingOn = isThinkingEnabled(effortOverride)
+            val effortValue = resolveReasoningEffort(effortOverride, profileDefaultEffort)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text("Thinking", style = MaterialTheme.typography.bodyMedium)
+                    Switch(
+                        checked = thinkingOn,
+                        onCheckedChange = { checked ->
+                            onSetReasoning(if (checked) effortValue else "none")
+                        },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Thinking for ${option.selection.model}"
+                        },
+                    )
+                }
+                if (thinkingOn) {
+                    Text(
+                        "Reasoning effort",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        ReasoningEffortLevels.forEach { level ->
+                            val active = level == effortValue
+                            FilterChip(
+                                selected = active,
+                                onClick = { onSetReasoning(level) },
+                                label = { Text(reasoningEffortShortLabel(level)) },
+                                modifier = Modifier.semantics {
+                                    this.selected = active
+                                    contentDescription =
+                                        "Set ${option.selection.model} reasoning to $level"
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A non-interactive capability label (e.g. "Reasoning") shown on the current
+ * model card. Deliberately not a chip, so it does not imply a tap target.
+ */
+@Composable
+private fun CapabilityBadge(label: String) {
+    Surface(
+        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
         )
     }
 }
@@ -4294,6 +4739,9 @@ private fun SessionDetailScreen(
                     }
                 }
                 else -> {
+                    val transcriptEntries = remember(chat.messages) {
+                        coalesceTranscriptEntries(chat.messages)
+                    }
                     LazyColumn(
                         state = transcriptListState,
                         modifier = Modifier
@@ -4302,10 +4750,36 @@ private fun SessionDetailScreen(
                             .testTag("Session timeline"),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
-                        itemsIndexed(
-                            items = chat.messages,
-                            key = { index, _ -> "message:$index" },
-                        ) { messageIndex, message ->
+                        items(
+                            items = transcriptEntries,
+                            key = { entry ->
+                                when (entry) {
+                                    is TranscriptEntry.Single -> "message:${entry.index}"
+                                    is TranscriptEntry.ToolRun ->
+                                        "tool-run:${entry.tools.first().index}"
+                                }
+                            },
+                        ) { entry ->
+                            if (entry is TranscriptEntry.ToolRun) {
+                                var toolsExpanded by rememberSaveable(
+                                    session.id.value,
+                                    entry.tools.first().index,
+                                ) {
+                                    mutableStateOf(false)
+                                }
+                                TranscriptToolRunGroup(
+                                    tools = entry.tools,
+                                    expanded = toolsExpanded,
+                                    onToggle = { toolsExpanded = !toolsExpanded },
+                                    sessionKey = session.id.value,
+                                    loadManagedImage = { path ->
+                                        onLoadManagedImage(path).getOrThrow()
+                                    },
+                                )
+                                return@items
+                            }
+                            val messageIndex = (entry as TranscriptEntry.Single).index
+                            val message = entry.message
                             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                                 if (message.role == ChatMessageRole.System) {
                                     Text(
@@ -4405,18 +4879,6 @@ private fun SessionDetailScreen(
                                                 onLoadManagedImage(path).getOrThrow()
                                             },
                                         )
-                                        if (
-                                            readAloudSession != null &&
-                                            message.role == ChatMessageRole.Assistant &&
-                                            renderedText.isNotBlank()
-                                        ) {
-                                            MessageSpeakerButton(
-                                                session = readAloudSession,
-                                                messageKey = "message:$messageIndex",
-                                                text = renderedText,
-                                                enabled = true,
-                                            )
-                                        }
                                     }
                                 }
                             }
@@ -6067,6 +6529,52 @@ private fun RunEventState.hasVisibleContent(): Boolean =
         approval != null ||
         unsupportedBlocking != null
 
+/** A transcript message paired with its stable index in the source list. */
+internal data class IndexedChatMessage(val index: Int, val message: ChatMessage)
+
+/**
+ * A renderable transcript unit: either a single non-tool message or a run of
+ * consecutive tool messages that collapse into one dropdown.
+ */
+internal sealed interface TranscriptEntry {
+    data class Single(val index: Int, val message: ChatMessage) : TranscriptEntry
+
+    data class ToolRun(val tools: List<IndexedChatMessage>) : TranscriptEntry
+}
+
+/**
+ * Fold a flat transcript into renderable entries, coalescing every maximal run
+ * of adjacent `Tool` messages into a single [TranscriptEntry.ToolRun]. Original
+ * message indices are preserved so per-message expansion state stays stable.
+ */
+internal fun coalesceTranscriptEntries(messages: List<ChatMessage>): List<TranscriptEntry> {
+    val entries = mutableListOf<TranscriptEntry>()
+    var run: MutableList<IndexedChatMessage>? = null
+    fun flush() {
+        run?.let { entries.add(TranscriptEntry.ToolRun(it.toList())) }
+        run = null
+    }
+    messages.forEachIndexed { index, message ->
+        if (message.role == ChatMessageRole.Tool) {
+            (run ?: mutableListOf<IndexedChatMessage>().also { run = it })
+                .add(IndexedChatMessage(index, message))
+        } else {
+            flush()
+            entries.add(TranscriptEntry.Single(index, message))
+        }
+    }
+    flush()
+    return entries
+}
+
+/**
+ * The tool name is the leading segment of a transcript tool message, before the
+ * " · " context separator (see `transcriptToolText` on the ViewModel). Falls
+ * back to the trimmed text when no separator is present.
+ */
+internal fun transcriptToolName(text: String): String =
+    text.substringBefore(" · ").trim().ifEmpty { text.trim() }
+
 /**
  * Verb bucket for a gateway tool name, or null for tools this client does not
  * recognize. Buckets merge related names ("write_file" and "patch" are both
@@ -6280,6 +6788,86 @@ private fun ToolMessageBlock(
                     text,
                     loadManagedImage = loadManagedImage,
                 )
+            }
+        }
+    }
+}
+
+/**
+ * A run of consecutive completed tool messages in the persisted transcript,
+ * collapsed into one dropdown mirroring the live [ToolActivityGroup]: a single
+ * header ("N actions, completed, <summary>") that expands to the individual
+ * tool rows, each independently expandable to its full result.
+ */
+@Composable
+private fun TranscriptToolRunGroup(
+    tools: List<IndexedChatMessage>,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    sessionKey: String,
+    loadManagedImage: (suspend (String) -> ByteArray)? = null,
+) {
+    val semanticColors = LocalHermesSemanticColors.current
+    val noun = if (tools.size == 1) "action" else "actions"
+    val summary = remember(tools) {
+        toolActivitySummary(
+            completedNames = tools.map { transcriptToolName(it.message.text) },
+        )
+    }
+    Surface(
+        onClick = onToggle,
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription =
+                    "${tools.size} $noun, completed, ${if (expanded) "expanded" else "collapsed"}"
+                stateDescription = if (expanded) "Expanded" else "Collapsed"
+            },
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    Icons.Outlined.Check,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = semanticColors.completed,
+                )
+                Text(
+                    summary,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Icon(
+                    if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (expanded) {
+                tools.forEach { indexed ->
+                    key(indexed.index) {
+                        var showToolMessage by rememberSaveable(sessionKey, indexed.index) {
+                            mutableStateOf(false)
+                        }
+                        ToolMessageBlock(
+                            text = indexed.message.text,
+                            expanded = showToolMessage,
+                            onToggle = { showToolMessage = !showToolMessage },
+                            loadManagedImage = loadManagedImage,
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/ModelPicker.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/ModelPicker.kt
@@ -1,0 +1,130 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import com.unsupportedpastels.hermesandroid.gateway.ModelCapabilities
+import com.unsupportedpastels.hermesandroid.gateway.ModelOptions
+import com.unsupportedpastels.hermesandroid.gateway.ModelSelection
+
+/** One selectable model with its provider label and advertised capabilities. */
+internal data class ModelOption(
+    val selection: ModelSelection,
+    val providerName: String,
+    val capabilities: ModelCapabilities = ModelCapabilities(),
+)
+
+/** A provider header plus its matching models, for the grouped picker list. */
+internal data class ModelProviderGroup(
+    val slug: String,
+    val name: String,
+    val models: List<ModelOption>,
+)
+
+/** Optional capability filters for the picker. A model must satisfy every active filter. */
+internal enum class ModelCapabilityFilter { Reasoning, Fast }
+
+/** Hermes' reasoning effort levels, ascending. `none` is thinking-off, owned by
+ *  the Thinking toggle, so it is not part of this scale. Mirrors the desktop's
+ *  REASONING_EFFORTS (lib/reasoning-effort.ts). */
+internal val ReasoningEffortLevels = listOf("minimal", "low", "medium", "high", "xhigh", "max", "ultra")
+
+/** Built-in effort used when neither the model override nor the profile sets one. */
+internal const val DefaultReasoningEffort = "medium"
+
+/** Compact label for an effort level, for tight chip rows. */
+internal fun reasoningEffortShortLabel(effort: String): String = when (effort.trim().lowercase()) {
+    "none" -> "Off"
+    "minimal" -> "Min"
+    "low" -> "Low"
+    "medium" -> "Med"
+    "high" -> "High"
+    "xhigh" -> "XHigh"
+    "max" -> "Max"
+    "ultra" -> "Ultra"
+    else -> effort
+}
+
+/** True when thinking is enabled for the given stored effort (anything but `none`). */
+internal fun isThinkingEnabled(effort: String?): Boolean =
+    (effort?.trim()?.lowercase() ?: return true) != "none"
+
+/**
+ * The effort level a scale control should display for a model: its stored
+ * override if it is a real level, else [fallback] (the profile default), else
+ * [DefaultReasoningEffort]. `none`/blank resolve through the fallback because
+ * thinking-off is represented separately by the Thinking toggle.
+ */
+internal fun resolveReasoningEffort(effort: String?, fallback: String?): String {
+    val value = effort?.trim()?.lowercase().orEmpty()
+    val resolved = value.takeUnless { it.isEmpty() || it == "none" }
+        ?: fallback?.trim()?.lowercase()?.takeUnless { it.isEmpty() || it == "none" }
+        ?: DefaultReasoningEffort
+    return if (resolved in ReasoningEffortLevels) resolved else DefaultReasoningEffort
+}
+
+/**
+ * Group the profile's providers into collapsible sections, keeping only the
+ * providers with at least one model matching [query] and every filter in
+ * [filters]. A blank query keeps every provider; an empty [filters] set applies
+ * no capability constraint. Query matching is case-insensitive against both the
+ * model identifier and the provider name, so searching a provider name surfaces
+ * all of its models.
+ */
+internal fun modelProviderGroups(
+    options: ModelOptions?,
+    query: String,
+    filters: Set<ModelCapabilityFilter> = emptySet(),
+): List<ModelProviderGroup> {
+    val trimmed = query.trim()
+    return options?.providers.orEmpty().mapNotNull { provider ->
+        val providerMatches = trimmed.isEmpty() ||
+            provider.name.contains(trimmed, ignoreCase = true) ||
+            provider.slug.contains(trimmed, ignoreCase = true)
+        val models = provider.models
+            .filter { model ->
+                providerMatches || model.contains(trimmed, ignoreCase = true)
+            }
+            .map { model ->
+                ModelOption(
+                    selection = ModelSelection(provider.slug, model),
+                    providerName = provider.name,
+                    capabilities = provider.capabilities[model] ?: ModelCapabilities(),
+                )
+            }
+            .filter { option -> option.capabilities.satisfies(filters) }
+        if (models.isEmpty()) null else ModelProviderGroup(provider.slug, provider.name, models)
+    }
+}
+
+/** True when these capabilities meet every requested filter. */
+private fun ModelCapabilities.satisfies(filters: Set<ModelCapabilityFilter>): Boolean =
+    filters.all { filter ->
+        when (filter) {
+            ModelCapabilityFilter.Reasoning -> reasoning == true
+            ModelCapabilityFilter.Fast -> fast == true
+        }
+    }
+
+/**
+ * Resolve recently-used selections (most-recent first) into full options,
+ * dropping any that are no longer offered by the current profile and any
+ * duplicates. Used to pin the models the user actually switches between at the
+ * top of the picker.
+ */
+internal fun recentModelOptions(
+    recents: List<ModelSelection>,
+    options: ModelOptions?,
+): List<ModelOption> {
+    val available = modelProviderGroups(options, "")
+        .flatMap { group -> group.models }
+        .associateBy { it.selection }
+    val seen = LinkedHashSet<ModelSelection>()
+    return recents.mapNotNull { selection ->
+        if (!seen.add(selection)) return@mapNotNull null
+        available[selection]
+    }
+}
+
+/** Human-readable capability chips for a model, e.g. ["Reasoning", "Fast"]. */
+internal fun modelCapabilityLabels(capabilities: ModelCapabilities): List<String> = buildList {
+    if (capabilities.reasoning == true) add("Reasoning")
+    if (capabilities.fast == true) add("Fast")
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/HermesAppHostTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/HermesAppHostTest.kt
@@ -57,6 +57,7 @@ class HermesAppHostTest {
         }
 
         composeRule.onNodeWithText("Configure server").performClick()
+        composeRule.onNodeWithContentDescription("Open Servers settings").performClick()
         composeRule.onNodeWithContentDescription("Server origin input")
             .performTextInput("https://hermes.example/")
         composeRule.onNodeWithText("Save").performScrollTo().performClick()

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
@@ -26,6 +26,8 @@ import org.junit.Test
 import com.unsupportedpastels.hermesandroid.app.DurableSessionId
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessage
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessageRole
+import com.unsupportedpastels.hermesandroid.gateway.ModelOptions
+import com.unsupportedpastels.hermesandroid.gateway.ModelProviderOption
 import com.unsupportedpastels.hermesandroid.gateway.ModelSelection
 import com.unsupportedpastels.hermesandroid.gateway.CronJobScope
 
@@ -223,6 +225,62 @@ class HermesConnectionClientTest {
             "opaque-access",
             "work",
             "high",
+        )
+    }
+
+    @Test
+    fun perModelReasoningOverrideWritesModelKeyedByItsOwnPrefixViaDeepMergedConfigPut() = runTest {
+        val engine = MockEngine { request ->
+            assertEquals(HttpMethod.Put, request.method)
+            assertEquals("/api/config", request.url.encodedPath)
+            assertEquals("work", request.url.parameters["profile"])
+            val body = (request.body as TextContent).text
+            // Keyed off the model string itself (which already carries its own
+            // provider prefix). The portal slug ("nous") is NOT prepended.
+            assertEquals(
+                """{"config":{"agent":{"reasoning_overrides":{"anthropic/claude-opus-5":"high"}}}}""",
+                body,
+            )
+            respond("{}", headers = headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        HttpHermesConnectionClient(HttpClient(engine)).setProfileModelReasoningOverride(
+            ServerOrigin.parse("https://hermes.example"),
+            "opaque-access",
+            "work",
+            ModelSelection("nous", "anthropic/claude-opus-5"),
+            "high",
+        )
+    }
+
+    @Test
+    fun loadProfileReasoningOverridesMatchesModelPrefixedKeys() = runTest {
+        val engine = MockEngine {
+            respond(
+                """{"agent":{"reasoning_overrides":{"anthropic/claude-opus-5":"high"}}}""",
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val options = ModelOptions(
+            current = null,
+            providers = listOf(
+                ModelProviderOption(
+                    slug = "nous",
+                    name = "Nous Portal",
+                    models = listOf("anthropic/claude-opus-5", "anthropic/claude-sonnet-5"),
+                    capabilities = emptyMap(),
+                ),
+            ),
+            profile = "work",
+        )
+        val overrides = HttpHermesConnectionClient(HttpClient(engine)).loadProfileReasoningOverrides(
+            ServerOrigin.parse("https://hermes.example"),
+            "opaque-access",
+            "work",
+            options,
+        )
+        assertEquals(
+            mapOf(ModelSelection("nous", "anthropic/claude-opus-5") to "high"),
+            overrides,
         )
     }
 

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
@@ -285,6 +285,50 @@ class HermesConnectionClientTest {
     }
 
     @Test
+    fun loadProfileReasoningOverridesMatchesProviderQualifiedBareModelIds() = runTest {
+        val engine = MockEngine {
+            respond(
+                """{"agent":{"reasoning_overrides":{"openai/shared-model":"low"}}}""",
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val options = ModelOptions(
+            current = null,
+            providers = listOf(
+                ModelProviderOption(
+                    slug = "openai",
+                    name = "OpenAI",
+                    models = listOf("shared-model"),
+                ),
+            ),
+            profile = "work",
+        )
+        val overrides = HttpHermesConnectionClient(HttpClient(engine)).loadProfileReasoningOverrides(
+            ServerOrigin.parse("https://hermes.example"),
+            "opaque-access",
+            "work",
+            options,
+        )
+        assertEquals(mapOf(ModelSelection("openai", "shared-model") to "low"), overrides)
+    }
+
+    @Test
+    fun loadProfileReasoningDefaultIgnoresCurrentModelOverride() = runTest {
+        val engine = MockEngine {
+            respond(
+                """{"agent":{"reasoning_effort":"medium","reasoning_overrides":{"anthropic/claude-opus-5":"high"}}}""",
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val effort = HttpHermesConnectionClient(HttpClient(engine)).loadProfileReasoningDefault(
+            ServerOrigin.parse("https://hermes.example"),
+            "opaque-access",
+            "work",
+        )
+        assertEquals("medium", effort)
+    }
+
+    @Test
     fun profileReasoningEffortUsesModelOverrideBeforeGlobalDefault() = runTest {
         val engine = MockEngine { request ->
             assertEquals("/api/config", request.url.encodedPath)

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/navigation/RoutesTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/navigation/RoutesTest.kt
@@ -42,4 +42,57 @@ class RoutesTest {
 
         assertEquals(ServerSettingsRoute, decoded)
     }
+
+    @Test
+    fun settingsSectionRoutesAreSerializable() {
+        assertEquals(
+            SettingsServersRoute,
+            Json.decodeFromString(
+                SettingsServersRoute.serializer(),
+                Json.encodeToString(SettingsServersRoute.serializer(), SettingsServersRoute),
+            ),
+        )
+        assertEquals(
+            SettingsConnectionRoute,
+            Json.decodeFromString(
+                SettingsConnectionRoute.serializer(),
+                Json.encodeToString(SettingsConnectionRoute.serializer(), SettingsConnectionRoute),
+            ),
+        )
+        assertEquals(
+            SettingsModelRoute,
+            Json.decodeFromString(
+                SettingsModelRoute.serializer(),
+                Json.encodeToString(SettingsModelRoute.serializer(), SettingsModelRoute),
+            ),
+        )
+        assertEquals(
+            SettingsVoiceRoute,
+            Json.decodeFromString(
+                SettingsVoiceRoute.serializer(),
+                Json.encodeToString(SettingsVoiceRoute.serializer(), SettingsVoiceRoute),
+            ),
+        )
+        assertEquals(
+            SettingsOfflineRoute,
+            Json.decodeFromString(
+                SettingsOfflineRoute.serializer(),
+                Json.encodeToString(SettingsOfflineRoute.serializer(), SettingsOfflineRoute),
+            ),
+        )
+        assertEquals(
+            SettingsJobsRoute,
+            Json.decodeFromString(
+                SettingsJobsRoute.serializer(),
+                Json.encodeToString(SettingsJobsRoute.serializer(), SettingsJobsRoute),
+            ),
+        )
+        assertEquals(
+            SettingsAccountRoute,
+            Json.decodeFromString(
+                SettingsAccountRoute.serializer(),
+                Json.encodeToString(SettingsAccountRoute.serializer(), SettingsAccountRoute),
+            ),
+        )
+    }
 }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
@@ -322,7 +322,7 @@ class HermesAppTest {
         composeRule.onNodeWithContentDescription("Filter artifacts: Image").performClick()
         composeRule.onNodeWithContentDescription("Zoom image preview.png").performClick()
         composeRule.waitForIdle()
-        composeRule.onNodeWithText("Close").assertIsDisplayed()
+        composeRule.onNodeWithText("Close").assertExists()
     }
 
     @Test

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeRight
@@ -54,6 +55,8 @@ import com.unsupportedpastels.hermesandroid.connection.ServerSettingsState
 import com.unsupportedpastels.hermesandroid.gateway.AuthenticationState
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessage
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessageRole
+import com.unsupportedpastels.hermesandroid.voice.MessageReadAloud
+import com.unsupportedpastels.hermesandroid.voice.SpeechAudio
 import com.unsupportedpastels.hermesandroid.gateway.ChatBillingNotice
 import com.unsupportedpastels.hermesandroid.gateway.ChatSessionSnapshot
 import com.unsupportedpastels.hermesandroid.gateway.ConnectionState
@@ -65,6 +68,7 @@ import com.unsupportedpastels.hermesandroid.gateway.ModelCapabilities
 import com.unsupportedpastels.hermesandroid.gateway.CurrentModelInfo
 import com.unsupportedpastels.hermesandroid.gateway.ModelProviderOption
 import com.unsupportedpastels.hermesandroid.gateway.ModelSelection
+import com.unsupportedpastels.hermesandroid.gateway.ModelSwitchResult
 import com.unsupportedpastels.hermesandroid.gateway.RuntimeSessionId
 import com.unsupportedpastels.hermesandroid.gateway.RuntimeAccess
 import com.unsupportedpastels.hermesandroid.gateway.ActiveRuntimeSession
@@ -202,6 +206,77 @@ class HermesAppTest {
 
         composeRule.onNodeWithContentDescription("Attach files").performClick()
         composeRule.onAllNodesWithText("Artifacts").assertCountEquals(0)
+    }
+
+    @Test
+    fun consecutiveTranscriptToolMessagesCollapseIntoOneExpandableGroup() {
+        val session = sessions.first()
+        val snapshot = connectedSnapshot.copy(
+            authenticationState = AuthenticationState.Authenticated,
+            chatSessions = mapOf(
+                session.id to ChatSessionSnapshot(
+                    messages = listOf(
+                        ChatMessage(ChatMessageRole.User, "deploy the site"),
+                        ChatMessage(ChatMessageRole.Tool, "web_extract · https://example.com/"),
+                        ChatMessage(ChatMessageRole.Tool, "patch · /home/mark/site/index.html"),
+                        ChatMessage(ChatMessageRole.Tool, "terminal · curl -fsSL https://example.com"),
+                        ChatMessage(ChatMessageRole.Assistant, "Deployed successfully."),
+                    ),
+                ),
+            ),
+        )
+
+        composeRule.setContent {
+            HermesAndroidTheme {
+                HermesApp(
+                    snapshot = snapshot,
+                    initialRoute = SessionDetailRoute(session.id),
+                )
+            }
+        }
+
+        // Collapsed: one group header, no raw per-tool rows visible yet.
+        composeRule.onNodeWithContentDescription("3 actions, completed, collapsed")
+            .assertIsDisplayed()
+        composeRule.onAllNodesWithText("Tool").assertCountEquals(0)
+
+        // Expand the group; the individual tool rows appear underneath.
+        composeRule.onNodeWithContentDescription("3 actions, completed, collapsed").performClick()
+        composeRule.onNodeWithContentDescription("3 actions, completed, expanded")
+            .assertIsDisplayed()
+        composeRule.onAllNodesWithText("Tool").assertCountEquals(3)
+    }
+
+    @Test
+    fun assistantResponsesHaveNoPerMessageReadAloudSpeakerButton() {
+        val session = sessions.first()
+        val snapshot = connectedSnapshot.copy(
+            authenticationState = AuthenticationState.Authenticated,
+            chatSessions = mapOf(
+                session.id to ChatSessionSnapshot(
+                    messages = listOf(
+                        ChatMessage(ChatMessageRole.User, "what device is linked?"),
+                        ChatMessage(ChatMessageRole.Assistant, "Your Garmin Venu X1 is linked."),
+                    ),
+                ),
+            ),
+        )
+
+        composeRule.setContent {
+            HermesAndroidTheme {
+                HermesApp(
+                    snapshot = snapshot,
+                    initialRoute = SessionDetailRoute(session.id),
+                    // TTS is fully available, yet the per-message speaker button
+                    // must not appear beneath responses.
+                    readAloud = MessageReadAloud { Result.success(SpeechAudio(byteArrayOf(1), "audio/mpeg")) },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Your Garmin Venu X1 is linked.").assertIsDisplayed()
+        composeRule.onAllNodesWithContentDescription("Read message aloud").assertCountEquals(0)
+        composeRule.onAllNodesWithContentDescription("Stop reading aloud").assertCountEquals(0)
     }
 
     @Test
@@ -771,7 +846,9 @@ class HermesAppTest {
         composeRule.onNodeWithText("New chat").assertDoesNotExist()
         composeRule.onNodeWithContentDescription("Settings").performClick()
         assertEquals(1, taskStarts)
-        composeRule.onNodeWithText("Hermes server").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Open Servers settings").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Open Servers settings").performClick()
+        composeRule.onNodeWithContentDescription("Server origin input").assertIsDisplayed()
     }
 
     @Test
@@ -796,6 +873,7 @@ class HermesAppTest {
         composeRule.onNodeWithContentDescription("New task").assertIsDisplayed().performClick()
         assertEquals(1, taskStarts)
         composeRule.onNodeWithContentDescription("Settings").performClick()
+        composeRule.onNodeWithContentDescription("Open Connection & profile settings").performClick()
         composeRule.onNodeWithContentDescription("Operational overview").assertIsDisplayed()
     }
 
@@ -2490,6 +2568,7 @@ class HermesAppTest {
         }
 
         composeRule.onNodeWithText("Configure server").performClick()
+        composeRule.onNodeWithContentDescription("Open Servers settings").performClick()
         composeRule.onNodeWithText("Server origin").assertIsDisplayed()
         composeRule.onNodeWithContentDescription("Server origin input")
             .performTextInput("HTTPS://Example.COM/")
@@ -2516,6 +2595,7 @@ class HermesAppTest {
         }
 
         composeRule.onNodeWithText("Configure server").performClick()
+        composeRule.onNodeWithContentDescription("Open Servers settings").performClick()
         composeRule.onNodeWithContentDescription("Server origin input")
             .performTextInput("http://10.0.1.2")
 
@@ -2560,10 +2640,10 @@ class HermesAppTest {
 
         composeRule.onNodeWithText("Current profile model").performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithText("Effective context: 131072 tokens").performScrollTo().assertIsDisplayed()
-        composeRule.onNodeWithText("Reasoning default for future chats").performScrollTo().assertIsDisplayed()
-        composeRule.onNodeWithText(
-            "This changes future chats only; it does not change the active runtime.",
-        ).performScrollTo().assertIsDisplayed()
+        // Reasoning is now set per-model inside the picker, not via a separate
+        // profile-wide dropdown, so the Change model entry point is what shows.
+        composeRule.onNodeWithContentDescription("Change default model").performScrollTo().assertIsDisplayed()
+        composeRule.onAllNodesWithText("Reasoning default for future chats").assertCountEquals(0)
     }
 
     @Test
@@ -2595,7 +2675,175 @@ class HermesAppTest {
         composeRule.onNodeWithText("Server settings unavailable").assertIsDisplayed()
         composeRule.onNodeWithText("Open Server to replace the saved origin.").assertIsDisplayed()
         composeRule.onNodeWithContentDescription("Settings").performClick()
-        composeRule.onNodeWithText("Hermes server").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Open Servers settings").performClick()
+        composeRule.onNodeWithContentDescription("Server origin input").assertIsDisplayed()
+    }
+
+    @Test
+    fun settingsHubListsSectionsAndOpensModelSectionForAuthenticatedServer() {
+        val snapshot = connectedSnapshot.copy(
+            authenticationState = AuthenticationState.Authenticated,
+            currentModelInfo = CurrentModelInfo(
+                profile = "default",
+                provider = "nous",
+                model = "Hermes-4-405B",
+                effectiveContextLength = 131072,
+                capabilities = ModelCapabilities(reasoning = true, fast = true),
+            ),
+            defaultModelOptions = ModelOptions(
+                current = ModelSelection("nous", "Hermes-4-405B"),
+                providers = emptyList(),
+                profile = "default",
+            ),
+        )
+        composeRule.setContent {
+            HermesAndroidTheme { HermesApp(snapshot = snapshot) }
+        }
+
+        composeRule.onNodeWithContentDescription("Settings").performClick()
+        // Hub shows a concise list of sections, not the full form.
+        composeRule.onNodeWithContentDescription("Open Servers settings").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Open Default model settings").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Open Offline & privacy settings").assertIsDisplayed()
+
+        composeRule.onNodeWithContentDescription("Open Default model settings").performClick()
+        composeRule.onNodeWithText("Default model for new chats").assertIsDisplayed()
+        // Servers form is not on the model section.
+        composeRule.onNodeWithContentDescription("Server origin input").assertDoesNotExist()
+    }
+
+    @Test
+    fun unauthenticatedSettingsHubOnlyOffersServers() {
+        composeRule.setContent {
+            HermesAndroidTheme {
+                HermesApp(snapshot = HermesGatewaySnapshot(connectionState = ConnectionState.Connected))
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Settings").performClick()
+        composeRule.onNodeWithContentDescription("Open Servers settings").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Open Default model settings").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("Open Account settings").assertDoesNotExist()
+    }
+
+    @Test
+    fun modelPickerGroupsByProviderSearchesAndSetsDefault() {
+        var chosen: ModelSelection? = null
+        val snapshot = connectedSnapshot.copy(
+            authenticationState = AuthenticationState.Authenticated,
+            defaultModelOptions = ModelOptions(
+                current = ModelSelection("nous", "Hermes-4-405B"),
+                providers = listOf(
+                    ModelProviderOption(
+                        slug = "nous",
+                        name = "Nous",
+                        models = listOf("Hermes-4-405B", "Hermes-4-70B"),
+                        capabilities = mapOf(
+                            "Hermes-4-405B" to ModelCapabilities(reasoning = true),
+                        ),
+                    ),
+                    ModelProviderOption(
+                        slug = "openai",
+                        name = "OpenAI",
+                        models = listOf("gpt-5.6-sol"),
+                    ),
+                ),
+                profile = "default",
+            ),
+        )
+        composeRule.setContent {
+            HermesAndroidTheme {
+                HermesApp(
+                    snapshot = snapshot,
+                    onSetProfileDefaultModel = { selection, _ ->
+                        chosen = selection
+                        ModelSwitchResult(accepted = true)
+                    },
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Settings").performClick()
+        composeRule.onNodeWithContentDescription("Open Default model settings").performClick()
+        // Current-model card, not a wall of chips.
+        composeRule.onNodeWithContentDescription("Change default model").performClick()
+
+        // Grouped by provider inside the sheet — the Nous models render.
+        composeRule.onNodeWithContentDescription("Select Nous Hermes-4-405B").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Select Nous Hermes-4-70B").assertIsDisplayed()
+
+        // Search narrows to a single provider's model.
+        composeRule.onNodeWithContentDescription("Search models").performTextInput("70b")
+        composeRule.onNodeWithContentDescription("Select Nous Hermes-4-70B").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Select Nous Hermes-4-405B").assertDoesNotExist()
+
+        // Clearing the query and filtering by Reasoning drops the fast-only 70B model.
+        composeRule.onNodeWithContentDescription("Search models").performTextClearance()
+        composeRule.onNodeWithContentDescription("Filter by Reasoning capability").performClick()
+        composeRule.onNodeWithContentDescription("Select Nous Hermes-4-405B").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Select Nous Hermes-4-70B").assertDoesNotExist()
+        // Turn the filter back off before selecting.
+        composeRule.onNodeWithContentDescription("Filter by Reasoning capability").performClick()
+
+        composeRule.onNodeWithContentDescription("Select Nous Hermes-4-70B").performClick()
+        composeRule.runOnIdle {
+            assertEquals(ModelSelection("nous", "Hermes-4-70B"), chosen)
+        }
+    }
+
+    @Test
+    fun modelPickerExpandsReasoningModelAndSetsPerModelEffort() {
+        var reasoningCall: Pair<ModelSelection, String>? = null
+        val snapshot = connectedSnapshot.copy(
+            authenticationState = AuthenticationState.Authenticated,
+            profileReasoningEffort = "medium",
+            defaultModelOptions = ModelOptions(
+                current = ModelSelection("nous", "Hermes-4-405B"),
+                providers = listOf(
+                    ModelProviderOption(
+                        slug = "nous",
+                        name = "Nous",
+                        models = listOf("Hermes-4-405B", "Hermes-4-70B"),
+                        capabilities = mapOf(
+                            "Hermes-4-405B" to ModelCapabilities(reasoning = true),
+                            "Hermes-4-70B" to ModelCapabilities(fast = true),
+                        ),
+                    ),
+                ),
+                profile = "default",
+            ),
+        )
+        composeRule.setContent {
+            HermesAndroidTheme {
+                HermesApp(
+                    snapshot = snapshot,
+                    onSetModelReasoningOverride = { selection, effort ->
+                        reasoningCall = selection to effort
+                        Result.success(Unit)
+                    },
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Settings").performClick()
+        composeRule.onNodeWithContentDescription("Open Default model settings").performClick()
+        composeRule.onNodeWithContentDescription("Change default model").performClick()
+
+        // The fast-only 70B model has no reasoning expander.
+        composeRule.onNodeWithContentDescription("Show options for Hermes-4-70B").assertDoesNotExist()
+
+        // Expand the reasoning-capable model to reveal Thinking + effort scale.
+        composeRule.onNodeWithContentDescription("Show options for Hermes-4-405B").performClick()
+        composeRule.onNodeWithContentDescription("Thinking for Hermes-4-405B").assertIsDisplayed()
+
+        // Setting an effort level writes a per-model override, not a global one.
+        composeRule.onNodeWithContentDescription("Set Hermes-4-405B reasoning to high")
+            .performScrollTo()
+            .performClick()
+        composeRule.waitUntil(timeoutMillis = 2_000) {
+            reasoningCall != null
+        }
+        assertEquals(ModelSelection("nous", "Hermes-4-405B") to "high", reasoningCall)
     }
 
     @Test

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
@@ -2625,6 +2625,7 @@ class HermesAppTest {
                 capabilities = ModelCapabilities(reasoning = true, fast = true),
             ),
             profileReasoningEffort = "medium",
+            profileReasoningDefault = "medium",
         )
         composeRule.setContent {
             HermesAndroidTheme {
@@ -2797,6 +2798,7 @@ class HermesAppTest {
         val snapshot = connectedSnapshot.copy(
             authenticationState = AuthenticationState.Authenticated,
             profileReasoningEffort = "medium",
+            profileReasoningDefault = "medium",
             defaultModelOptions = ModelOptions(
                 current = ModelSelection("nous", "Hermes-4-405B"),
                 providers = listOf(

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/ModelPickerTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/ModelPickerTest.kt
@@ -1,0 +1,160 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import com.unsupportedpastels.hermesandroid.gateway.ModelCapabilities
+import com.unsupportedpastels.hermesandroid.gateway.ModelOptions
+import com.unsupportedpastels.hermesandroid.gateway.ModelProviderOption
+import com.unsupportedpastels.hermesandroid.gateway.ModelSelection
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ModelPickerTest {
+    private val options = ModelOptions(
+        current = ModelSelection("nous", "Hermes-4-405B"),
+        providers = listOf(
+            ModelProviderOption(
+                slug = "nous",
+                name = "Nous",
+                models = listOf("Hermes-4-405B", "Hermes-4-70B"),
+                capabilities = mapOf(
+                    "Hermes-4-405B" to ModelCapabilities(reasoning = true, fast = false),
+                    "Hermes-4-70B" to ModelCapabilities(fast = true),
+                ),
+            ),
+            ModelProviderOption(
+                slug = "openai",
+                name = "OpenAI",
+                models = listOf("gpt-5.6-sol"),
+                capabilities = mapOf("gpt-5.6-sol" to ModelCapabilities(reasoning = true)),
+            ),
+        ),
+        profile = "default",
+    )
+
+    @Test
+    fun blankQueryKeepsEveryProviderAndModel() {
+        val groups = modelProviderGroups(options, "")
+        assertEquals(listOf("Nous", "OpenAI"), groups.map { it.name })
+        assertEquals(2, groups.first().models.size)
+    }
+
+    @Test
+    fun queryMatchesModelIdentifierWithinAProvider() {
+        val groups = modelProviderGroups(options, "70b")
+        assertEquals(1, groups.size)
+        assertEquals("Nous", groups.first().name)
+        assertEquals(
+            listOf(ModelSelection("nous", "Hermes-4-70B")),
+            groups.first().models.map { it.selection },
+        )
+    }
+
+    @Test
+    fun queryMatchingProviderNameKeepsAllOfItsModels() {
+        val groups = modelProviderGroups(options, "openai")
+        assertEquals(1, groups.size)
+        assertEquals(listOf("gpt-5.6-sol"), groups.first().models.map { it.selection.model })
+    }
+
+    @Test
+    fun recentsResolveToOptionsDropUnavailableAndDedupe() {
+        val recents = listOf(
+            ModelSelection("openai", "gpt-5.6-sol"),
+            ModelSelection("openai", "gpt-5.6-sol"), // duplicate
+            ModelSelection("nous", "retired-model"), // no longer offered
+            ModelSelection("nous", "Hermes-4-70B"),
+        )
+
+        val resolved = recentModelOptions(recents, options)
+
+        assertEquals(
+            listOf(
+                ModelSelection("openai", "gpt-5.6-sol"),
+                ModelSelection("nous", "Hermes-4-70B"),
+            ),
+            resolved.map { it.selection },
+        )
+    }
+
+    @Test
+    fun capabilityLabelsListReasoningThenFast() {
+        assertEquals(
+            listOf("Reasoning", "Fast"),
+            modelCapabilityLabels(ModelCapabilities(reasoning = true, fast = true)),
+        )
+        assertEquals(emptyList<String>(), modelCapabilityLabels(ModelCapabilities()))
+    }
+
+    @Test
+    fun reasoningFilterKeepsOnlyReasoningModels() {
+        val groups = modelProviderGroups(
+            options,
+            query = "",
+            filters = setOf(ModelCapabilityFilter.Reasoning),
+        )
+        val kept = groups.flatMap { it.models.map { model -> model.selection } }
+        assertEquals(
+            listOf(
+                ModelSelection("nous", "Hermes-4-405B"),
+                ModelSelection("openai", "gpt-5.6-sol"),
+            ),
+            kept,
+        )
+    }
+
+    @Test
+    fun fastFilterKeepsOnlyFastModels() {
+        val groups = modelProviderGroups(
+            options,
+            query = "",
+            filters = setOf(ModelCapabilityFilter.Fast),
+        )
+        val kept = groups.flatMap { it.models.map { model -> model.selection } }
+        assertEquals(listOf(ModelSelection("nous", "Hermes-4-70B")), kept)
+    }
+
+    @Test
+    fun combinedFiltersRequireEveryCapability() {
+        val groups = modelProviderGroups(
+            options,
+            query = "",
+            filters = setOf(ModelCapabilityFilter.Reasoning, ModelCapabilityFilter.Fast),
+        )
+        // No model in the fixture is both reasoning and fast.
+        assertEquals(emptyList<ModelProviderGroup>(), groups)
+    }
+
+    @Test
+    fun filterCombinesWithTextQuery() {
+        val groups = modelProviderGroups(
+            options,
+            query = "hermes",
+            filters = setOf(ModelCapabilityFilter.Reasoning),
+        )
+        val kept = groups.flatMap { it.models.map { model -> model.selection } }
+        assertEquals(listOf(ModelSelection("nous", "Hermes-4-405B")), kept)
+    }
+
+    @Test
+    fun resolveReasoningEffortPrefersOverrideThenFallbackThenDefault() {
+        assertEquals("high", resolveReasoningEffort("high", "low"))
+        assertEquals("low", resolveReasoningEffort(null, "low"))
+        assertEquals("low", resolveReasoningEffort("none", "low"))
+        assertEquals("medium", resolveReasoningEffort(null, null))
+        assertEquals("medium", resolveReasoningEffort("nonsense", null))
+        assertEquals("medium", resolveReasoningEffort(null, "none"))
+    }
+
+    @Test
+    fun thinkingEnabledUnlessNone() {
+        assertEquals(true, isThinkingEnabled(null))
+        assertEquals(true, isThinkingEnabled("high"))
+        assertEquals(false, isThinkingEnabled("none"))
+    }
+
+    @Test
+    fun reasoningEffortLabelsAreCompact() {
+        assertEquals("Med", reasoningEffortShortLabel("medium"))
+        assertEquals("XHigh", reasoningEffortShortLabel("xhigh"))
+        assertEquals("Off", reasoningEffortShortLabel("none"))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/TranscriptToolGroupingTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/TranscriptToolGroupingTest.kt
@@ -1,0 +1,67 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import com.unsupportedpastels.hermesandroid.gateway.ChatMessage
+import com.unsupportedpastels.hermesandroid.gateway.ChatMessageRole
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TranscriptToolGroupingTest {
+    private fun message(role: ChatMessageRole, text: String) = ChatMessage(role, text)
+
+    @Test
+    fun consecutiveToolMessagesCoalesceIntoOneRunWithPreservedIndices() {
+        val messages = listOf(
+            message(ChatMessageRole.User, "deploy the site"),
+            message(ChatMessageRole.Assistant, "on it"),
+            message(ChatMessageRole.Tool, "web_extract · https://example.com/"),
+            message(ChatMessageRole.Tool, "terminal · curl -fsSL https://example.com"),
+            message(ChatMessageRole.Tool, "patch · /home/mark/site/index.html"),
+            message(ChatMessageRole.Assistant, "Deployed successfully."),
+        )
+
+        val entries = coalesceTranscriptEntries(messages)
+
+        assertEquals(4, entries.size)
+        assertEquals(TranscriptEntry.Single(0, messages[0]), entries[0])
+        assertEquals(TranscriptEntry.Single(1, messages[1]), entries[1])
+        assertEquals(
+            TranscriptEntry.ToolRun(
+                listOf(
+                    IndexedChatMessage(2, messages[2]),
+                    IndexedChatMessage(3, messages[3]),
+                    IndexedChatMessage(4, messages[4]),
+                ),
+            ),
+            entries[2],
+        )
+        assertEquals(TranscriptEntry.Single(5, messages[5]), entries[3])
+    }
+
+    @Test
+    fun toolMessagesSplitByANonToolMessageFormSeparateRuns() {
+        val messages = listOf(
+            message(ChatMessageRole.Tool, "read_file · a.kt"),
+            message(ChatMessageRole.Assistant, "thinking out loud"),
+            message(ChatMessageRole.Tool, "write_file · a.kt"),
+        )
+
+        val entries = coalesceTranscriptEntries(messages)
+
+        assertEquals(3, entries.size)
+        assertEquals(TranscriptEntry.ToolRun(listOf(IndexedChatMessage(0, messages[0]))), entries[0])
+        assertEquals(TranscriptEntry.Single(1, messages[1]), entries[1])
+        assertEquals(TranscriptEntry.ToolRun(listOf(IndexedChatMessage(2, messages[2]))), entries[2])
+    }
+
+    @Test
+    fun emptyTranscriptProducesNoEntries() {
+        assertEquals(emptyList<TranscriptEntry>(), coalesceTranscriptEntries(emptyList()))
+    }
+
+    @Test
+    fun toolNameIsParsedFromLeadingSegmentBeforeSeparator() {
+        assertEquals("web_extract", transcriptToolName("web_extract · https://example.com/"))
+        assertEquals("terminal", transcriptToolName("terminal · curl -fsSL https://example.com"))
+        assertEquals("bare", transcriptToolName("bare"))
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the monolithic settings scroll with a Navigation 3 settings hub and focused section routes.
- Replace the flat model chip wall with a searchable, provider-grouped picker and recent models.
- Add inline per-model Thinking and reasoning-effort controls (`minimal` through `ultra`) with server-backed `reasoning_overrides`.
- Keep Fast as a capability filter and make capability badges non-interactive.
- Rename the offline transcript setting to plain-language “Save conversations for offline reading.”
- Collapse persisted transcript tool activity into one expandable group.
- Remove the per-response read-aloud speaker button while preserving hands-free voice auto-speak.

## Verification
- `./gradlew testDebugUnitTest lintDebug assembleDebug`
- `./gradlew validateDebugScreenshotTest`
- Verified the settings hub, model picker, inline effort controls, and persisted High override on the physical Samsung Fold.
- Verified the per-response speaker icon is absent in the Garmin conversation.

## Notes
- The per-model override key follows the server contract and uses the model’s own provider-qualified identifier, not the portal slug.
- No merge performed; this PR targets `main`.