### PR TITLE
fix(ui): route artifact image clicks to preview dialog

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
@@ -5714,10 +5714,10 @@ private fun ArtifactBrowserSheet(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .heightIn(max = 260.dp)
-                                        .clickable { zoomedImage = artifact }
                                         .semantics {
                                             contentDescription = "Zoom image ${artifact.displayName}"
                                         },
+                                    onImageClick = { zoomedImage = artifact },
                                     loadManagedImage = if (artifact.origin == ArtifactOrigin.ManagedPath) {
                                         { path -> onLoadManagedImage(path).getOrThrow() }
                                     } else {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImage.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImage.kt
@@ -239,6 +239,7 @@ internal fun RemoteMediaImage(
     source: String,
     modifier: Modifier = Modifier,
     loadManagedImage: (suspend (String) -> ByteArray)? = null,
+    onImageClick: (() -> Unit)? = null,
 ) {
     val state by produceState<RemoteImageUiState>(
         initialValue = RemoteImageRuntime.cached(source)
@@ -279,10 +280,15 @@ internal fun RemoteMediaImage(
         }
     }
 
+    val fallbackModifier = if (onImageClick == null) {
+        modifier
+    } else {
+        modifier.clickable(onClick = onImageClick)
+    }
     when (val current = state) {
         RemoteImageUiState.Loading -> {
             Box(
-                modifier = modifier
+                modifier = fallbackModifier
                     .fillMaxWidth()
                     .aspectRatio(16f / 9f)
                     .background(
@@ -301,12 +307,12 @@ internal fun RemoteMediaImage(
             }
         }
         is RemoteImageUiState.Loaded -> {
-            LoadedRemoteMediaImage(current.bitmap, modifier)
+            LoadedRemoteMediaImage(current.bitmap, modifier, onClick = onImageClick)
         }
         RemoteImageUiState.Failed -> {
             Text(
                 text = "Image unavailable",
-                modifier = modifier
+                modifier = fallbackModifier
                     .fillMaxWidth()
                     .background(
                         MaterialTheme.colorScheme.surfaceVariant,
@@ -324,11 +330,21 @@ internal fun RemoteMediaImage(
 internal fun LoadedRemoteMediaImage(
     bitmap: ImageBitmap,
     modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
 ) {
     var enlarged by remember { mutableStateOf(false) }
     var zoom by remember { mutableStateOf(1f) }
     var pan by remember { mutableStateOf(Offset.Zero) }
     val ratio = bitmap.width.toFloat() / bitmap.height.coerceAtLeast(1)
+    val imageClickModifier = if (onClick == null) {
+        Modifier.clickable {
+            zoom = 1f
+            pan = Offset.Zero
+            enlarged = true
+        }
+    } else {
+        Modifier.clickable(onClick = onClick)
+    }
     Image(
         bitmap = bitmap,
         contentDescription = "Generated image; tap to enlarge",
@@ -336,15 +352,11 @@ internal fun LoadedRemoteMediaImage(
             .fillMaxWidth()
             .aspectRatio(ratio.coerceIn(0.4f, 2.5f))
             .clip(RoundedCornerShape(8.dp))
-            .clickable {
-                zoom = 1f
-                pan = Offset.Zero
-                enlarged = true
-            },
+            .then(imageClickModifier),
         contentScale = ContentScale.Fit,
     )
 
-    if (enlarged) {
+    if (enlarged && onClick == null) {
         Dialog(
             onDismissRequest = { enlarged = false },
             properties = DialogProperties(

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
@@ -1,5 +1,6 @@
 package com.unsupportedpastels.hermesandroid.ui
 
+import android.graphics.Bitmap
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -86,6 +87,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.io.ByteArrayOutputStream
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [35])
@@ -282,6 +284,11 @@ class HermesAppTest {
     @Test
     fun sessionDetailsSummarizeArtifactsAndOpenArtifactBrowser() {
         val session = sessions.first()
+        val previewBytes = ByteArrayOutputStream().use { output ->
+            val bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888)
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output))
+            output.toByteArray()
+        }
         val snapshot = connectedSnapshot.copy(
             authenticationState = AuthenticationState.Authenticated,
             chatSessions = mapOf(
@@ -301,6 +308,7 @@ class HermesAppTest {
                 HermesApp(
                     snapshot = snapshot,
                     initialRoute = SessionDetailRoute(session.id),
+                    onLoadManagedImage = { Result.success(previewBytes) },
                 )
             }
         }


### PR DESCRIPTION
## Summary
- route artifact image taps through the artifact preview dialog
- prevent the generic image viewer from consuming artifact-row clicks
- make the artifact preview test use a deterministic PNG fixture

## Verification
- ./gradlew testDebugUnitTest lintDebug assembleDebug validateDebugScreenshotTest --rerun-tasks
- ./gradlew assembleRelease --rerun-tasks