### PR TITLE
chore(release): bump versionName to 0.2.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         // duplicates). Release CI passes VERSION_CODE=${{ github.run_number }};
         // local builds fall back to 1.
         versionCode = (System.getenv("VERSION_CODE") ?: "1").toInt()
-        versionName = "0.2.0"
+        versionName = "0.2.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Cuts a distinct **v0.2.1** release so the Hermes Cloud connect feature (#36) ships under its own tag and notes instead of overwriting the v0.2.0 release asset.

Single-line change: `versionName 0.2.0 → 0.2.1` in `app/build.gradle.kts`. The release workflow tags `v${versionName}` on push to main, so merging this publishes a signed v0.2.1 APK + AAB.

Gate: `assembleDebug` green.