### PR TITLE
feat(android): add Hermes Cloud connect mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ HAM uses the available window and posture — not a device name or orientation �
 
 HAM is a client, not an agent host. Install and configure Hermes Agent on a machine you control (or deploy an always-on **Hermes Cloud** instance from the [Nous Portal](https://portal.nousresearch.com/cloud)), then keep a compatible Hermes backend running before connecting from Android. The host remains authoritative for your agent, tools, files, sessions, and data.
 
-Both paths authenticate the same way — **Sign in with Nous**. For a managed Hermes Cloud instance the endpoints are already live: enter your Cloud instance's origin on HAM's Connect screen and sign in. The rest of this section covers self-hosting.
+Both paths authenticate the same way — **Sign in with Nous**. HAM's Connect screen has two modes:
+
+- **Hermes Cloud** — sign in once to Nous Portal and pick from the agents on your account; no URL to paste. HAM discovers your deployed [Hermes Cloud](https://portal.nousresearch.com/cloud) agents automatically and connects to the one you choose. Multi-org accounts get an org picker.
+- **Server URL** — enter the HTTP/HTTPS origin of a Hermes host you run yourself. Use this for self-hosting (below) or to connect to a known instance by hand.
+
+The rest of this section covers self-hosting.
 
 ### Recommended public access: HTTPS through Cloudflare Tunnel
 

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
@@ -77,6 +77,9 @@ class MainActivity : ComponentActivity() {
     private val paneLayoutPreferencesViewModel by viewModels<PaneLayoutPreferencesViewModel> {
         PaneLayoutPreferencesViewModel.Factory(this)
     }
+    private val cloudViewModel by viewModels<com.unsupportedpastels.hermesandroid.connection.HermesCloudViewModel> {
+        com.unsupportedpastels.hermesandroid.connection.HermesCloudViewModel.Factory(this)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -113,6 +116,7 @@ class MainActivity : ComponentActivity() {
                 HermesAppHost(
                     viewModel = serverSettingsViewModel,
                     connectionViewModel = connectionViewModel,
+                    cloudViewModel = cloudViewModel,
                     projectIconViewModel = projectIconViewModel,
                     paneLayoutPreferencesViewModel = paneLayoutPreferencesViewModel,
                     snapshot = snapshot,
@@ -134,6 +138,15 @@ class MainActivity : ComponentActivity() {
                             launchBrowserAndAwaitReturn(HermesWindowFocus.state) {
                                 startActivity(
                                     Intent(Intent.ACTION_VIEW, authorizationUrl.toUri()),
+                                )
+                            }
+                        }
+                    },
+                    onCloudSignIn = {
+                        cloudViewModel.signIn { verificationUrl ->
+                            launchBrowserAndAwaitReturn(HermesWindowFocus.state) {
+                                startActivity(
+                                    Intent(Intent.ACTION_VIEW, verificationUrl.toUri()),
                                 )
                             }
                         }
@@ -202,6 +215,7 @@ internal fun voiceScreenOffPreferenceKey(origin: ServerOrigin?): String =
 internal fun HermesAppHost(
     viewModel: ServerSettingsViewModel,
     connectionViewModel: HermesConnectionViewModel? = null,
+    cloudViewModel: com.unsupportedpastels.hermesandroid.connection.HermesCloudViewModel? = null,
     projectIconViewModel: ProjectIconViewModel? = null,
     paneLayoutPreferencesViewModel: PaneLayoutPreferencesViewModel? = null,
     snapshot: HermesGatewaySnapshot,
@@ -214,6 +228,7 @@ internal fun HermesAppHost(
     requestedSessionRequestId: Long? = null,
     onVisibleSessionChanged: (DurableSessionId?) -> Unit = {},
     onSignIn: () -> Unit = {},
+    onCloudSignIn: () -> Unit = {},
     onOpenProject: (ProjectId) -> Unit = {},
     onCreateProjectSession: (ProjectId) -> DurableSessionId? = { null },
     onOpenSession: (DurableSessionId) -> Unit = {},
@@ -226,6 +241,18 @@ internal fun HermesAppHost(
     onStopSession: (DurableSessionId) -> Unit = {},
 ) {
     val serverSettingsState by viewModel.states.collectAsStateWithLifecycle()
+    val cloudConnectStateFlow = cloudViewModel?.state
+        ?: remember {
+            MutableStateFlow<com.unsupportedpastels.hermesandroid.connection.CloudConnectState>(
+                com.unsupportedpastels.hermesandroid.connection.CloudConnectState.SignedOut,
+            )
+        }
+    val cloudConnectState by cloudConnectStateFlow.collectAsStateWithLifecycle()
+    // Silently resume a persisted Hermes Cloud session so the roster is ready
+    // when the user opens the connect surface; no-op when nothing is stored.
+    LaunchedEffect(cloudViewModel) {
+        cloudViewModel?.resume()
+    }
     val projectIconAssignmentsFlow = projectIconViewModel?.assignments
         ?: remember {
             MutableStateFlow<ProjectIconAssignmentsState>(ProjectIconAssignmentsState.Loading)
@@ -343,6 +370,23 @@ internal fun HermesAppHost(
         onUpdateServerLabel = { entry -> viewModel.updateLabel(entry).await() },
         onSelectServerOrigin = { origin -> viewModel.select(origin).await() },
         onRemoveServerOrigin = { origin -> viewModel.remove(origin).await() },
+        cloudState = cloudConnectState,
+        onCloudSignIn = onCloudSignIn,
+        onCloudRefresh = { cloudViewModel?.refresh() },
+        onCloudSignOut = { cloudViewModel?.signOut() },
+        onCloudSelectOrg = { org -> cloudViewModel?.selectOrg(org) },
+        onCloudSelectAgent = { agent ->
+            val dashboard = agent.dashboardUrl
+                ?: return@HermesApp Result.failure(
+                    IllegalStateException("Agent is still provisioning"),
+                )
+            val origin = runCatching {
+                com.unsupportedpastels.hermesandroid.connection.ServerOrigin.parse(dashboard)
+            }.getOrElse {
+                return@HermesApp Result.failure(it)
+            }
+            viewModel.save(origin).await()
+        },
         onLoadManagementSettings = { profile -> connectionViewModel?.loadManagementSettings(profile) },
         onRefreshDurableSessions = { archivedOnly ->
             connectionViewModel?.refreshDurableSessions(archivedOnly)

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloud.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloud.kt
@@ -1,0 +1,143 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Hermes Cloud discovery contract, mirrored from the desktop shell
+ * (`apps/desktop/electron/main.ts` — `discoverCloudAgents`, `trimCloudAgents`,
+ * `trimCloudOrg`, `parseOrgSelectionError`). These are the trimmed DTOs the
+ * Nous Portal `GET /api/agents` endpoint returns.
+ *
+ * The desktop authenticates that call with a Privy browser cookie because it is
+ * an Electron shell. A native client instead uses the Portal's device-code
+ * OAuth bearer (same `hermes-cli` client the CLI uses); both authenticate the
+ * identical endpoint. All parsing here is tolerant: unknown fields are ignored
+ * and malformed rows dropped so a preview-era Portal response can never crash
+ * the client.
+ */
+
+/** The canonical Nous Portal origin the CLI/desktop default to. */
+const val DEFAULT_NOUS_PORTAL_ORIGIN: String = "https://portal.nousresearch.com"
+
+/** A discovered Hermes Cloud agent — the trimmed row from `GET /api/agents`. */
+data class CloudAgent(
+    val id: String,
+    val name: String,
+    val status: String,
+    /** null until the agent has a provisioned dashboard (show "provisioning…"). */
+    val dashboardUrl: String?,
+    /** "active" | "degraded" | "down" | "unknown". */
+    val dashboardGatewayState: String,
+) {
+    /** True once the agent exposes a reachable dashboard origin to connect to. */
+    val isConnectable: Boolean
+        get() {
+            val url = dashboardUrl ?: return false
+            return url.isNotBlank() && runCatching { ServerOrigin.parse(url) }.isSuccess
+        }
+}
+
+/**
+ * An org the signed-in user belongs to. Surfaced for the picker shown when a
+ * multi-org user's discovery call needs disambiguation (Portal NAS 409).
+ */
+data class CloudOrg(
+    val id: String,
+    val slug: String?,
+    val name: String,
+    val isPersonal: Boolean,
+    /** "OWNER" | "MEMBER". */
+    val role: String,
+)
+
+/**
+ * Discovery result: either the agent list, OR a request to pick an org first
+ * (multi-org user, no org chosen yet). On the [Agents] branch, [Agents.org]
+ * echoes the authoritatively-resolved org the list was scoped to so the client
+ * can persist it without relying on transient picker state.
+ */
+sealed interface CloudDiscoverResult {
+    data class Agents(
+        val agents: List<CloudAgent>,
+        val org: CloudOrg?,
+    ) : CloudDiscoverResult
+
+    data class NeedsOrgSelection(
+        val orgs: List<CloudOrg>,
+    ) : CloudDiscoverResult
+}
+
+/**
+ * Pure, tolerant parsers for the Portal discovery contract. Kept separate from
+ * transport so protocol shape is unit-testable without a live server.
+ */
+object HermesCloudParsing {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Parse a successful `GET /api/agents` body into agents + resolved org. */
+    fun parseAgentsBody(body: String): CloudDiscoverResult.Agents {
+        val root = runCatching { json.parseToJsonElement(body) as? JsonObject }.getOrNull()
+        return CloudDiscoverResult.Agents(
+            agents = trimAgents(root?.get("agents")),
+            org = trimOrg(root?.get("org")),
+        )
+    }
+
+    /**
+     * Parse a 409 `org_selection_required` error body into the org list, or
+     * null when it isn't that shape (caller then treats it as a hard error).
+     */
+    fun parseOrgSelection(body: String): List<CloudOrg>? {
+        val root = runCatching { json.parseToJsonElement(body) as? JsonObject }.getOrNull()
+            ?: return null
+        val error = root["error"]?.jsonPrimitive?.contentOrNull
+        if (error != "org_selection_required") return null
+        val orgsElement = root["orgs"] ?: return null
+        val orgs = trimOrgs(orgsElement)
+        return orgs
+    }
+
+    private fun trimAgents(element: JsonElement?): List<CloudAgent> {
+        val array = runCatching { element?.jsonArray }.getOrNull() ?: return emptyList()
+        return array.mapNotNull { entry ->
+            val obj = runCatching { entry.jsonObject }.getOrNull() ?: return@mapNotNull null
+            val id = obj["id"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            if (id.isBlank()) return@mapNotNull null
+            CloudAgent(
+                id = id,
+                name = obj["name"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() } ?: id,
+                status = obj["status"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+                    ?: "unknown",
+                dashboardUrl = obj["dashboardUrl"]?.jsonPrimitive?.contentOrNull
+                    ?.takeIf { it.isNotBlank() },
+                dashboardGatewayState = obj["dashboardGatewayState"]?.jsonPrimitive?.contentOrNull
+                    ?.takeIf { it.isNotBlank() } ?: "unknown",
+            )
+        }
+    }
+
+    private fun trimOrgs(element: JsonElement?): List<CloudOrg> {
+        val array = runCatching { element?.jsonArray }.getOrNull() ?: return emptyList()
+        return array.mapNotNull { entry -> trimOrg(entry) }
+    }
+
+    private fun trimOrg(element: JsonElement?): CloudOrg? {
+        val obj = runCatching { element?.jsonObject }.getOrNull() ?: return null
+        val id = obj["id"]?.jsonPrimitive?.contentOrNull ?: return null
+        if (id.isBlank()) return null
+        return CloudOrg(
+            id = id,
+            slug = obj["slug"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
+            name = obj["name"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() } ?: id,
+            isPersonal = obj["isPersonal"]?.jsonPrimitive?.booleanOrNull ?: false,
+            role = obj["role"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() } ?: "MEMBER",
+        )
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloud.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloud.kt
@@ -1,13 +1,12 @@
 package com.unsupportedpastels.hermesandroid.connection
 
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Hermes Cloud discovery contract, mirrored from the desktop shell
@@ -97,7 +96,7 @@ object HermesCloudParsing {
     fun parseOrgSelection(body: String): List<CloudOrg>? {
         val root = runCatching { json.parseToJsonElement(body) as? JsonObject }.getOrNull()
             ?: return null
-        val error = root["error"]?.jsonPrimitive?.contentOrNull
+        val error = (root["error"] as? JsonPrimitive)?.contentOrNull
         if (error != "org_selection_required") return null
         val orgsElement = root["orgs"] ?: return null
         val orgs = trimOrgs(orgsElement)
@@ -105,39 +104,50 @@ object HermesCloudParsing {
     }
 
     private fun trimAgents(element: JsonElement?): List<CloudAgent> {
-        val array = runCatching { element?.jsonArray }.getOrNull() ?: return emptyList()
+        val array = (element as? JsonArray) ?: return emptyList()
         return array.mapNotNull { entry ->
-            val obj = runCatching { entry.jsonObject }.getOrNull() ?: return@mapNotNull null
-            val id = obj["id"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
-            if (id.isBlank()) return@mapNotNull null
-            CloudAgent(
-                id = id,
-                name = obj["name"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() } ?: id,
-                status = obj["status"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
-                    ?: "unknown",
-                dashboardUrl = obj["dashboardUrl"]?.jsonPrimitive?.contentOrNull
-                    ?.takeIf { it.isNotBlank() },
-                dashboardGatewayState = obj["dashboardGatewayState"]?.jsonPrimitive?.contentOrNull
-                    ?.takeIf { it.isNotBlank() } ?: "unknown",
-            )
+            // Wrap the whole row so a single preview-era schema mismatch (e.g. a
+            // wrong-typed field like "name": {}) discards only that row instead
+            // of failing the entire discovery — the tolerant-row contract.
+            runCatching {
+                val obj = (entry as? JsonObject) ?: return@runCatching null
+                val id = obj.stringOrNull("id") ?: return@runCatching null
+                if (id.isBlank()) return@runCatching null
+                CloudAgent(
+                    id = id,
+                    name = obj.stringOrNull("name")?.takeIf { it.isNotBlank() } ?: id,
+                    status = obj.stringOrNull("status")?.takeIf { it.isNotBlank() } ?: "unknown",
+                    dashboardUrl = obj.stringOrNull("dashboardUrl")?.takeIf { it.isNotBlank() },
+                    dashboardGatewayState = obj.stringOrNull("dashboardGatewayState")
+                        ?.takeIf { it.isNotBlank() } ?: "unknown",
+                )
+            }.getOrNull()
         }
     }
 
     private fun trimOrgs(element: JsonElement?): List<CloudOrg> {
-        val array = runCatching { element?.jsonArray }.getOrNull() ?: return emptyList()
+        val array = (element as? JsonArray) ?: return emptyList()
         return array.mapNotNull { entry -> trimOrg(entry) }
     }
 
-    private fun trimOrg(element: JsonElement?): CloudOrg? {
-        val obj = runCatching { element?.jsonObject }.getOrNull() ?: return null
-        val id = obj["id"]?.jsonPrimitive?.contentOrNull ?: return null
-        if (id.isBlank()) return null
-        return CloudOrg(
+    private fun trimOrg(element: JsonElement?): CloudOrg? = runCatching {
+        val obj = (element as? JsonObject) ?: return@runCatching null
+        val id = obj.stringOrNull("id") ?: return@runCatching null
+        if (id.isBlank()) return@runCatching null
+        CloudOrg(
             id = id,
-            slug = obj["slug"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
-            name = obj["name"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() } ?: id,
-            isPersonal = obj["isPersonal"]?.jsonPrimitive?.booleanOrNull ?: false,
-            role = obj["role"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() } ?: "MEMBER",
+            slug = obj.stringOrNull("slug")?.takeIf { it.isNotBlank() },
+            name = obj.stringOrNull("name")?.takeIf { it.isNotBlank() } ?: id,
+            isPersonal = obj.booleanOrNull("isPersonal") ?: false,
+            role = obj.stringOrNull("role")?.takeIf { it.isNotBlank() } ?: "MEMBER",
         )
-    }
+    }.getOrNull()
+
+    /** Read a string field, returning null for absent OR wrong-typed values. */
+    private fun JsonObject.stringOrNull(key: String): String? =
+        (this[key] as? JsonPrimitive)?.contentOrNull
+
+    /** Read a boolean field, returning null for absent OR wrong-typed values. */
+    private fun JsonObject.booleanOrNull(key: String): Boolean? =
+        (this[key] as? JsonPrimitive)?.booleanOrNull
 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudClient.kt
@@ -1,0 +1,368 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.parameter
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.content.TextContent
+import io.ktor.http.isSuccess
+import java.net.UnknownHostException
+import java.nio.channels.UnresolvedAddressException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A Nous Portal OAuth token set — distinct from a per-agent dashboard
+ * [NativeTokenSet]. This authenticates Hermes Cloud discovery (`GET /api/agents`)
+ * and is minted via the Portal device-code flow (RFC 8628), the same flow the
+ * `hermes` CLI uses (`hermes_cli/auth.py`, `client_id = "hermes-cli"`,
+ * scope `inference:invoke`).
+ */
+@Serializable
+data class PortalTokenSet(
+    val accessToken: String,
+    val refreshToken: String,
+    val tokenType: String,
+    val scope: String,
+    /** Epoch seconds; 0 when the server did not supply an expiry. */
+    val expiresAt: Long,
+)
+
+/** A pending device authorization, from `POST /api/oauth/device/code`. */
+data class PortalDeviceCode(
+    val deviceCode: String,
+    val userCode: String,
+    val verificationUri: String,
+    val verificationUriComplete: String,
+    val expiresInSeconds: Long,
+    val intervalSeconds: Long,
+)
+
+/** Raised when the Portal session is absent/expired and a fresh sign-in is needed. */
+class HermesCloudSignInRequiredException(
+    message: String = "Sign in to Hermes Cloud to continue.",
+    cause: Throwable? = null,
+) : HermesConnectionException(message, cause)
+
+/** The Portal contract HAM depends on: device-code sign-in, refresh, discovery. */
+interface HermesCloudClient {
+    /** Start a device authorization; returns the code + verification URL to open. */
+    suspend fun requestDeviceCode(portalOrigin: ServerOrigin): PortalDeviceCode
+
+    /**
+     * Poll the token endpoint until the user approves the [deviceCode], honoring
+     * the server's `interval`/`slow_down` backoff and the code's expiry. Throws
+     * [HermesCloudSignInRequiredException] on denial/expiry.
+     */
+    suspend fun awaitDeviceToken(
+        portalOrigin: ServerOrigin,
+        deviceCode: PortalDeviceCode,
+    ): PortalTokenSet
+
+    /**
+     * Exchange a persisted refresh token for a fresh access token. The Portal
+     * rotates refresh tokens with reuse detection, so the returned set's
+     * [PortalTokenSet.refreshToken] MUST replace the stored one immediately.
+     * Throws [HermesCloudSignInRequiredException] on a terminal grant rejection.
+     */
+    suspend fun refreshToken(
+        portalOrigin: ServerOrigin,
+        refreshToken: String,
+    ): PortalTokenSet
+
+    /**
+     * Discover the Hermes Cloud agents visible to the signed-in user. Pass [org]
+     * (a slug or id) to scope a multi-org account. A 401 surfaces as
+     * [HermesCloudSignInRequiredException]; a 409 returns
+     * [CloudDiscoverResult.NeedsOrgSelection].
+     */
+    suspend fun discoverAgents(
+        portalOrigin: ServerOrigin,
+        accessToken: String,
+        org: String? = null,
+    ): CloudDiscoverResult
+}
+
+class HttpHermesCloudClient(
+    private val client: HttpClient,
+    private val clientId: String = PORTAL_CLIENT_ID,
+    private val scope: String = PORTAL_SCOPE,
+    private val delayMillis: suspend (Long) -> Unit = { delay(it) },
+    private val nowSeconds: () -> Long = { System.currentTimeMillis() / 1000 },
+) : HermesCloudClient {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * CIO on Android intermittently throws [UnresolvedAddressException] /
+     * [UnknownHostException] on the first request after the app is backgrounded
+     * — exactly what happens when the sign-in browser opens over this flow. The
+     * existing native token exchanger ([HttpHermesNativeAuthClient]) retries the
+     * same class of transient DNS failure; mirror it so a blip on the token poll
+     * or discovery call doesn't abort an otherwise-successful sign-in.
+     */
+    private suspend fun httpWithDnsRetry(
+        url: String,
+        method: HttpMethod,
+        block: HttpRequestBuilder.() -> Unit,
+    ): HttpResponse {
+        var attempt = 0
+        while (true) {
+            attempt += 1
+            try {
+                return client.request(url) {
+                    this.method = method
+                    block()
+                }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                if (!error.isTransientNetworkFailure() || attempt >= MAX_DNS_ATTEMPTS) throw error
+                delayMillis(DNS_RETRY_BASE_MILLIS * attempt)
+            }
+        }
+    }
+
+    private fun Throwable.isTransientNetworkFailure(): Boolean =
+        generateSequence<Throwable>(this) { it.cause }
+            .any { it is UnknownHostException || it is UnresolvedAddressException }
+
+    override suspend fun requestDeviceCode(portalOrigin: ServerOrigin): PortalDeviceCode = try {
+        val response = httpWithDnsRetry(
+            "${portalOrigin.value}/api/oauth/device/code",
+            HttpMethod.Post,
+        ) {
+            header("Accept", "application/json")
+            setBody(
+                TextContent(
+                    formEncode(
+                        "client_id" to clientId,
+                        "scope" to scope,
+                    ),
+                    ContentType.Application.FormUrlEncoded,
+                ),
+            )
+        }
+        val body = response.readBodyTextBounded()
+        if (!response.status.isSuccess()) {
+            throw HermesConnectionException(
+                "Hermes Cloud device authorization returned HTTP ${response.status.value}",
+            )
+        }
+        val root = json.parseToJsonElement(body).jsonObject
+        val deviceCode = root.string("device_code")
+        val userCode = root.string("user_code")
+        val verificationUri = root.string("verification_uri")
+        val verificationUriComplete = root["verification_uri_complete"]
+            ?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() } ?: verificationUri
+        if (deviceCode.isBlank() || userCode.isBlank() || verificationUri.isBlank()) {
+            throw HermesConnectionException("Hermes Cloud device authorization was incomplete")
+        }
+        PortalDeviceCode(
+            deviceCode = deviceCode,
+            userCode = userCode,
+            verificationUri = verificationUri,
+            verificationUriComplete = verificationUriComplete,
+            expiresInSeconds = root["expires_in"]?.jsonPrimitive?.longOrNull ?: 600L,
+            intervalSeconds = (root["interval"]?.jsonPrimitive?.longOrNull ?: 5L)
+                .coerceIn(1L, 30L),
+        )
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (error: HermesConnectionException) {
+        throw error
+    } catch (error: Exception) {
+        throw HermesConnectionException(
+            "Could not start Hermes Cloud sign-in (${error.javaClass.simpleName})",
+            error,
+        )
+    }
+
+    override suspend fun awaitDeviceToken(
+        portalOrigin: ServerOrigin,
+        deviceCode: PortalDeviceCode,
+    ): PortalTokenSet {
+        var interval = deviceCode.intervalSeconds.coerceIn(1L, 30L)
+        val deadline = nowSeconds() + deviceCode.expiresInSeconds.coerceAtLeast(1L)
+        while (nowSeconds() < deadline) {
+            delayMillis(interval * 1000L)
+            // The user is approving in the browser, so this app is backgrounded
+            // and Android may tear the network down: CIO then throws
+            // UnresolvedAddressException/UnknownHostException. During a device
+            // flow that is NOT terminal — it's the same "keep waiting" case as
+            // authorization_pending. Swallow transient network failures and keep
+            // polling until the code's own deadline, or the sign-in dies the
+            // instant the browser steals focus.
+            val response = try {
+                httpWithDnsRetry(
+                    "${portalOrigin.value}/api/oauth/token",
+                    HttpMethod.Post,
+                ) {
+                    header("Accept", "application/json")
+                    setBody(
+                        TextContent(
+                            formEncode(
+                                "grant_type" to "urn:ietf:params:oauth:grant-type:device_code",
+                                "client_id" to clientId,
+                                "device_code" to deviceCode.deviceCode,
+                            ),
+                            ContentType.Application.FormUrlEncoded,
+                        ),
+                    )
+                }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                if (error.isTransientNetworkFailure()) continue
+                throw error
+            }
+            val body = response.readBodyTextBounded()
+            if (response.status.isSuccess()) {
+                return parseTokenBody(body)
+            }
+            when (errorCode(body)) {
+                "authorization_pending" -> Unit
+                "slow_down" -> interval = (interval + 5L).coerceAtMost(30L)
+                else -> throw HermesCloudSignInRequiredException(
+                    "Hermes Cloud sign-in was not approved.",
+                )
+            }
+        }
+        throw HermesCloudSignInRequiredException(
+            "Hermes Cloud sign-in timed out. Start again to get a new code.",
+        )
+    }
+
+    override suspend fun refreshToken(
+        portalOrigin: ServerOrigin,
+        refreshToken: String,
+    ): PortalTokenSet {
+        val response = httpWithDnsRetry(
+            "${portalOrigin.value}/api/oauth/token",
+            HttpMethod.Post,
+        ) {
+            header("Accept", "application/json")
+            header("x-nous-refresh-token", refreshToken)
+            setBody(
+                TextContent(
+                    formEncode(
+                        "grant_type" to "refresh_token",
+                        "client_id" to clientId,
+                    ),
+                    ContentType.Application.FormUrlEncoded,
+                ),
+            )
+        }
+        val body = response.readBodyTextBounded()
+        if (response.status.isSuccess()) {
+            val refreshed = parseTokenBody(body)
+            // The Portal rotates refresh tokens; carry the previous one forward
+            // only if the response omitted a replacement.
+            return if (refreshed.refreshToken.isBlank()) {
+                refreshed.copy(refreshToken = refreshToken)
+            } else {
+                refreshed
+            }
+        }
+        val code = errorCode(body)
+        if (code in TERMINAL_REFRESH_ERRORS) {
+            throw HermesCloudSignInRequiredException(
+                "Your Hermes Cloud session expired. Sign in again.",
+            )
+        }
+        throw HermesConnectionException(
+            "Hermes Cloud token refresh returned HTTP ${response.status.value}",
+        )
+    }
+
+    override suspend fun discoverAgents(
+        portalOrigin: ServerOrigin,
+        accessToken: String,
+        org: String?,
+    ): CloudDiscoverResult {
+        val response = httpWithDnsRetry(
+            "${portalOrigin.value}/api/agents",
+            HttpMethod.Get,
+        ) {
+            header("Accept", "application/json")
+            bearerAuth(accessToken)
+            if (!org.isNullOrBlank()) parameter("org", org)
+        }
+        val body = response.readBodyTextBounded()
+        if (response.status.isSuccess()) {
+            return HermesCloudParsing.parseAgentsBody(body)
+        }
+        when (response.status.value) {
+            401, 403 -> throw HermesCloudSignInRequiredException(
+                "Your Hermes Cloud session expired. Sign in again.",
+            )
+            409 -> {
+                val orgs = HermesCloudParsing.parseOrgSelection(body)
+                if (orgs != null) return CloudDiscoverResult.NeedsOrgSelection(orgs)
+            }
+        }
+        throw HermesConnectionException(
+            "Could not load your Hermes Cloud agents (HTTP ${response.status.value})",
+        )
+    }
+
+    private fun parseTokenBody(body: String): PortalTokenSet {
+        val root = json.parseToJsonElement(body).jsonObject
+        val accessToken = root.string("access_token")
+        if (accessToken.isBlank()) {
+            throw HermesConnectionException("Hermes Cloud token response was incomplete")
+        }
+        val expiresIn = root["expires_in"]?.jsonPrimitive?.longOrNull
+        return PortalTokenSet(
+            accessToken = accessToken,
+            refreshToken = root.string("refresh_token"),
+            tokenType = root["token_type"]?.jsonPrimitive?.contentOrNull
+                ?.takeIf { it.isNotBlank() } ?: "Bearer",
+            scope = root["scope"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() } ?: scope,
+            expiresAt = if (expiresIn != null && expiresIn > 0) nowSeconds() + expiresIn else 0L,
+        )
+    }
+
+    private fun errorCode(body: String): String? =
+        runCatching { (json.parseToJsonElement(body) as? JsonObject)?.string("error") }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+
+    private fun JsonObject.string(key: String): String =
+        this[key]?.jsonPrimitive?.contentOrNull.orEmpty().trim()
+
+    private fun formEncode(vararg pairs: Pair<String, String>): String =
+        pairs.joinToString("&") { (k, v) ->
+            "${k.encodeFormComponent()}=${v.encodeFormComponent()}"
+        }
+
+    private fun String.encodeFormComponent(): String =
+        java.net.URLEncoder.encode(this, "UTF-8")
+
+    companion object {
+        const val PORTAL_CLIENT_ID = "hermes-cli"
+        const val PORTAL_SCOPE = "inference:invoke"
+        private const val MAX_DNS_ATTEMPTS = 3
+        private const val DNS_RETRY_BASE_MILLIS = 500L
+        private val TERMINAL_REFRESH_ERRORS = setOf(
+            "invalid_grant",
+            "invalid_token",
+            "refresh_token_reused",
+        )
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudViewModel.kt
@@ -1,0 +1,232 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Presentation state for the Hermes Cloud connect surface. This is a distinct
+ * concern from [ServerSettingsState] (which owns the manual server-URL catalog):
+ * once the user picks an agent, its `dashboardUrl` is saved as an ordinary
+ * server origin and the existing dashboard `native_pkce` sign-in flow takes over
+ * unchanged.
+ */
+sealed interface CloudConnectState {
+    /** No Portal session yet — show the "Sign in to Hermes Cloud" action. */
+    data object SignedOut : CloudConnectState
+
+    /**
+     * A device-code sign-in is in progress. [userCode] and [verificationUri] are
+     * shown so the user can confirm the code the browser opened to.
+     */
+    data class SigningIn(
+        val userCode: String,
+        val verificationUri: String,
+    ) : CloudConnectState
+
+    /** Signed in; loading the agent roster. */
+    data object Discovering : CloudConnectState
+
+    /** Multi-org account: the user must pick which org's agents to list. */
+    data class SelectOrg(
+        val orgs: List<CloudOrg>,
+    ) : CloudConnectState
+
+    /** Signed in with the agent roster resolved. */
+    data class Agents(
+        val agents: List<CloudAgent>,
+        val org: CloudOrg?,
+    ) : CloudConnectState
+
+    /** A non-fatal failure with a retry affordance; still signed in unless [signedOut]. */
+    data class Error(
+        val message: String,
+        val signedOut: Boolean,
+    ) : CloudConnectState
+}
+
+/**
+ * Owns Hermes Cloud sign-in (Portal device-code OAuth) and agent discovery.
+ *
+ * The Portal access token is persisted encrypted and refreshed silently; only a
+ * terminal grant rejection ([HermesCloudSignInRequiredException]) drops to
+ * [CloudConnectState.SignedOut]. Selecting an agent hands off to
+ * [onAgentSelected] with the agent's dashboard [ServerOrigin], which the caller
+ * saves so the existing dashboard sign-in flow connects to it.
+ */
+class HermesCloudViewModel(
+    private val client: HermesCloudClient,
+    private val tokenStore: PortalTokenStore,
+    private val portalOrigin: ServerOrigin = ServerOrigin.parse(DEFAULT_NOUS_PORTAL_ORIGIN),
+    private val nowSeconds: () -> Long = { System.currentTimeMillis() / 1000 },
+    private val closeResources: () -> Unit = {},
+) : ViewModel() {
+    private val mutableState = MutableStateFlow<CloudConnectState>(CloudConnectState.SignedOut)
+    val state: StateFlow<CloudConnectState> = mutableState.asStateFlow()
+
+    private var activeJob: Job? = null
+    private var selectedOrg: String? = null
+
+    /**
+     * Attempt a silent resume: if a Portal token is persisted, refresh it if
+     * needed and discover agents without any user interaction. Leaves the state
+     * at [CloudConnectState.SignedOut] when there is nothing to resume, so the
+     * connect screen simply offers sign-in.
+     */
+    fun resume() {
+        activeJob?.cancel()
+        activeJob = viewModelScope.launch {
+            val stored = tokenStore.load(portalOrigin) ?: run {
+                mutableState.value = CloudConnectState.SignedOut
+                return@launch
+            }
+            mutableState.value = CloudConnectState.Discovering
+            runCatching { discoverWithValidToken(stored) }
+                .onFailure { error -> publishError(error) }
+        }
+    }
+
+    /**
+     * Start the interactive device-code flow. [openBrowser] receives the
+     * verification URL to launch (system browser / custom tab); the returned Job
+     * completes when discovery resolves or fails.
+     */
+    fun signIn(openBrowser: suspend (String) -> Unit): Job {
+        activeJob?.cancel()
+        val job = viewModelScope.launch {
+            try {
+                val device = client.requestDeviceCode(portalOrigin)
+                mutableState.value = CloudConnectState.SigningIn(
+                    userCode = device.userCode,
+                    verificationUri = device.verificationUriComplete,
+                )
+                launch { openBrowser(device.verificationUriComplete) }
+                val tokens = client.awaitDeviceToken(portalOrigin, device)
+                tokenStore.save(portalOrigin, tokens)
+                mutableState.value = CloudConnectState.Discovering
+                discover(tokens.accessToken)
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                publishError(error)
+            }
+        }
+        activeJob = job
+        return job
+    }
+
+    /** Re-run discovery scoped to a chosen org (from [CloudConnectState.SelectOrg]). */
+    fun selectOrg(org: CloudOrg) {
+        selectedOrg = org.slug ?: org.id
+        activeJob?.cancel()
+        activeJob = viewModelScope.launch {
+            val stored = tokenStore.load(portalOrigin) ?: run {
+                mutableState.value = CloudConnectState.SignedOut
+                return@launch
+            }
+            mutableState.value = CloudConnectState.Discovering
+            runCatching { discoverWithValidToken(stored) }
+                .onFailure { error -> publishError(error) }
+        }
+    }
+
+    /** Reload the agent roster with the persisted token. */
+    fun refresh() = resume()
+
+    /** Clear the persisted Portal session and return to the signed-out state. */
+    fun signOut() {
+        activeJob?.cancel()
+        selectedOrg = null
+        activeJob = viewModelScope.launch {
+            runCatching { tokenStore.clear(portalOrigin) }
+            mutableState.value = CloudConnectState.SignedOut
+        }
+    }
+
+    private suspend fun discoverWithValidToken(stored: PortalTokenSet) {
+        // Refresh proactively when the access token is expired/near-expiry so
+        // discovery does not 401 into a re-login the refresh token could heal.
+        val token = if (stored.expiresAt in 1 until (nowSeconds() + EXPIRY_SKEW_SECONDS)) {
+            val refreshed = client.refreshToken(portalOrigin, stored.refreshToken)
+            tokenStore.save(portalOrigin, refreshed)
+            refreshed.accessToken
+        } else {
+            stored.accessToken
+        }
+        try {
+            discover(token)
+        } catch (signInRequired: HermesCloudSignInRequiredException) {
+            // A live token still rejected: try one refresh before giving up.
+            val refreshed = client.refreshToken(portalOrigin, stored.refreshToken)
+            tokenStore.save(portalOrigin, refreshed)
+            discover(refreshed.accessToken)
+        }
+    }
+
+    private suspend fun discover(accessToken: String) {
+        when (val result = client.discoverAgents(portalOrigin, accessToken, selectedOrg)) {
+            is CloudDiscoverResult.Agents -> {
+                selectedOrg = result.org?.slug ?: result.org?.id ?: selectedOrg
+                mutableState.value = CloudConnectState.Agents(result.agents, result.org)
+            }
+            is CloudDiscoverResult.NeedsOrgSelection -> {
+                mutableState.value = CloudConnectState.SelectOrg(result.orgs)
+            }
+        }
+    }
+
+    private suspend fun publishError(error: Throwable) {
+        if (error is CancellationException) throw error
+        val signInRequired = error is HermesCloudSignInRequiredException
+        if (signInRequired) {
+            runCatching { tokenStore.clear(portalOrigin) }
+        }
+        // A transient DNS/host failure (common right after the sign-in browser
+        // backgrounds the app) is not a sign-out; surface a plain retry, keep the
+        // token, and never say "could not reach" for a blip that a Retry fixes.
+        val transientNetwork = !signInRequired &&
+            generateSequence(error) { it.cause }.any {
+                it is java.net.UnknownHostException ||
+                    it is java.nio.channels.UnresolvedAddressException
+            }
+        val message = when {
+            transientNetwork -> "Network unavailable. Tap Retry."
+            else -> (error as? HermesConnectionException)?.message?.takeIf { it.isNotBlank() }
+                ?: "Could not reach Hermes Cloud (${error.javaClass.simpleName})"
+        }
+        mutableState.value = CloudConnectState.Error(message, signedOut = signInRequired)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        runCatching { closeResources() }
+    }
+
+    private companion object {
+        const val EXPIRY_SKEW_SECONDS = 60L
+    }
+
+    class Factory(context: Context) : ViewModelProvider.Factory {
+        private val applicationContext = context.applicationContext
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(HermesCloudViewModel::class.java))
+            val httpClient = HttpClient(CIO) { configureHermesHttpClient() }
+            return HermesCloudViewModel(
+                client = HttpHermesCloudClient(httpClient),
+                tokenStore = EncryptedPortalTokenStore(applicationContext),
+                closeResources = httpClient::close,
+            ) as T
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudViewModel.kt
@@ -155,18 +155,20 @@ class HermesCloudViewModel(
     private suspend fun discoverWithValidToken(stored: PortalTokenSet) {
         // Refresh proactively when the access token is expired/near-expiry so
         // discovery does not 401 into a re-login the refresh token could heal.
-        val token = if (stored.expiresAt in 1 until (nowSeconds() + EXPIRY_SKEW_SECONDS)) {
-            val refreshed = client.refreshToken(portalOrigin, stored.refreshToken)
-            tokenStore.save(portalOrigin, refreshed)
-            refreshed.accessToken
-        } else {
-            stored.accessToken
+        // Track the CURRENT token set: the Portal rotates (and reuse-detects)
+        // refresh tokens, so the 401 fallback below must reuse the rotated token,
+        // never the original that a proactive refresh already consumed.
+        var current = stored
+        if (stored.expiresAt in 1 until (nowSeconds() + EXPIRY_SKEW_SECONDS)) {
+            current = client.refreshToken(portalOrigin, stored.refreshToken)
+            tokenStore.save(portalOrigin, current)
         }
         try {
-            discover(token)
+            discover(current.accessToken)
         } catch (signInRequired: HermesCloudSignInRequiredException) {
-            // A live token still rejected: try one refresh before giving up.
-            val refreshed = client.refreshToken(portalOrigin, stored.refreshToken)
+            // A live token still rejected: try one refresh before giving up,
+            // using the latest (possibly already-rotated) refresh token.
+            val refreshed = client.refreshToken(portalOrigin, current.refreshToken)
             tokenStore.save(portalOrigin, refreshed)
             discover(refreshed.accessToken)
         }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/PortalTokenStore.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/PortalTokenStore.kt
@@ -1,0 +1,143 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import android.content.Context
+import android.util.Base64
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.aead.AeadKeyTemplates
+import com.google.crypto.tink.integration.android.AndroidKeysetManager
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Encrypted at-rest storage for the Nous Portal OAuth token that authenticates
+ * Hermes Cloud discovery. Scoped by portal origin (there is only one canonical
+ * portal today, but staging overrides exist), mirroring [EncryptedNativeTokenStore]
+ * so the refresh token never touches plaintext prefs.
+ */
+interface PortalTokenStore {
+    suspend fun load(portalOrigin: ServerOrigin): PortalTokenSet?
+
+    suspend fun save(portalOrigin: ServerOrigin, tokens: PortalTokenSet)
+
+    suspend fun clear(portalOrigin: ServerOrigin)
+}
+
+class EncryptedPortalTokenStore(
+    context: Context,
+    private val preferencesName: String = DEFAULT_PREFERENCES_NAME,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    aeadFactory: () -> Aead = {
+        createAead(context.applicationContext, preferencesName)
+    },
+) : PortalTokenStore {
+    private val preferences = context.applicationContext
+        .getSharedPreferences(preferencesName, Context.MODE_PRIVATE)
+    private val json = Json { ignoreUnknownKeys = true }
+    private val aead by lazy(LazyThreadSafetyMode.SYNCHRONIZED, aeadFactory)
+
+    override suspend fun load(portalOrigin: ServerOrigin): PortalTokenSet? = withContext(ioDispatcher) {
+        val encoded = preferences.getString(preferenceKey(portalOrigin), null)
+            ?: return@withContext null
+        val ciphertext = runCatching { Base64.decode(encoded, Base64.DEFAULT) }.getOrNull()
+            ?: return@withContext null
+        if (ciphertext.size > MAX_CIPHERTEXT_BYTES) return@withContext null
+
+        runCatching {
+            val plaintext = aead.decrypt(ciphertext, associatedData(portalOrigin))
+            if (plaintext.size > MAX_SERIALIZED_TOKEN_BYTES) return@runCatching null
+            val tokens = json.decodeFromString<PortalTokenSet>(
+                plaintext.toString(StandardCharsets.UTF_8),
+            )
+            validate(tokens)
+            tokens
+        }.getOrNull()
+    }
+
+    @Suppress("UseKtx") // Preserve commit() result so credential persistence fails closed.
+    override suspend fun save(portalOrigin: ServerOrigin, tokens: PortalTokenSet) = withContext(ioDispatcher) {
+        validate(tokens)
+        val plaintext = json.encodeToString(tokens).toByteArray(StandardCharsets.UTF_8)
+        require(plaintext.size <= MAX_SERIALIZED_TOKEN_BYTES) {
+            "Portal token record is too large"
+        }
+        val ciphertext = aead.encrypt(plaintext, associatedData(portalOrigin))
+        require(ciphertext.size <= MAX_CIPHERTEXT_BYTES) {
+            "Portal token record is too large"
+        }
+        check(
+            preferences.edit()
+                .putString(
+                    preferenceKey(portalOrigin),
+                    Base64.encodeToString(ciphertext, Base64.NO_WRAP),
+                )
+                .commit(),
+        ) { "Could not persist Portal tokens" }
+    }
+
+    @Suppress("UseKtx") // Preserve commit() result so credential removal fails closed.
+    override suspend fun clear(portalOrigin: ServerOrigin) = withContext(ioDispatcher) {
+        check(
+            preferences.edit()
+                .remove(preferenceKey(portalOrigin))
+                .commit(),
+        ) { "Could not clear Portal tokens" }
+    }
+
+    private fun associatedData(portalOrigin: ServerOrigin): ByteArray =
+        portalOrigin.value.toByteArray(StandardCharsets.UTF_8)
+
+    private fun preferenceKey(portalOrigin: ServerOrigin): String =
+        "portal_" + sha256(portalOrigin.value).toHex()
+
+    private fun validate(tokens: PortalTokenSet) {
+        require(tokens.accessToken.isNotBlank()) { "Portal token response was incomplete" }
+        requireTokenSize(tokens.accessToken)
+        requireTokenSize(tokens.refreshToken)
+        requireTokenSize(tokens.tokenType)
+        requireTokenSize(tokens.scope)
+    }
+
+    private fun requireTokenSize(value: String) {
+        require(value.toByteArray(StandardCharsets.UTF_8).size <= MAX_TOKEN_FIELD_BYTES) {
+            "Portal token field is too large"
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_PREFERENCES_NAME = "portal_token_store"
+        const val KEYSET_PREFERENCES_SUFFIX = ".keyset"
+        const val KEYSET_NAME = "portal_token_store_keyset"
+        const val MASTER_KEY_URI = "android-keystore://portal_token_store_master"
+        const val MAX_TOKEN_FIELD_BYTES = 16 * 1024
+        const val MAX_SERIALIZED_TOKEN_BYTES = 64 * 1024
+        const val MAX_CIPHERTEXT_BYTES = MAX_SERIALIZED_TOKEN_BYTES + 1024
+
+        fun createAead(context: Context, preferencesName: String): Aead {
+            AeadConfig.register()
+            return AndroidKeysetManager.Builder()
+                .withSharedPref(
+                    context,
+                    "$KEYSET_NAME:$preferencesName",
+                    "$preferencesName$KEYSET_PREFERENCES_SUFFIX",
+                )
+                .withKeyTemplate(AeadKeyTemplates.AES256_GCM)
+                .withMasterKeyUri(MASTER_KEY_URI)
+                .build()
+                .keysetHandle
+                .getPrimitive(Aead::class.java)
+        }
+
+        fun sha256(value: String): ByteArray = MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray(StandardCharsets.UTF_8))
+
+        fun ByteArray.toHex(): String = joinToString("") { byte ->
+            "%02x".format(byte.toInt() and 0xff)
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
@@ -108,6 +108,9 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -424,6 +427,14 @@ fun HermesApp(
     },
     onRemoveServerOrigin: suspend (ServerOrigin) -> Result<Unit> = { _ ->
         Result.failure(UnsupportedOperationException("Removing servers is unavailable"))
+    },
+    cloudState: com.unsupportedpastels.hermesandroid.connection.CloudConnectState? = null,
+    onCloudSignIn: () -> Unit = {},
+    onCloudRefresh: () -> Unit = {},
+    onCloudSignOut: () -> Unit = {},
+    onCloudSelectOrg: (com.unsupportedpastels.hermesandroid.connection.CloudOrg) -> Unit = {},
+    onCloudSelectAgent: suspend (com.unsupportedpastels.hermesandroid.connection.CloudAgent) -> Result<Unit> = {
+        Result.success(Unit)
     },
     onLoadManagementSettings: (String) -> Unit = {},
     onRefreshDurableSessions: (Boolean) -> Unit = {},
@@ -846,6 +857,12 @@ fun HermesApp(
                     onLogout = onLogout,
                     visibleSections = setOf(section),
                     title = section.title,
+                    cloudState = cloudState,
+                    onCloudSignIn = onCloudSignIn,
+                    onCloudRefresh = onCloudRefresh,
+                    onCloudSignOut = onCloudSignOut,
+                    onCloudSelectOrg = onCloudSelectOrg,
+                    onCloudSelectAgent = onCloudSelectAgent,
                 )
             }
             Box(
@@ -3983,6 +4000,14 @@ internal fun ServerSettingsScreen(
     voiceSettings: VoiceSettings? = null,
     visibleSections: Set<SettingsSection> = SettingsSection.entries.toSet(),
     title: String = "Hermes server",
+    cloudState: com.unsupportedpastels.hermesandroid.connection.CloudConnectState? = null,
+    onCloudSignIn: () -> Unit = {},
+    onCloudRefresh: () -> Unit = {},
+    onCloudSignOut: () -> Unit = {},
+    onCloudSelectOrg: (com.unsupportedpastels.hermesandroid.connection.CloudOrg) -> Unit = {},
+    onCloudSelectAgent: suspend (com.unsupportedpastels.hermesandroid.connection.CloudAgent) -> Result<Unit> = {
+        Result.success(Unit)
+    },
 ) {
     var value by rememberSaveable(serverOrigin?.value) {
         mutableStateOf(serverOrigin?.value.orEmpty())
@@ -4074,6 +4099,47 @@ internal fun ServerSettingsScreen(
             ) {
                 if (SettingsSection.Servers in visibleSections) {
                     Text("Servers", style = MaterialTheme.typography.titleMedium)
+                    // When a Cloud view-model is wired in, offer the two connect
+                    // modes: Hermes Cloud (sign in → pick agent) and Server URL
+                    // (manual origin entry). Selecting a Cloud agent saves its
+                    // dashboard origin, so the manual catalog stays authoritative
+                    // once connected.
+                    val cloudActive = cloudState != null &&
+                        cloudState !is com.unsupportedpastels.hermesandroid.connection.CloudConnectState.SignedOut
+                    var connectMode by rememberConnectMode(initialCloud = cloudActive)
+                    if (cloudState != null) {
+                        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                            SegmentedButton(
+                                selected = connectMode == ConnectMode.Cloud,
+                                onClick = { connectMode = ConnectMode.Cloud },
+                                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                            ) { Text("Hermes Cloud") }
+                            SegmentedButton(
+                                selected = connectMode == ConnectMode.ServerUrl,
+                                onClick = { connectMode = ConnectMode.ServerUrl },
+                                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                            ) { Text("Server URL") }
+                        }
+                    }
+                    if (cloudState != null && connectMode == ConnectMode.Cloud) {
+                        HermesCloudConnectPanel(
+                            state = cloudState,
+                            onSignIn = onCloudSignIn,
+                            onRefresh = onCloudRefresh,
+                            onSignOut = onCloudSignOut,
+                            onSelectOrg = onCloudSelectOrg,
+                            onSelectAgent = { agent ->
+                                coroutineScope.launch {
+                                    val result = onCloudSelectAgent(agent)
+                                    if (result.isSuccess) {
+                                        onBack()
+                                    } else {
+                                        saveError = "Could not connect to that agent. Try again."
+                                    }
+                                }
+                            },
+                        )
+                    } else {
                     if (serverCatalog.entries.isEmpty()) {
                         Text(
                             "Add a Hermes server to get started.",
@@ -4259,6 +4325,7 @@ internal fun ServerSettingsScreen(
                         ) {
                             Text("Cancel")
                         }
+                    }
                     }
                 }
                 if (SettingsSection.Connection in visibleSections) {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesCloudConnectPanel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesCloudConnectPanel.kt
@@ -1,0 +1,220 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.unsupportedpastels.hermesandroid.connection.CloudAgent
+import com.unsupportedpastels.hermesandroid.connection.CloudConnectState
+import com.unsupportedpastels.hermesandroid.connection.CloudOrg
+
+/**
+ * The Hermes Cloud connect surface: sign in once to Nous Portal, then pick from
+ * the agents discovered on the account. Selecting an agent hands its dashboard
+ * origin back to [onSelectAgent], which persists it so the standard dashboard
+ * sign-in flow connects to it — no URL to paste.
+ *
+ * Rendered inside [ServerSettingsScreen] only when a Cloud view-model is wired
+ * in; kept in its own composable so the state machine stays self-contained.
+ */
+@Composable
+internal fun HermesCloudConnectPanel(
+    state: CloudConnectState,
+    onSignIn: () -> Unit,
+    onRefresh: () -> Unit,
+    onSignOut: () -> Unit,
+    onSelectOrg: (CloudOrg) -> Unit,
+    onSelectAgent: (CloudAgent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            "Sign in once to Hermes Cloud and pick from the agents on your account — no URL to paste.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        when (state) {
+            is CloudConnectState.SignedOut -> {
+                Button(
+                    onClick = onSignIn,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Sign in to Hermes Cloud"
+                    },
+                ) {
+                    Icon(Icons.Outlined.Cloud, contentDescription = null)
+                    Text(
+                        "Sign in to Hermes Cloud",
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+            }
+
+            is CloudConnectState.SigningIn -> {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                    Column {
+                        Text(
+                            "Finish signing in in your browser.",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Text(
+                            "Confirm the code: ${state.userCode}",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                }
+                TextButton(onClick = onSignOut) { Text("Cancel") }
+            }
+
+            is CloudConnectState.Discovering -> {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                    Text("Loading your agents…", style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+
+            is CloudConnectState.SelectOrg -> {
+                Text("Choose an organization", style = MaterialTheme.typography.titleSmall)
+                state.orgs.forEach { org ->
+                    ListItem(
+                        headlineContent = {
+                            Text(org.name, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        },
+                        supportingContent = {
+                            Text(if (org.isPersonal) "Personal · ${org.role}" else org.role)
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelectOrg(org) }
+                            .semantics { contentDescription = "Select organization ${org.name}" },
+                    )
+                }
+                TextButton(onClick = onSignOut) { Text("Sign out") }
+            }
+
+            is CloudConnectState.Agents -> {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        state.org?.name?.let { "Your agents · $it" } ?: "Your agents",
+                        style = MaterialTheme.typography.titleSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(end = 8.dp),
+                    )
+                    TextButton(onClick = onRefresh) { Text("Refresh") }
+                }
+                if (state.agents.isEmpty()) {
+                    Text(
+                        "No agents yet. Deploy one from the Nous Portal, then refresh.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    state.agents.forEach { agent ->
+                        val connectable = agent.isConnectable
+                        ListItem(
+                            headlineContent = {
+                                Text(agent.name, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                            },
+                            supportingContent = {
+                                Text(
+                                    if (connectable) {
+                                        agent.dashboardUrl.orEmpty()
+                                    } else {
+                                        "${agent.status.lowercase()} · provisioning…"
+                                    },
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            },
+                            leadingContent = {
+                                Icon(Icons.Outlined.Cloud, contentDescription = null)
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable(enabled = connectable) { onSelectAgent(agent) }
+                                .semantics {
+                                    contentDescription = if (connectable) {
+                                        "Connect to ${agent.name}"
+                                    } else {
+                                        "${agent.name} is provisioning"
+                                    }
+                                },
+                        )
+                    }
+                }
+                TextButton(onClick = onSignOut) { Text("Sign out of Hermes Cloud") }
+            }
+
+            is CloudConnectState.Error -> {
+                Text(
+                    state.message,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (state.signedOut) {
+                        Button(onClick = onSignIn) { Text("Sign in to Hermes Cloud") }
+                    } else {
+                        Button(onClick = onRefresh) { Text("Retry") }
+                        OutlinedButton(onClick = onSignOut) { Text("Sign out") }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** The two connect modes surfaced at the top of the Servers settings section. */
+internal enum class ConnectMode { Cloud, ServerUrl }
+
+/**
+ * Remembers which connect mode is showing. Defaults to Cloud when a Cloud
+ * session or roster is already present, otherwise Server URL so existing manual
+ * users land where they expect.
+ */
+@Composable
+internal fun rememberConnectMode(initialCloud: Boolean): androidx.compose.runtime.MutableState<ConnectMode> {
+    return remember {
+        mutableStateOf(if (initialCloud) ConnectMode.Cloud else ConnectMode.ServerUrl)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudClientTest.kt
@@ -1,0 +1,286 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Assert.fail
+import org.junit.Test
+
+class HermesCloudClientTest {
+    private val portal = ServerOrigin.parse("https://portal.nousresearch.com")
+
+    private fun jsonEngine(
+        handler: (path: String, method: HttpMethod, query: String) -> Pair<HttpStatusCode, String>,
+    ) = MockEngine { request ->
+        val (status, body) = handler(
+            request.url.encodedPath,
+            request.method,
+            request.url.encodedQuery,
+        )
+        respond(
+            content = body,
+            status = status,
+            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+        )
+    }
+
+    @Test
+    fun discoverAgentsParsesTrimmedRowsAndResolvedOrg() = runTest {
+        val engine = jsonEngine { path, method, _ ->
+            assertEquals("/api/agents", path)
+            assertEquals(HttpMethod.Get, method)
+            HttpStatusCode.OK to """
+                {
+                  "agents": [
+                    {"id":"a1","name":"small","status":"RUNNING",
+                     "dashboardUrl":"https://small-9000.agents.nousresearch.com",
+                     "dashboardGatewayState":"unknown","extra":"ignored"},
+                    {"id":"a2","name":"Zulu Beta","status":"RUNNING","dashboardUrl":null,
+                     "dashboardGatewayState":"active"},
+                    {"name":"no-id-dropped","status":"RUNNING"}
+                  ],
+                  "org": {"id":"org1","slug":"672c1d1f","name":"Personal","isPersonal":true,"role":"OWNER"}
+                }
+            """.trimIndent()
+        }
+        val client = HttpHermesCloudClient(HttpClient(engine))
+
+        val result = client.discoverAgents(portal, "bearer-token")
+
+        assertTrue(result is CloudDiscoverResult.Agents)
+        val agents = (result as CloudDiscoverResult.Agents)
+        assertEquals(2, agents.agents.size)
+        assertEquals("a1", agents.agents[0].id)
+        assertEquals("small", agents.agents[0].name)
+        assertTrue(agents.agents[0].isConnectable)
+        // Missing dashboardUrl → not connectable, shows provisioning.
+        assertNull(agents.agents[1].dashboardUrl)
+        assertFalse(agents.agents[1].isConnectable)
+        assertEquals("org1", agents.org?.id)
+        assertEquals("672c1d1f", agents.org?.slug)
+        assertTrue(agents.org?.isPersonal == true)
+    }
+
+    @Test
+    fun discoverAgentsScopesToOrgQueryWhenProvided() = runTest {
+        var seenQuery = ""
+        val engine = jsonEngine { _, _, query ->
+            seenQuery = query
+            HttpStatusCode.OK to """{"agents":[]}"""
+        }
+        val client = HttpHermesCloudClient(HttpClient(engine))
+
+        client.discoverAgents(portal, "bearer-token", org = "672c1d1f")
+
+        assertEquals("org=672c1d1f", seenQuery)
+    }
+
+    @Test
+    fun discoverAgents409ReturnsOrgSelection() = runTest {
+        val engine = jsonEngine { _, _, _ ->
+            HttpStatusCode.Conflict to """
+                {"error":"org_selection_required","orgs":[
+                  {"id":"o1","slug":"acme","name":"Acme","isPersonal":false,"role":"MEMBER"},
+                  {"id":"o2","slug":null,"name":"Personal","isPersonal":true,"role":"OWNER"}
+                ]}
+            """.trimIndent()
+        }
+        val client = HttpHermesCloudClient(HttpClient(engine))
+
+        val result = client.discoverAgents(portal, "bearer-token")
+
+        assertTrue(result is CloudDiscoverResult.NeedsOrgSelection)
+        val orgs = (result as CloudDiscoverResult.NeedsOrgSelection).orgs
+        assertEquals(listOf("o1", "o2"), orgs.map { it.id })
+        assertNull(orgs[1].slug)
+    }
+
+    @Test
+    fun discoverAgents401SurfacesSignInRequired() = runTest {
+        val engine = jsonEngine { _, _, _ ->
+            HttpStatusCode.Unauthorized to """{"error":"unauthorized"}"""
+        }
+        val client = HttpHermesCloudClient(HttpClient(engine))
+
+        try {
+            client.discoverAgents(portal, "stale-token")
+            fail("expected sign-in-required")
+        } catch (expected: HermesCloudSignInRequiredException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun requestDeviceCodeParsesVerificationDetails() = runTest {
+        val engine = jsonEngine { path, method, _ ->
+            assertEquals("/api/oauth/device/code", path)
+            assertEquals(HttpMethod.Post, method)
+            HttpStatusCode.OK to """
+                {"device_code":"dc_secret","user_code":"TF96-5E58",
+                 "verification_uri":"https://portal.nousresearch.com/manage-subscription",
+                 "verification_uri_complete":"https://portal.nousresearch.com/manage-subscription?user_code=TF96-5E58",
+                 "expires_in":600,"interval":5}
+            """.trimIndent()
+        }
+        val client = HttpHermesCloudClient(HttpClient(engine))
+
+        val code = client.requestDeviceCode(portal)
+
+        assertEquals("dc_secret", code.deviceCode)
+        assertEquals("TF96-5E58", code.userCode)
+        assertEquals(600L, code.expiresInSeconds)
+        assertEquals(5L, code.intervalSeconds)
+        assertTrue(code.verificationUriComplete.contains("user_code=TF96-5E58"))
+    }
+
+    @Test
+    fun awaitDeviceTokenPollsPastPendingThenReturnsToken() = runTest {
+        var call = 0
+        val engine = jsonEngine { path, _, _ ->
+            assertEquals("/api/oauth/token", path)
+            call += 1
+            if (call == 1) {
+                HttpStatusCode.BadRequest to """{"error":"authorization_pending"}"""
+            } else {
+                HttpStatusCode.OK to """
+                    {"access_token":"at","refresh_token":"rt","token_type":"Bearer",
+                     "scope":"inference:invoke","expires_in":3600}
+                """.trimIndent()
+            }
+        }
+        var now = 1000L
+        val client = HttpHermesCloudClient(
+            client = HttpClient(engine),
+            delayMillis = { /* no real sleep */ },
+            nowSeconds = { now },
+        )
+        val device = PortalDeviceCode(
+            deviceCode = "dc",
+            userCode = "u",
+            verificationUri = "https://portal.nousresearch.com",
+            verificationUriComplete = "https://portal.nousresearch.com",
+            expiresInSeconds = 600L,
+            intervalSeconds = 1L,
+        )
+
+        val token = client.awaitDeviceToken(portal, device)
+
+        assertEquals(2, call)
+        assertEquals("at", token.accessToken)
+        assertEquals("rt", token.refreshToken)
+        assertEquals(now + 3600L, token.expiresAt)
+    }
+
+    @Test
+    fun refreshTokenSendsRefreshHeaderAndCarriesRotatedToken() = runTest {
+        val engine = MockEngine { request ->
+            assertEquals("/api/oauth/token", request.url.encodedPath)
+            assertEquals("old-rt", request.headers["x-nous-refresh-token"])
+            respond(
+                content = """{"access_token":"new-at","refresh_token":"new-rt","expires_in":3600}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpHermesCloudClient(HttpClient(engine), nowSeconds = { 0L })
+
+        val token = client.refreshToken(portal, "old-rt")
+
+        assertEquals("new-at", token.accessToken)
+        assertEquals("new-rt", token.refreshToken)
+    }
+
+    @Test
+    fun refreshTokenReuseIsTerminalSignIn() = runTest {
+        val engine = jsonEngine { _, _, _ ->
+            HttpStatusCode.BadRequest to """{"error":"refresh_token_reused"}"""
+        }
+        val client = HttpHermesCloudClient(HttpClient(engine))
+
+        try {
+            client.refreshToken(portal, "old-rt")
+            fail("expected sign-in-required")
+        } catch (expected: HermesCloudSignInRequiredException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun discoveryRetriesTransientDnsFailureThenSucceeds() = runTest {
+        var calls = 0
+        val engine = MockEngine { request ->
+            calls += 1
+            if (calls == 1) {
+                // CIO surfaces a bare UnresolvedAddressException on the first
+                // request after backgrounding; the client must retry, not abort.
+                throw java.nio.channels.UnresolvedAddressException()
+            }
+            respond(
+                content = """{"agents":[{"id":"a1","name":"small","status":"RUNNING",
+                    "dashboardUrl":"https://small-9000.agents.nousresearch.com",
+                    "dashboardGatewayState":"unknown"}]}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpHermesCloudClient(HttpClient(engine), delayMillis = {})
+
+        val result = client.discoverAgents(portal, "bearer-token")
+
+        assertEquals(2, calls)
+        assertTrue(result is CloudDiscoverResult.Agents)
+        assertEquals("a1", (result as CloudDiscoverResult.Agents).agents.single().id)
+    }
+
+    @Test
+    fun awaitDeviceTokenKeepsPollingThroughBackgroundNetworkDrop() = runTest {
+        // The app is backgrounded while the user approves in the browser, so the
+        // token poll's first several attempts hit a torn-down network. Those must
+        // not abort the sign-in; polling continues until approval lands.
+        var calls = 0
+        val engine = MockEngine { _ ->
+            calls += 1
+            when {
+                calls <= 4 -> throw java.nio.channels.UnresolvedAddressException()
+                calls == 5 -> respond(
+                    content = """{"error":"authorization_pending"}""",
+                    status = HttpStatusCode.BadRequest,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+                else -> respond(
+                    content = """{"access_token":"at","refresh_token":"rt","expires_in":3600}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        }
+        var now = 0L
+        val client = HttpHermesCloudClient(
+            client = HttpClient(engine),
+            delayMillis = { now += 1 }, // advance clock a little each wait
+            nowSeconds = { now },
+        )
+        val device = PortalDeviceCode(
+            deviceCode = "dc",
+            userCode = "u",
+            verificationUri = "https://portal.nousresearch.com",
+            verificationUriComplete = "https://portal.nousresearch.com",
+            expiresInSeconds = 600L,
+            intervalSeconds = 1L,
+        )
+
+        val token = client.awaitDeviceToken(portal, device)
+
+        assertEquals("at", token.accessToken)
+        assertTrue(calls >= 6)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudClientTest.kt
@@ -71,6 +71,36 @@ class HermesCloudClientTest {
     }
 
     @Test
+    fun discoverAgentsToleratesWrongTypedOptionalFields() = runTest {
+        val engine = jsonEngine { _, _, _ ->
+            // A preview-era schema mismatch: wrong-typed "name" (object) and
+            // "dashboardGatewayState" (array). This must NOT crash discovery or
+            // lose the sibling valid row. A row with a valid id survives with
+            // wrong-typed optionals falling back to their defaults.
+            HttpStatusCode.OK to """
+                {"agents":[
+                  {"id":"bad","name":{},"status":"RUNNING",
+                   "dashboardUrl":"https://bad.agents.nousresearch.com","dashboardGatewayState":[]},
+                  {"id":"good","name":"good","status":"RUNNING",
+                   "dashboardUrl":"https://good.agents.nousresearch.com","dashboardGatewayState":"active"}
+                ]}
+            """.trimIndent()
+        }
+        val client = HttpHermesCloudClient(HttpClient(engine))
+
+        val result = client.discoverAgents(portal, "bearer-token")
+
+        assertTrue(result is CloudDiscoverResult.Agents)
+        val agents = (result as CloudDiscoverResult.Agents).agents
+        // Both rows present; the wrong-typed fields fall back (name → id,
+        // dashboardGatewayState → "unknown") instead of failing the discovery.
+        assertEquals(listOf("bad", "good"), agents.map { it.id })
+        val bad = agents.first { it.id == "bad" }
+        assertEquals("bad", bad.name)
+        assertEquals("unknown", bad.dashboardGatewayState)
+    }
+
+    @Test
     fun discoverAgentsScopesToOrgQueryWhenProvided() = runTest {
         var seenQuery = ""
         val engine = jsonEngine { _, _, query ->

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudViewModelTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudViewModelTest.kt
@@ -1,0 +1,203 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HermesCloudViewModelTest {
+    private val portal = ServerOrigin.parse("https://portal.nousresearch.com")
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun agent(id: String, url: String?) = CloudAgent(
+        id = id,
+        name = id,
+        status = "RUNNING",
+        dashboardUrl = url,
+        dashboardGatewayState = "unknown",
+    )
+
+    private class FakeStore(var token: PortalTokenSet? = null) : PortalTokenStore {
+        var cleared = false
+        override suspend fun load(portalOrigin: ServerOrigin) = token
+        override suspend fun save(portalOrigin: ServerOrigin, tokens: PortalTokenSet) {
+            token = tokens
+        }
+        override suspend fun clear(portalOrigin: ServerOrigin) {
+            token = null
+            cleared = true
+        }
+    }
+
+    private class FakeClient : HermesCloudClient {
+        var deviceCode = PortalDeviceCode("dc", "U-CODE", "https://verify", "https://verify?u=U-CODE", 600, 1)
+        var tokenToReturn = PortalTokenSet("at", "rt", "Bearer", "inference:invoke", 0)
+        var discoverResult: CloudDiscoverResult = CloudDiscoverResult.Agents(emptyList(), null)
+        var discoverError: Throwable? = null
+        var refreshError: Throwable? = null
+        var refreshCalls = 0
+        var lastOrg: String? = null
+        var discoverCalls = 0
+
+        override suspend fun requestDeviceCode(portalOrigin: ServerOrigin) = deviceCode
+        override suspend fun awaitDeviceToken(portalOrigin: ServerOrigin, deviceCode: PortalDeviceCode) = tokenToReturn
+        override suspend fun refreshToken(portalOrigin: ServerOrigin, refreshToken: String): PortalTokenSet {
+            refreshCalls += 1
+            refreshError?.let { throw it }
+            return tokenToReturn.copy(accessToken = "refreshed-at", refreshToken = "rotated-rt")
+        }
+        override suspend fun discoverAgents(
+            portalOrigin: ServerOrigin,
+            accessToken: String,
+            org: String?,
+        ): CloudDiscoverResult {
+            discoverCalls += 1
+            lastOrg = org
+            discoverError?.let { discoverError = null; throw it }
+            return discoverResult
+        }
+    }
+
+    private fun viewModel(client: HermesCloudClient, store: PortalTokenStore, now: Long = 1000L) =
+        HermesCloudViewModel(client, store, portal, nowSeconds = { now })
+
+    @Test
+    fun signInPersistsTokenAndDiscoversAgents() = runTest(dispatcher) {
+        val client = FakeClient().apply {
+            discoverResult = CloudDiscoverResult.Agents(
+                listOf(agent("a1", "https://small-9000.agents.nousresearch.com")),
+                CloudOrg("o1", "slug", "Personal", true, "OWNER"),
+            )
+        }
+        val store = FakeStore()
+        val vm = viewModel(client, store)
+        var openedUrl: String? = null
+
+        vm.signIn { openedUrl = it }
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("https://verify?u=U-CODE", openedUrl)
+        assertEquals("at", store.token?.accessToken)
+        val state = vm.state.value
+        assertTrue(state is CloudConnectState.Agents)
+        assertEquals("a1", (state as CloudConnectState.Agents).agents.single().id)
+    }
+
+    @Test
+    fun resumeWithoutTokenStaysSignedOut() = runTest(dispatcher) {
+        val vm = viewModel(FakeClient(), FakeStore(token = null))
+
+        vm.resume()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(CloudConnectState.SignedOut, vm.state.value)
+    }
+
+    @Test
+    fun resumeRefreshesExpiredTokenBeforeDiscovery() = runTest(dispatcher) {
+        val client = FakeClient().apply {
+            discoverResult = CloudDiscoverResult.Agents(listOf(agent("a1", "https://x.agents.nousresearch.com")), null)
+        }
+        // expiresAt in the past relative to now=1000 → must refresh first.
+        val store = FakeStore(PortalTokenSet("old-at", "old-rt", "Bearer", "inference:invoke", 500))
+        val vm = viewModel(client, store, now = 1000L)
+
+        vm.resume()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, client.refreshCalls)
+        assertEquals("refreshed-at", store.token?.accessToken)
+        assertEquals("rotated-rt", store.token?.refreshToken)
+        assertTrue(vm.state.value is CloudConnectState.Agents)
+    }
+
+    @Test
+    fun discovery401RefreshesOnceThenSucceeds() = runTest(dispatcher) {
+        val client = FakeClient().apply {
+            // Valid (non-expired) token, but discovery still 401s once.
+            discoverError = HermesCloudSignInRequiredException("expired")
+            discoverResult = CloudDiscoverResult.Agents(listOf(agent("a1", "https://x.agents.nousresearch.com")), null)
+        }
+        val store = FakeStore(PortalTokenSet("at", "rt", "Bearer", "inference:invoke", 9_999_999L))
+        val vm = viewModel(client, store, now = 1000L)
+
+        vm.resume()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, client.refreshCalls)
+        assertTrue(vm.state.value is CloudConnectState.Agents)
+    }
+
+    @Test
+    fun terminalRefreshFailureClearsTokenAndSignsOut() = runTest(dispatcher) {
+        val client = FakeClient().apply {
+            discoverError = HermesCloudSignInRequiredException("expired")
+            refreshError = HermesCloudSignInRequiredException("reuse")
+        }
+        val store = FakeStore(PortalTokenSet("at", "rt", "Bearer", "inference:invoke", 9_999_999L))
+        val vm = viewModel(client, store, now = 1000L)
+
+        vm.resume()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(store.cleared)
+        assertNull(store.token)
+        val state = vm.state.value
+        assertTrue(state is CloudConnectState.Error)
+        assertTrue((state as CloudConnectState.Error).signedOut)
+    }
+
+    @Test
+    fun orgSelectionSurfacedThenScopedDiscovery() = runTest(dispatcher) {
+        val client = FakeClient().apply {
+            discoverResult = CloudDiscoverResult.NeedsOrgSelection(
+                listOf(CloudOrg("o1", "acme", "Acme", false, "MEMBER")),
+            )
+        }
+        val store = FakeStore(PortalTokenSet("at", "rt", "Bearer", "inference:invoke", 9_999_999L))
+        val vm = viewModel(client, store, now = 1000L)
+
+        vm.resume()
+        dispatcher.scheduler.advanceUntilIdle()
+        assertTrue(vm.state.value is CloudConnectState.SelectOrg)
+
+        // Now pick the org; discovery should re-run scoped to its slug.
+        client.discoverResult = CloudDiscoverResult.Agents(listOf(agent("a1", "https://x.agents.nousresearch.com")), null)
+        vm.selectOrg(CloudOrg("o1", "acme", "Acme", false, "MEMBER"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("acme", client.lastOrg)
+        assertTrue(vm.state.value is CloudConnectState.Agents)
+    }
+
+    @Test
+    fun signOutClearsTokenAndState() = runTest(dispatcher) {
+        val store = FakeStore(PortalTokenSet("at", "rt", "Bearer", "inference:invoke", 9_999_999L))
+        val vm = viewModel(FakeClient(), store)
+
+        vm.signOut()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(store.cleared)
+        assertEquals(CloudConnectState.SignedOut, vm.state.value)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudViewModelTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudViewModelTest.kt
@@ -55,6 +55,7 @@ class HermesCloudViewModelTest {
         var discoverError: Throwable? = null
         var refreshError: Throwable? = null
         var refreshCalls = 0
+        val refreshTokensSeen = mutableListOf<String>()
         var lastOrg: String? = null
         var discoverCalls = 0
 
@@ -62,8 +63,14 @@ class HermesCloudViewModelTest {
         override suspend fun awaitDeviceToken(portalOrigin: ServerOrigin, deviceCode: PortalDeviceCode) = tokenToReturn
         override suspend fun refreshToken(portalOrigin: ServerOrigin, refreshToken: String): PortalTokenSet {
             refreshCalls += 1
+            refreshTokensSeen += refreshToken
             refreshError?.let { throw it }
-            return tokenToReturn.copy(accessToken = "refreshed-at", refreshToken = "rotated-rt")
+            // Rotate uniquely each call so a caller reusing a stale refresh token
+            // is detectable (as the real reuse-detecting Portal would reject it).
+            return tokenToReturn.copy(
+                accessToken = "refreshed-at-$refreshCalls",
+                refreshToken = "rotated-rt-$refreshCalls",
+            )
         }
         override suspend fun discoverAgents(
             portalOrigin: ServerOrigin,
@@ -125,8 +132,8 @@ class HermesCloudViewModelTest {
         dispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(1, client.refreshCalls)
-        assertEquals("refreshed-at", store.token?.accessToken)
-        assertEquals("rotated-rt", store.token?.refreshToken)
+        assertEquals("refreshed-at-1", store.token?.accessToken)
+        assertEquals("rotated-rt-1", store.token?.refreshToken)
         assertTrue(vm.state.value is CloudConnectState.Agents)
     }
 
@@ -145,6 +152,34 @@ class HermesCloudViewModelTest {
 
         assertEquals(1, client.refreshCalls)
         assertTrue(vm.state.value is CloudConnectState.Agents)
+    }
+
+    @Test
+    fun proactiveRefreshThen401FallbackUsesRotatedTokenNotConsumedOne() = runTest(dispatcher) {
+        // Near-expiry token → proactive refresh rotates rt → discovery still 401s
+        // → the fallback refresh MUST use the rotated token, not the original
+        // (which the Portal's reuse detection would reject, wrongly signing out).
+        val client = FakeClient().apply {
+            discoverError = HermesCloudSignInRequiredException("expired")
+            discoverResult = CloudDiscoverResult.Agents(
+                listOf(agent("a1", "https://x.agents.nousresearch.com")),
+                null,
+            )
+        }
+        // expiresAt=500 < now(1000)+skew → triggers the proactive refresh branch.
+        val store = FakeStore(PortalTokenSet("at", "original-rt", "Bearer", "inference:invoke", 500L))
+        val vm = viewModel(client, store, now = 1000L)
+
+        vm.resume()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(2, client.refreshCalls)
+        // First refresh sees the original; the fallback must use the rotated one.
+        assertEquals("original-rt", client.refreshTokensSeen[0])
+        assertEquals("rotated-rt-1", client.refreshTokensSeen[1])
+        assertTrue(vm.state.value is CloudConnectState.Agents)
+        // The latest rotated token is what stays persisted — never cleared.
+        assertEquals("rotated-rt-2", store.token?.refreshToken)
     }
 
     @Test

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesCloudConnectPanelTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesCloudConnectPanelTest.kt
@@ -1,0 +1,128 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.unsupportedpastels.hermesandroid.connection.CloudAgent
+import com.unsupportedpastels.hermesandroid.connection.CloudConnectState
+import com.unsupportedpastels.hermesandroid.connection.CloudOrg
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class HermesCloudConnectPanelTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private fun agent(id: String, url: String?) = CloudAgent(
+        id = id,
+        name = id,
+        status = "RUNNING",
+        dashboardUrl = url,
+        dashboardGatewayState = "unknown",
+    )
+
+    @Test
+    fun signedOutShowsSignInAction() {
+        var signedIn = false
+        composeRule.setContent {
+            MaterialTheme {
+                HermesCloudConnectPanel(
+                    state = CloudConnectState.SignedOut,
+                    onSignIn = { signedIn = true },
+                    onRefresh = {},
+                    onSignOut = {},
+                    onSelectOrg = {},
+                    onSelectAgent = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Sign in to Hermes Cloud").performClick()
+        assertEquals(true, signedIn)
+    }
+
+    @Test
+    fun agentsListSelectsConnectableAgentAndSkipsProvisioning() {
+        val selected = mutableListOf<String>()
+        composeRule.setContent {
+            MaterialTheme {
+                HermesCloudConnectPanel(
+                    state = CloudConnectState.Agents(
+                        agents = listOf(
+                            agent("small", "https://small-9000.agents.nousresearch.com"),
+                            agent("provisioning", null),
+                        ),
+                        org = CloudOrg("o1", "slug", "Personal", true, "OWNER"),
+                    ),
+                    onSignIn = {},
+                    onRefresh = {},
+                    onSignOut = {},
+                    onSelectOrg = {},
+                    onSelectAgent = { selected += it.id },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("small").assertIsDisplayed()
+        composeRule.onNodeWithText("provisioning").assertIsDisplayed()
+
+        // Connectable agent dispatches; provisioning agent's row is not clickable.
+        composeRule.onNodeWithText("small").performClick()
+        composeRule.onNodeWithText("provisioning").performClick()
+        assertEquals(listOf("small"), selected)
+    }
+
+    @Test
+    fun orgSelectionDispatchesChosenOrg() {
+        val picked = mutableListOf<String>()
+        composeRule.setContent {
+            MaterialTheme {
+                HermesCloudConnectPanel(
+                    state = CloudConnectState.SelectOrg(
+                        orgs = listOf(
+                            CloudOrg("o1", "acme", "Acme", false, "MEMBER"),
+                            CloudOrg("o2", null, "Personal", true, "OWNER"),
+                        ),
+                    ),
+                    onSignIn = {},
+                    onRefresh = {},
+                    onSignOut = {},
+                    onSelectOrg = { picked += it.id },
+                    onSelectAgent = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Acme").performClick()
+        assertEquals(listOf("o1"), picked)
+    }
+
+    @Test
+    fun errorWithSignedOutOffersReSignIn() {
+        var signedIn = false
+        composeRule.setContent {
+            MaterialTheme {
+                HermesCloudConnectPanel(
+                    state = CloudConnectState.Error("Session expired", signedOut = true),
+                    onSignIn = { signedIn = true },
+                    onRefresh = {},
+                    onSignOut = {},
+                    onSelectOrg = {},
+                    onSelectAgent = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Session expired").assertIsDisplayed()
+        composeRule.onNodeWithText("Sign in to Hermes Cloud").performClick()
+        assertEquals(true, signedIn)
+    }
+}


### PR DESCRIPTION
## What

Adds a two-mode **Connect** surface to HAM's server settings: **Hermes Cloud** and **Server URL**.

Under **Hermes Cloud** you sign in once to Nous Portal and pick from the agents on your account — **no URL to paste** — matching the desktop app's cloud-auto-discovery experience. **Server URL** keeps today's manual origin entry unchanged.

![Agent picker](https://github.com/user-attachments/assets/placeholder)

## How it works (grounded in the released contracts)

- **Discovery**: `GET {portal}/api/agents` returns trimmed agent rows (`id`, `name`, `status`, `dashboardUrl`, `dashboardGatewayState`) plus the resolved `org`. A `409 org_selection_required` response drives an org picker for multi-org accounts. This mirrors the desktop shell (`apps/desktop/electron/main.ts` — `discoverCloudAgents` / `trimCloudAgents` / `parseOrgSelectionError`).
- **Auth**: desktop authenticates `/api/agents` with a Privy **browser cookie** (it's an Electron webview). A native client can't reuse that cookie, so this uses the Portal **device-code OAuth flow** (RFC 8628, `client_id=hermes-cli`, scope `inference:invoke`) — the same flow the `hermes` CLI uses (`hermes_cli/auth.py`). Verified live that a device-code bearer authenticates `/api/agents`.
- **Handoff**: selecting an agent saves its `dashboardUrl` as the active server origin; the **existing** dashboard `native_pkce` sign-in then connects to it, unchanged.

No server-side changes — official Portal + dashboard contracts only, per the repo product boundary.

## Device-flow resilience

The device-code token poll runs while the app is **backgrounded** during browser approval, so Android tears the network down and CIO throws `UnresolvedAddressException`. Fixes:

- Transient DNS/host failures **during polling** are treated like `authorization_pending` — keep polling to the code deadline instead of aborting the sign-in.
- Bounded DNS retry on every Portal call (mirrors `HttpHermesNativeAuthClient`).
- A soft "Network unavailable · Retry" state that never clears the persisted token; only a conclusive grant rejection signs out.

## Security

- Portal tokens stored **encrypted (Tink AEAD)**, origin-scoped, in a dedicated `PortalTokenStore` separate from the per-agent `NativeTokenStore`.
- Rotated `refresh_token` replaces the stored one immediately (Portal uses reuse detection).
- No tokens/codes logged.

## Files

- `connection/HermesCloud.kt` — DTOs + tolerant parsers
- `connection/HermesCloudClient.kt` — device-code sign-in, refresh, discovery, retry
- `connection/PortalTokenStore.kt` — encrypted, origin-scoped token store
- `connection/HermesCloudViewModel.kt` — sign-in / resume / discover / org-pick state machine
- `ui/HermesCloudConnectPanel.kt` — connect panel UI; toggle wired into `HermesApp.kt` / `MainActivity.kt`
- `README.md` — Connect-mode docs

## Testing

**Gates**: `./gradlew testDebugUnitTest lintDebug assembleDebug` — all green.

New unit/UI tests: tolerant discovery parsing, `409` org selection, device-code poll (pending→token, **and polling through a backgrounded network drop**), refresh rotation + terminal reuse, ViewModel sign-in/resume/refresh/org-pick/sign-out and expired-token refresh-before-discovery, and Compose UI states for the connect panel.

**Device verification** (Pixel, release-signed, in-place update): Portal sign-in → agent discovery (`small`, `Zulu Beta`) → select `small` → dashboard `native_pkce` auth → **Connected**, live sessions/projects rendering.
