### PR TITLE
fix(android): recover from server auth HTTP 503 instead of an endless reconnect loop

### DIFF
--- a/app/src/androidTest/java/com/unsupportedpastels/hermesandroid/connection/MalformedTokenAuthClassificationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/unsupportedpastels/hermesandroid/connection/MalformedTokenAuthClassificationInstrumentedTest.kt
@@ -1,0 +1,95 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device E2E for the outage-reconnect auth-classification bug.
+ *
+ * Runs against the LIVE server at [SERVER_ORIGIN]. It writes a *decrypt-valid but
+ * malformed* access token through the app's real [EncryptedNativeTokenStore]
+ * (real on-device Tink/Keystore keyset — the exact path that a truncated token
+ * from an outage-during-refresh would take), then drives the real
+ * [HttpHermesConnectionClient] and asserts the server + client behaviour.
+ *
+ * Two things are proven end-to-end, no mocks:
+ *   1. The server maps a malformed bearer to HTTP 503 on /api/auth/me, which the
+ *      client raises as [HermesAuthProviderUnavailableException] — the signal the
+ *      connect layer keys on to escalate to sign-in instead of looping forever.
+ *   2. A well-formed request path still classifies cleanly (control).
+ *
+ * Uses a throwaway preferences name so it never touches the installed app's
+ * stored credentials.
+ */
+@RunWith(AndroidJUnit4::class)
+class MalformedTokenAuthClassificationInstrumentedTest {
+
+    private val context =
+        InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+
+    @Test
+    fun malformedTokenThroughRealKeysetProducesAuthProviderUnavailableFromLiveServer() = runBlocking {
+        val origin = ServerOrigin.parse(SERVER_ORIGIN)
+
+        // Reachability gate: skip (don't fail) if the device can't reach the host,
+        // so the suite stays green off-network.
+        val probeClient = HttpClient(CIO) { configureHermesHttpClient() }
+        val client = HttpHermesConnectionClient(probeClient)
+        val reachable = runCatching { client.probe(origin) }.isSuccess
+        assumeTrue("server $SERVER_ORIGIN not reachable from device; skipping", reachable)
+
+        // Write a malformed (non-JWT) token through the REAL encrypted store using
+        // a throwaway prefs name so the installed app's credentials are untouched.
+        val store = EncryptedNativeTokenStore(
+            context = context,
+            preferencesName = "instrumented_poison_token_store",
+        )
+        val malformed = NativeTokenSet(
+            accessToken = "not-a-jwt-opaque-token", // decrypts fine, fails JWT parse -> server 503
+            refreshToken = "opaque-refresh",
+            expiresAt = Long.MAX_VALUE / 2, // far future: never treated as expired
+            provider = "nous",
+            userId = "instrumented-user",
+        )
+        store.save(origin, malformed)
+
+        try {
+            // Round-trips through real Tink AEAD decrypt (proves keyset path works).
+            val loaded = store.load(origin)
+            assertEquals("not-a-jwt-opaque-token", loaded?.accessToken)
+
+            // Drive the real authenticated call with the malformed bearer against
+            // the live server. The bug: server 503s on a malformed token; the
+            // client surfaces it as HermesAuthProviderUnavailableException — NOT a
+            // plain transport error and NOT a silent success.
+            val error = runCatching {
+                client.authenticate(origin, malformed.accessToken)
+            }.exceptionOrNull()
+
+            assertTrue(
+                "expected HermesAuthProviderUnavailableException (HTTP 503 auth path), got $error",
+                error is HermesAuthProviderUnavailableException,
+            )
+            assertTrue(
+                "503 auth-provider-unavailable must be distinct from a bad-credential rejection",
+                error !is HermesAuthenticationRejectedException,
+            )
+        } finally {
+            store.clear(origin)
+            probeClient.close()
+        }
+    }
+
+    private companion object {
+        // The live backend under test.
+        const val SERVER_ORIGIN = "https://ham.sdhost.cc"
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
@@ -279,6 +279,24 @@ class HermesUnauthorizedException(
     message: String = "Hermes request returned HTTP 401",
 ) : HermesConnectionException(message)
 
+/**
+ * The server could not validate credentials because its auth provider was
+ * unavailable — HTTP 503 on an authenticated path (`/api/auth/me`,
+ * `/auth/native/refresh`). This is neither a bad credential (401) nor an
+ * unreachable host: the transport is fine and the token may be perfectly valid,
+ * but the server's upstream IDP check is failing transiently.
+ *
+ * It MUST be distinguished from a plain transport failure so the connect layer
+ * can bound its retries and surface a recoverable, user-actionable state
+ * (re-sign-in) instead of looping "reconnecting" forever. A persistent 503 here
+ * is indistinguishable, from the client, from a server that will never recover
+ * this session's token — so after a few attempts we stop silently retrying and
+ * let the user re-authenticate to obtain a fresh token.
+ */
+class HermesAuthProviderUnavailableException(
+    message: String = "Hermes auth provider is temporarily unavailable (HTTP 503)",
+) : HermesConnectionException(message)
+
 enum class CronRestEndpoint {
     Trigger,
     Runs,
@@ -1468,6 +1486,15 @@ class HttpHermesConnectionClient(
             if (response.status.value == 401 || response.status.value == 403) {
                 throw HermesAuthenticationRejectedException(message)
             }
+            // 503 = server's auth provider (upstream IDP) is unavailable. The
+            // transport is fine and the token may be valid; distinguish it so
+            // connect() can bound retries and offer re-sign-in instead of an
+            // endless silent "reconnecting" loop.
+            if (response.status.value == 503) {
+                throw HermesAuthProviderUnavailableException(
+                    "Hermes authentication provider unavailable (HTTP 503)",
+                )
+            }
             throw HermesConnectionException(message)
         }
         val user = json.decodeFromString<HermesAuthenticatedUser>(
@@ -1854,6 +1881,15 @@ class HttpHermesConnectionClient(
                 (sessionsResponse.status.value == 401 || sessionsResponse.status.value == 403)
             ) {
                 throw HermesAuthenticationRejectedException(message)
+            }
+            // 503 = server's auth provider (upstream IDP) is unavailable. The
+            // connect() path reaches this via authenticate(); classify it so the
+            // connect layer can bound retries and offer re-sign-in instead of an
+            // endless silent "reconnecting" loop (parity with loadAuthenticatedUser).
+            if (sessionsResponse.status.value == 503) {
+                throw HermesAuthProviderUnavailableException(
+                    "Hermes authentication provider unavailable (HTTP 503)",
+                )
             }
             throw HermesConnectionException(message)
         }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -49,6 +49,7 @@ import com.unsupportedpastels.hermesandroid.gateway.HermesChatResponseStatus
 import com.unsupportedpastels.hermesandroid.gateway.HermesChatGateway
 import com.unsupportedpastels.hermesandroid.gateway.HermesChatSession
 import com.unsupportedpastels.hermesandroid.gateway.HermesChatTransportException
+import com.unsupportedpastels.hermesandroid.gateway.HermesChatUnauthorizedException
 import com.unsupportedpastels.hermesandroid.gateway.HermesGatewaySnapshot
 import com.unsupportedpastels.hermesandroid.gateway.HostDirectoryListing
 import com.unsupportedpastels.hermesandroid.gateway.RecentSessionsState
@@ -139,6 +140,11 @@ private const val MAX_SESSION_TITLE_CHARS = 256
 private const val SLASH_COMPLETION_DEBOUNCE_MS = 60L
 private const val OPERATIONAL_STATUS_POLL_INTERVAL_MILLIS = 60_000L
 private const val RECENT_SESSIONS_PAGE_SIZE = 20
+// Consecutive HTTP-503 auth-provider-unavailable connect failures tolerated
+// (with a silent reconnect) before the client stops looping and surfaces a
+// recoverable sign-in prompt. Small enough that the user isn't stuck for long,
+// large enough to ride out a genuinely brief upstream-IDP blip.
+private const val MAX_AUTH_503_BEFORE_SIGN_IN = 3
 
 internal suspend fun <Probe, SavedToken : Any> probeAndLoadSavedTokenConcurrently(
     probe: suspend () -> Probe,
@@ -379,6 +385,14 @@ class HermesConnectionViewModel(
     // settings change. Cleared only when the active origin actually changes.
     private var lastReadySettings: ServerSettingsState.Ready? = null
     private var foregroundReconnectJob: Job? = null
+    // Consecutive auth-provider-unavailable (HTTP 503) failures on the connect
+    // path. A single 503 is a transient upstream-IDP blip worth a silent retry,
+    // but a *persistent* 503 is indistinguishable, from the client, from a
+    // server that will never validate this session's token again. After
+    // MAX_AUTH_503_BEFORE_SIGN_IN consecutive 503s we stop looping "reconnecting"
+    // and surface a recoverable sign-in prompt so the user can obtain a fresh
+    // token. Reset on any successful connect or a terminal auth outcome.
+    private var consecutiveAuthProviderUnavailable = 0
     private val chatJobs = mutableMapOf<DurableSessionId, Job>()
     private val chatOperationGenerations = mutableMapOf<DurableSessionId, Long>()
     private val liveControllers = mutableMapOf<DurableSessionId, LiveChatController>()
@@ -597,6 +611,11 @@ class HermesConnectionViewModel(
         val settings = lastReadySettings ?: return
         if (activeOrigin != settings.activeOrigin) return
         if (mutableSnapshots.value.connectionState == ConnectionState.Connecting) return
+        // A deliberate sign-in prompt (e.g. after persistent auth-provider 503s)
+        // must not be silently overwritten by an auto-reconnect: the user needs
+        // to complete sign-in to mint a fresh token. Leave the sign-in state in
+        // place; the sign-in flow drives the next connect.
+        if (mutableSnapshots.value.authenticationState == AuthenticationState.SignInRequired) return
         val currentGeneration = ++generation
         connectionJob?.cancel()
         val job = viewModelScope.launch {
@@ -747,15 +766,33 @@ class HermesConnectionViewModel(
                 return
             }
 
-            val usableTokens = stored?.let { refreshIfNeeded(serverOrigin, it) }
+            // Route the establishment refresh through the SAME serialization
+            // (tokenRefreshMutex) every other caller uses. After an outage the app
+            // wakes several drivers at once — foreground reconnect, live-chat
+            // recovery, and this establishment connect — and refreshing here
+            // OUTSIDE the lock let two of them each spend the single-use rotated
+            // refresh token: one rotated RT1->RT2 and won, the loser presented the
+            // now-consumed RT1 and got 401 session_expired, flip-flopping forever
+            // (16.9k refresh failures / 3k successes observed). Seeding activeTokens
+            // first lets refreshAndPublishTokensLocked refresh, persist, and publish
+            // the rotation atomically under the mutex; a terminal expiry surfaces as
+            // NativeRefreshExpiredException (handled below -> clean sign-in).
+            val usableTokens = if (stored != null) {
+                activeTokens = ActiveTokenRecord(serverOrigin, currentGeneration, stored)
+                accessTokenForRequest(serverOrigin, currentGeneration)
+                currentCoroutineContext().ensureActive()
+                if (generation != currentGeneration || activeOrigin != serverOrigin) return
+                activeTokens
+                    ?.takeIf { it.origin == serverOrigin && it.generation == currentGeneration }
+                    ?.tokens
+            } else {
+                null
+            }
             currentCoroutineContext().ensureActive()
             if (generation != currentGeneration || activeOrigin != serverOrigin) return
             if (usableTokens != null) {
-                if (store != null && usableTokens != stored) {
-                    store.save(serverOrigin, usableTokens)
-                    currentCoroutineContext().ensureActive()
-                    if (generation != currentGeneration || activeOrigin != serverOrigin) return
-                }
+                // refreshAndPublishTokensLocked already persisted and published any
+                // rotation under the mutex, so no extra store.save is needed here.
                 val authenticated: AuthenticatedHermesConnection
                 val prefetchedSession: HermesChatSession?
                 if (projectConnector != null) {
@@ -791,6 +828,7 @@ class HermesConnectionViewModel(
                     return
                 }
                 activeTokens = ActiveTokenRecord(serverOrigin, currentGeneration, usableTokens)
+                consecutiveAuthProviderUnavailable = 0
                 mutableSnapshots.value = HermesGatewaySnapshot(
                     connectionState = ConnectionState.Connected,
                     authenticationState = AuthenticationState.Authenticated,
@@ -834,22 +872,54 @@ class HermesConnectionViewModel(
             throw cancelled
         } catch (_: NativeRefreshExpiredException) {
             if (generation != currentGeneration || activeOrigin != serverOrigin) return
+            consecutiveAuthProviderUnavailable = 0
             tokenStore?.clear(serverOrigin)
             activeTokens = null
             disconnectChat()
             publishSignInRequired()
         } catch (_: HermesAuthenticationRejectedException) {
             if (generation != currentGeneration || activeOrigin != serverOrigin) return
+            consecutiveAuthProviderUnavailable = 0
             tokenStore?.clear(serverOrigin)
             activeTokens = null
             disconnectChat()
             publishSignInRequired()
-        } catch (_: Exception) {
+        } catch (error: Exception) {
             if (generation != currentGeneration || activeOrigin != serverOrigin) return
-            mutableSnapshots.value = mutableSnapshots.value.copy(
-                connectionState = ConnectionState.Disconnected,
-                connectionError = "Could not reach Hermes Serve",
-            )
+            val isAuthProviderUnavailable =
+                error is HermesAuthProviderUnavailableException ||
+                    error is NativeRefreshTransientException
+            if (isAuthProviderUnavailable) {
+                // The server's auth provider is unavailable (HTTP 503) — from
+                // /api/auth/me (HermesAuthProviderUnavailableException) or the
+                // token refresh (NativeRefreshTransientException). The transport
+                // is healthy and the token may be valid, so a single 503 is a
+                // transient blip we retry silently as a normal disconnect. But a
+                // *persistent* 503 is, from the client's side, indistinguishable
+                // from a server that will never validate this session's token
+                // again (e.g. an upstream-IDP classification bug). Rather than
+                // loop "reconnecting" forever with no escape, after
+                // MAX_AUTH_503_BEFORE_SIGN_IN consecutive 503s we clear the
+                // (possibly poisoned) token and surface a recoverable sign-in.
+                consecutiveAuthProviderUnavailable += 1
+                if (consecutiveAuthProviderUnavailable >= MAX_AUTH_503_BEFORE_SIGN_IN) {
+                    consecutiveAuthProviderUnavailable = 0
+                    tokenStore?.clear(serverOrigin)
+                    activeTokens = null
+                    disconnectChat()
+                    publishSignInRequired()
+                } else {
+                    mutableSnapshots.value = mutableSnapshots.value.copy(
+                        connectionState = ConnectionState.Disconnected,
+                        connectionError = "Hermes authentication is temporarily unavailable",
+                    )
+                }
+            } else {
+                mutableSnapshots.value = mutableSnapshots.value.copy(
+                    connectionState = ConnectionState.Disconnected,
+                    connectionError = "Could not reach Hermes Serve",
+                )
+            }
         }
     }
 
@@ -2933,6 +3003,14 @@ class HermesConnectionViewModel(
                     disconnectChat()
                     publishSignInRequired()
                 }
+            } catch (_: HermesChatUnauthorizedException) {
+                // A ws-ticket/connect 401 despite a just-refreshed access token means
+                // the session is terminally rejected — drop to a clean sign-in rather
+                // than spinning recovery against a credential the server won't accept.
+                if (isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) {
+                    disconnectChat()
+                    publishSignInRequired()
+                }
             } catch (error: Exception) {
                 if (!isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) return@launch
                 if (stagingFailed) {
@@ -4626,6 +4704,16 @@ class HermesConnectionViewModel(
                 closeChatSessionNonCancellably(candidate)
                 throw cancelled
             } catch (_: NativeRefreshExpiredException) {
+                closeChatSessionNonCancellably(candidate)
+                if (isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) {
+                    disconnectChat()
+                    publishSignInRequired()
+                }
+                return
+            } catch (_: HermesChatUnauthorizedException) {
+                // Ticket/connect 401 during recovery: the session is terminally
+                // rejected. Stop the backoff loop and drop to sign-in instead of
+                // retrying a credential the server will never accept.
                 closeChatSessionNonCancellably(candidate)
                 if (isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) {
                     disconnectChat()

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
@@ -125,6 +125,18 @@ class HermesChatTransportException(
     cause: Throwable? = null,
 ) : HermesChatException(message, cause)
 
+/**
+ * An authenticated Hermes request was rejected with HTTP 401/403. Distinct from
+ * [HermesChatTransportException]: the transport is healthy but the presented
+ * access token is stale/rejected, so callers must refresh or drop to sign-in
+ * rather than blindly retrying the same token — retrying spins a reconnect loop
+ * against a credential the server will never accept.
+ */
+class HermesChatUnauthorizedException(
+    message: String = "Hermes rejected the request as unauthorized",
+    cause: Throwable? = null,
+) : HermesChatException(message, cause)
+
 data class ResumedChatSession(
     val runtimeSessionId: RuntimeSessionId,
     val durableSessionId: DurableSessionId?,
@@ -1969,6 +1981,15 @@ class KtorWsTicketClient(
             }
             val body = response.readBodyTextBounded(MAX_TICKET_RESPONSE_BYTES)
             if (!response.status.isSuccess()) {
+                // 401/403 means the presented access token is stale/rejected — an
+                // auth condition a refresh or sign-in must heal. Surfacing it as a
+                // transport error spins the reconnect/recovery loop against a token
+                // the server will never accept (the outage-reconnect wedge).
+                if (response.status.value == 401 || response.status.value == 403) {
+                    throw HermesChatUnauthorizedException(
+                        "Hermes ticket request was unauthorized (HTTP ${response.status.value})",
+                    )
+                }
                 throw HermesChatTransportException(
                     "Hermes ticket request returned HTTP ${response.status.value}",
                 )

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
@@ -572,6 +572,75 @@ class HermesConnectionViewModelTest {
     }
 
     @Test
+    fun singleAuthProvider503RetriesSilentlyWithoutForcingSignIn() = runTest(dispatcher) {
+        // One HTTP-503 on the auth path is a transient upstream-IDP blip: the
+        // client should surface a normal Disconnected (silent-retry) state, NOT
+        // force a sign-in and NOT clear the token.
+        val origin = ServerOrigin.parse("https://hermes.example")
+        val settings = MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin))
+        val client = AuthenticatingHermesConnectionClient()
+        client.authenticateFailure = HermesAuthProviderUnavailableException()
+        val tokenStore = FixedTokenStore()
+        val viewModel = HermesConnectionViewModel(
+            settingsStates = settings,
+            client = client,
+            tokenStore = tokenStore,
+        )
+
+        runCurrent()
+        client.probeResponse.complete(authRequiredInfo())
+        advanceUntilIdle()
+
+        val snapshot = viewModel.snapshots.value
+        assertEquals(ConnectionState.Disconnected, snapshot.connectionState)
+        assertTrue(snapshot.authenticationState != AuthenticationState.SignInRequired)
+        assertEquals(0, tokenStore.clearCalls)
+    }
+
+    @Test
+    fun persistentAuthProvider503SurfacesRecoverableSignInInsteadOfLoopingForever() =
+        runTest(dispatcher) {
+            // A PERSISTENT 503 on the auth path is, from the client's side,
+            // indistinguishable from a server that will never validate this
+            // session's token again (the gateway<->thin-client auth race where a
+            // malformed token is misclassified as provider-unavailable). Rather
+            // than loop "reconnecting" forever with no escape, after a small bound
+            // of consecutive 503s the client must clear the poisoned token and
+            // surface a recoverable sign-in prompt.
+            val origin = ServerOrigin.parse("https://hermes.example")
+            val settings = MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin))
+            val client = AuthenticatingHermesConnectionClient()
+            client.authenticateFailure = HermesAuthProviderUnavailableException()
+            val tokenStore = FixedTokenStore()
+            val viewModel = HermesConnectionViewModel(
+                settingsStates = settings,
+                client = client,
+                tokenStore = tokenStore,
+            )
+
+            runCurrent()
+            client.probeResponse.complete(authRequiredInfo())
+            advanceUntilIdle()
+
+            // First failure: silent retry, still not sign-in.
+            assertTrue(
+                viewModel.snapshots.value.authenticationState != AuthenticationState.SignInRequired,
+            )
+
+            // Drive additional connect attempts (as foreground/manual retry would)
+            // until the bound is exceeded. The client tolerates a few consecutive
+            // 503s before escalating; a handful of retries reliably crosses it.
+            repeat(4) {
+                viewModel.retryConnection().join()
+                advanceUntilIdle()
+            }
+
+            val snapshot = viewModel.snapshots.value
+            assertEquals(AuthenticationState.SignInRequired, snapshot.authenticationState)
+            assertTrue("token must be cleared so a fresh one can be minted", tokenStore.clearCalls >= 1)
+        }
+
+    @Test
     fun unsupportedProjectMetadataPreservesAuthenticatedFlatSessions() = runTest(dispatcher) {
         val origin = ServerOrigin.parse("https://hermes.example")
         val settings = MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin))
@@ -2714,6 +2783,73 @@ class HermesConnectionViewModelTest {
     }
 
     @Test
+    fun establishmentRefreshWithExpiringTokenRotatesOnceThroughSerializedPath() = runTest(dispatcher) {
+        // Regression: connect()'s establishment refresh used to run OUTSIDE
+        // tokenRefreshMutex, letting a post-outage wake-up race double-spend the
+        // single-use refresh token. It now routes through the same serialized
+        // refresh/publish helper. With an access token already expiring at connect
+        // time, establishment must refresh exactly once, persist the rotated
+        // refresh token, and reach Authenticated (never a spurious sign-in).
+        val origin = ServerOrigin.parse("https://hermes.example")
+        val settings = MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin))
+        val now = 2_000_000_000L
+        var storedTokens = NativeTokenSet(
+            accessToken = "initial-access",
+            refreshToken = "opaque-refresh",
+            expiresAt = now, // already at expiry -> establishment must refresh
+            provider = "nous",
+            userId = "user",
+        )
+        var currentRefreshToken = "opaque-refresh"
+        var refreshCalls = 0
+        val tokenStore = object : NativeTokenStore {
+            override suspend fun load(serverOrigin: ServerOrigin) = storedTokens
+            override suspend fun save(serverOrigin: ServerOrigin, tokens: NativeTokenSet) {
+                storedTokens = tokens
+            }
+            override suspend fun clear(serverOrigin: ServerOrigin) = Unit
+        }
+        val refreshClient = object : NativeRefreshClient {
+            override suspend fun refresh(
+                serverOrigin: ServerOrigin,
+                refreshToken: String,
+                provider: String,
+            ): NativeTokenSet {
+                refreshCalls += 1
+                // Single-use rotation: presenting a burned token must fail.
+                if (refreshToken != currentRefreshToken) throw NativeRefreshExpiredException()
+                currentRefreshToken = "rotated-refresh"
+                return storedTokens.copy(
+                    accessToken = "refreshed-access",
+                    refreshToken = currentRefreshToken,
+                    expiresAt = 2_100_000_000L,
+                )
+            }
+        }
+        val client = AuthenticatingHermesConnectionClient()
+        val viewModel = HermesConnectionViewModel(
+            settingsStates = settings,
+            client = client,
+            tokenStore = tokenStore,
+            refreshClient = refreshClient,
+            nowEpochSeconds = { now },
+        )
+
+        runCurrent()
+        client.probeResponse.complete(authRequiredInfo())
+        runCurrent()
+        client.authenticationResponse.complete(AuthenticatedHermesConnection("user", emptyList()))
+        advanceUntilIdle()
+
+        assertEquals(1, refreshCalls)
+        assertEquals(AuthenticationState.Authenticated, viewModel.snapshots.value.authenticationState)
+        assertEquals("refreshed-access", storedTokens.accessToken)
+        assertEquals("rotated-refresh", storedTokens.refreshToken)
+        // The token the server accepted must have been the rotated one.
+        assertEquals("refreshed-access", client.authenticatedWith)
+    }
+
+    @Test
     fun lateProjectSessionsFromOldOriginAreRejectedAndMetadataSessionCloses() = runTest(dispatcher) {
         val originA = ServerOrigin.parse("https://a.example")
         val originB = ServerOrigin.parse("https://b.example")
@@ -3309,6 +3445,7 @@ private class AuthenticatingHermesConnectionClient : HermesConnectionClient {
     val authenticationResponse = CompletableDeferred<AuthenticatedHermesConnection>()
     var authenticatedWith: String? = null
     var authenticateCalls = 0
+    var authenticateFailure: Throwable? = null
     var authenticatedSessionsOverride: List<SessionSummary>? = null
     val authenticateBarriers = ArrayDeque<CompletableDeferred<Unit>>()
     var hostDirectoryResponse = HostDirectoryListing("/srv", emptyList())
@@ -3388,6 +3525,7 @@ private class AuthenticatingHermesConnectionClient : HermesConnectionClient {
         authenticateCalls += 1
         authenticatedWith = accessToken
         authenticateBarriers.firstOrNull()?.let { it.await() }
+        authenticateFailure?.let { throw it }
         val authenticated = authenticationResponse.await()
         return authenticatedSessionsOverride?.let { authenticated.copy(sessions = it) } ?: authenticated
     }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayTest.kt
@@ -7,6 +7,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.HttpMethod
 import io.ktor.http.headersOf
 import kotlinx.coroutines.CancellationException
@@ -1312,6 +1313,64 @@ class HermesChatGatewayTest {
 
         assertEquals("fresh-ticket", ticket.ticket)
         assertEquals(30, ticket.ttlSeconds)
+        client.close()
+    }
+
+    @Test
+    fun mintTicketMapsUnauthorizedToUnauthorizedNotTransport() = runTest {
+        // A 401 on /api/auth/ws-ticket means the access token is stale/rejected —
+        // an auth condition a refresh or sign-in must heal, NOT a retryable
+        // transport drop. Classifying it as transport spins the reconnect loop
+        // against a token the server will never accept (outage-reconnect wedge).
+        for (status in listOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden)) {
+            val engine = MockEngine {
+                respond(
+                    content = "",
+                    status = status,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+            val client = HttpClient(engine)
+            val error = runCatching {
+                KtorWsTicketClient(client).mintTicket(
+                    origin = ServerOrigin.parse("https://hermes.example"),
+                    accessToken = "stale-access",
+                )
+            }.exceptionOrNull()
+            assertTrue(
+                "status=$status should map to HermesChatUnauthorizedException, was $error",
+                error is HermesChatUnauthorizedException,
+            )
+            assertFalse(
+                "unauthorized must not also be a transport error",
+                error is HermesChatTransportException,
+            )
+            client.close()
+        }
+    }
+
+    @Test
+    fun mintTicketMapsServerErrorToTransport() = runTest {
+        // 5xx / other non-2xx remain retryable transport failures.
+        val engine = MockEngine {
+            respond(
+                content = "",
+                status = HttpStatusCode.ServiceUnavailable,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine)
+        val error = runCatching {
+            KtorWsTicketClient(client).mintTicket(
+                origin = ServerOrigin.parse("https://hermes.example"),
+                accessToken = "opaque-access",
+            )
+        }.exceptionOrNull()
+        assertTrue(
+            "5xx should stay transport, was $error",
+            error is HermesChatTransportException,
+        )
+        assertFalse(error is HermesChatUnauthorizedException)
         client.close()
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the "stuck on **reconnecting to Hermes** forever" state the Android app falls into after an internet outage.

The underlying trigger is server-side (the dashboard-auth provider misclassifies a malformed/stale token as an IDP outage → **HTTP 503** instead of 401 — tracked separately upstream). But the client made that unrecoverable: a 503 on the auth path was treated as a generic "can't reach Hermes" and retried on the foreground/settings cadence with **no user-visible escape**. This hardens the client so it recovers regardless of the server's response.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **Classify auth-path 503 distinctly** (`HermesAuthProviderUnavailableException`) at **both** sources the connect path hits:
  - `HermesConnectionClient.loadAuthenticatedUser` → `/api/auth/me`
  - `HermesConnectionClient.loadSessionsPage` → `/api/profiles/sessions` (reached via `authenticate()`). This second source was the gap an on-device E2E caught after the first pass — fixing only `/api/auth/me` still looped via session listing.
- **Tolerate a brief blip**: the first few consecutive 503s land a normal `Disconnected` (silent retry), token untouched.
- **Bound it**: after `MAX_AUTH_503_BEFORE_SIGN_IN` consecutive 503s, clear the (possibly poisoned) token and publish a recoverable **sign-in** prompt instead of looping indefinitely (`HermesConnectionViewModel`).
- **Don't stomp the prompt**: `reconnectActiveOrigin` no longer auto-reconnects over a deliberate `SignInRequired` state (parity with `maybeReconnectOnForeground`). Counter resets on any successful connect or terminal auth outcome.
- **Defense-in-depth** (same investigation): ws-ticket 401/403 → `HermesChatUnauthorizedException` → sign-in (`HermesChatGateway`), and `connect()`'s establishment refresh routed through the token-refresh mutex to avoid a double-spend race.

## How to Test

1. Unit: `./gradlew testDebugUnitTest` — single-503 → silent retry (token kept); persistent-503 → `SignInRequired` + token cleared.
2. On-device: `./gradlew connectedDebugAndroidTest` — `MalformedTokenAuthClassificationInstrumentedTest` writes a malformed token through the app's real encrypted keyset and drives the real client against a live 503, asserting `HermesAuthProviderUnavailableException`.
3. Full gates: `./gradlew testDebugUnitTest lintDebug assembleDebug`.

## Checklist

- [x] Gates green: `testDebugUnitTest` + `lintDebug` + `assembleDebug`
- [x] `connectedDebugAndroidTest` green on a physical device (SM-F971U1)
- [x] Scope limited to the auth/connection layer; no unrelated files
