### PR TITLE
fix: complete mobile OAuth recovery

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         // duplicates). Release CI passes VERSION_CODE=${{ github.run_number }};
         // local builds fall back to 1.
         versionCode = (System.getenv("VERSION_CODE") ?: "1").toInt()
-        versionName = "0.2.1"
+        versionName = "0.2.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudClient.kt
@@ -14,6 +14,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.content.TextContent
 import io.ktor.http.isSuccess
+import java.io.IOException
 import java.net.UnknownHostException
 import java.nio.channels.UnresolvedAddressException
 import kotlinx.coroutines.CancellationException
@@ -142,6 +143,18 @@ class HttpHermesCloudClient(
         generateSequence<Throwable>(this) { it.cause }
             .any { it is UnknownHostException || it is UnresolvedAddressException }
 
+    /**
+     * Device-token polling is explicitly replayable until the RFC 8628 code's
+     * deadline. Once the initial device-code request has established Portal TLS,
+     * an I/O failure here means Android tore down the background response stream,
+     * not that the user's authorization was rejected. Keep this broader policy
+     * local to polling: refresh-token POSTs rotate credentials and must not be
+     * replayed after an ambiguous response failure.
+     */
+    private fun Throwable.isTransientDevicePollFailure(): Boolean =
+        generateSequence<Throwable>(this) { it.cause }
+            .any { it is IOException || it is UnknownHostException || it is UnresolvedAddressException }
+
     override suspend fun requestDeviceCode(portalOrigin: ServerOrigin): PortalDeviceCode = try {
         val response = httpWithDnsRetry(
             "${portalOrigin.value}/api/oauth/device/code",
@@ -208,8 +221,8 @@ class HttpHermesCloudClient(
             // authorization_pending. Swallow transient network failures and keep
             // polling until the code's own deadline, or the sign-in dies the
             // instant the browser steals focus.
-            val response = try {
-                httpWithDnsRetry(
+            val (response, body) = try {
+                val response = httpWithDnsRetry(
                     "${portalOrigin.value}/api/oauth/token",
                     HttpMethod.Post,
                 ) {
@@ -225,13 +238,13 @@ class HttpHermesCloudClient(
                         ),
                     )
                 }
+                response to response.readBodyTextBounded()
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (error: Exception) {
-                if (error.isTransientNetworkFailure()) continue
+                if (error.isTransientDevicePollFailure()) continue
                 throw error
             }
-            val body = response.readBodyTextBounded()
             if (response.status.isSuccess()) {
                 return parseTokenBody(body)
             }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesCloudClientTest.kt
@@ -7,6 +7,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import java.io.EOFException
+import java.io.IOException
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -312,5 +314,49 @@ class HermesCloudClientTest {
 
         assertEquals("at", token.accessToken)
         assertTrue(calls >= 6)
+    }
+
+    @Test
+    fun awaitDeviceTokenKeepsPollingThroughClosedResponseStream() = runTest {
+        // CIO can establish the request while the app is backgrounded, then
+        // lose the response stream as Android freezes/unfreezes the process.
+        // Both observed shapes are retryable for RFC 8628 device polling.
+        var calls = 0
+        val engine = MockEngine { _ ->
+            calls += 1
+            when (calls) {
+                1 -> throw EOFException("response ended early")
+                2 -> throw IOException("connection closed")
+                3 -> respond(
+                    content = """{"error":"authorization_pending"}""",
+                    status = HttpStatusCode.BadRequest,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+                else -> respond(
+                    content = """{"access_token":"at","refresh_token":"rt","expires_in":3600}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        }
+        var now = 0L
+        val client = HttpHermesCloudClient(
+            client = HttpClient(engine),
+            delayMillis = { now += 1 },
+            nowSeconds = { now },
+        )
+        val device = PortalDeviceCode(
+            deviceCode = "dc",
+            userCode = "u",
+            verificationUri = "https://portal.nousresearch.com",
+            verificationUriComplete = "https://portal.nousresearch.com",
+            expiresInSeconds = 600L,
+            intervalSeconds = 1L,
+        )
+
+        val token = client.awaitDeviceToken(portal, device)
+
+        assertEquals("at", token.accessToken)
+        assertEquals(4, calls)
     }
 }

--- a/ios/Mercury/BrowserAuthenticationSession.swift
+++ b/ios/Mercury/BrowserAuthenticationSession.swift
@@ -12,40 +12,111 @@ import UIKit
 final class BrowserAuthenticationSession: NSObject, ASWebAuthenticationPresentationContextProviding {
     static let shared = BrowserAuthenticationSession()
 
-    private var session: ASWebAuthenticationSession?
+    /// One-shot bridge between Apple's callback and Swift concurrency.
+    /// `ASWebAuthenticationSession.cancel()` does not guarantee that its
+    /// completion handler runs, so cancellation must resolve the checked
+    /// continuation directly. Resolution is idempotent because a late Apple
+    /// callback can race with explicit teardown after the loopback path wins.
+    final class CompletionGate {
+        private var continuation: CheckedContinuation<URL, Error>?
+        private var pendingResult: Result<URL, Error>?
+        private var resolved = false
 
-    func authenticate(url: URL, callbackURLScheme: String) async throws -> URL {
-        cancel()
-
-        return try await withCheckedThrowingContinuation { continuation in
-            let session = ASWebAuthenticationSession(
-                url: url,
-                callbackURLScheme: callbackURLScheme
-            ) { [weak self] callbackURL, error in
-                self?.session = nil
-                if let callbackURL {
-                    continuation.resume(returning: callbackURL)
-                } else if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(throwing: FlowError.badResponse)
-                }
+        func install(_ continuation: CheckedContinuation<URL, Error>) {
+            precondition(self.continuation == nil)
+            if let pendingResult {
+                self.pendingResult = nil
+                continuation.resume(with: pendingResult)
+            } else {
+                self.continuation = continuation
             }
-            session.presentationContextProvider = self
-            session.prefersEphemeralWebBrowserSession = false
-            self.session = session
+        }
 
-            guard session.start() else {
-                self.session = nil
-                continuation.resume(throwing: FlowError.transient("could not start browser sign-in"))
-                return
+        func resolve(_ result: Result<URL, Error>) {
+            guard !resolved else { return }
+            resolved = true
+            if let continuation {
+                self.continuation = nil
+                continuation.resume(with: result)
+            } else {
+                pendingResult = result
             }
         }
     }
 
+    private var session: ASWebAuthenticationSession?
+    private var completionGate: CompletionGate?
+
+    func authenticate(url: URL, callbackURLScheme: String) async throws -> URL {
+        cancel()
+
+        let gate = CompletionGate()
+        completionGate = gate
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                gate.install(continuation)
+                let session = ASWebAuthenticationSession(
+                    url: url,
+                    callbackURLScheme: callbackURLScheme
+                ) { [weak self] callbackURL, error in
+                    self?.session = nil
+                    self?.completionGate = nil
+                    if let callbackURL {
+                        gate.resolve(.success(callbackURL))
+                    } else if let error {
+                        gate.resolve(.failure(error))
+                    } else {
+                        gate.resolve(.failure(FlowError.badResponse))
+                    }
+                }
+                session.presentationContextProvider = self
+                session.prefersEphemeralWebBrowserSession = false
+                self.session = session
+
+                guard session.start() else {
+                    self.session = nil
+                    self.completionGate = nil
+                    gate.resolve(.failure(FlowError.transient("could not start browser sign-in")))
+                    return
+                }
+            }
+        } onCancel: { [weak self] in
+            Task { @MainActor in
+                self?.cancel()
+            }
+        }
+    }
+
+    /// Detects the system authentication UI yielding control back to Mercury.
+    /// A system authentication sheet can yield control back to the app without
+    /// invoking the ASWebAuthenticationSession completion handler, even when
+    /// the browser-side login looked successful. That handler therefore cannot
+    /// be the only signal that starts the bounded callback grace period.
+    func waitForReturnToApp() async -> Bool {
+        for await _ in NotificationCenter.default.notifications(
+            named: UIApplication.willResignActiveNotification
+        ) {
+            if Task.isCancelled { return false }
+            break
+        }
+        if Task.isCancelled { return false }
+
+        for await _ in NotificationCenter.default.notifications(
+            named: UIApplication.didBecomeActiveNotification
+        ) {
+            return !Task.isCancelled
+        }
+        return false
+    }
+
     func cancel() {
-        session?.cancel()
+        let pendingSession = session
         session = nil
+        let gate = completionGate
+        completionGate = nil
+        gate?.resolve(.failure(CancellationError()))
+        pendingSession?.cancel()
     }
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {

--- a/ios/Mercury/MercuryKit/AppFlow/ConnectionController.swift
+++ b/ios/Mercury/MercuryKit/AppFlow/ConnectionController.swift
@@ -194,6 +194,7 @@ final class ConnectionController {
         }
 
         appModel.setSigningIn(true)
+        appModel.setAuthenticationError(nil)
         defer { appModel.setSigningIn(false) }
 
         let flow = signInFlowFactory(origin)
@@ -227,7 +228,16 @@ final class ConnectionController {
             authDebug("failed")
             flow.cancel()
             guard appModel.serverOrigin == origin else { return }
-            appModel.setPhase(.failed("Sign-in failed"))
+            if case FlowError.stateMismatch = error {
+                appModel.setPhase(.failed("Sign-in failed"))
+            } else {
+                // Portal authentication can require a second browser hop or
+                // return a transient rejection. Keep the user on the sign-in
+                // screen with a retryable state instead of requiring an app
+                // restart to clear the in-flight button state.
+                appModel.setAuthenticationError("Sign-in did not complete. Try again.")
+                appModel.setPhase(.signInRequired)
+            }
         }
     }
 

--- a/ios/Mercury/MercuryKit/Auth/NativePKCEFlow.swift
+++ b/ios/Mercury/MercuryKit/Auth/NativePKCEFlow.swift
@@ -27,6 +27,20 @@ enum TokenOutcome: Equatable {
 /// Flow: `begin()` → open returned authorize URL in browser → Portal 302s to
 /// the loopback listener → `awaitCallback()` → `exchange(code:)`.
 final class NativePKCEFlow {
+    enum CallbackRaceEvent: Equatable {
+        case callback(CallbackResult)
+        case browserClosed
+        case browserReturnedToApp
+        case listenerEnded
+        case graceExpired
+    }
+
+    enum CallbackRaceDecision: Equatable {
+        case keepWaiting
+        case startGracePeriod
+        case finish(CallbackResult?)
+    }
+
     let origin: String
     let provider: String
 
@@ -79,24 +93,84 @@ final class NativePKCEFlow {
             throw FlowError.badResponse
         }
 
-        let browserTask = Task { @MainActor in
-            try? await BrowserAuthenticationSession.shared.authenticate(
-                url: url,
-                callbackURLScheme: "http"
-            )
-        }
-        defer {
-            browserTask.cancel()
-            Task { @MainActor in
-                BrowserAuthenticationSession.shared.cancel()
+        // The Portal may complete the first authentication hop through
+        // ASWebAuthenticationSession and the final hop through loopback (or
+        // vice versa). Do not discard the browser callback and wait forever on
+        // only one transport: accept the first valid callback from either path.
+        let result = await withTaskGroup(of: CallbackRaceEvent.self) { group -> CallbackResult? in
+            // Register before presenting ASWebAuthenticationSession so the
+            // resign-active edge cannot be missed on a fast browser launch.
+            group.addTask {
+                let returned = await BrowserAuthenticationSession.shared.waitForReturnToApp()
+                return returned ? .browserReturnedToApp : .listenerEnded
             }
+            await Task.yield()
+
+            group.addTask {
+                do {
+                    let callbackURL = try await listener.waitForCallback()
+                    return .callback(
+                        try Self.validate(callbackURL: callbackURL, expectedState: expectedState)
+                    )
+                } catch {
+                    return .listenerEnded
+                }
+            }
+            group.addTask {
+                do {
+                    let callbackURL = try await BrowserAuthenticationSession.shared.authenticate(
+                        url: url,
+                        callbackURLScheme: "http"
+                    )
+                    return .callback(
+                        try Self.validate(callbackURL: callbackURL, expectedState: expectedState)
+                    )
+                } catch {
+                    return .browserClosed
+                }
+            }
+
+            var gracePeriodStarted = false
+            while let event = await group.next() {
+                switch Self.callbackRaceDecision(for: event) {
+                case .keepWaiting:
+                    continue
+                case .startGracePeriod:
+                    guard !gracePeriodStarted else { continue }
+                    gracePeriodStarted = true
+                    group.addTask {
+                        do {
+                            try await Task.sleep(nanoseconds: 10_000_000_000)
+                            return .graceExpired
+                        } catch {
+                            return .listenerEnded
+                        }
+                    }
+                case .finish(let callback):
+                    // A task group waits for every child before returning. Cancel
+                    // both callback transports synchronously so the losing child
+                    // can finish; scheduling browser cancellation in an unawaited
+                    // MainActor task deadlocks when this flow already owns that
+                    // actor and is waiting for the group to drain.
+                    group.cancelAll()
+                    listener.stop()
+                    await MainActor.run {
+                        BrowserAuthenticationSession.shared.cancel()
+                    }
+                    return callback
+                }
+            }
+            return nil
         }
 
-        let callbackURL = try await listener.waitForCallback()
         listener.stop()
+        await MainActor.run {
+            BrowserAuthenticationSession.shared.cancel()
+        }
         self.listener = nil
-        debug("callback-listener-returned")
-        return try Self.validate(callbackURL: callbackURL, expectedState: expectedState)
+        debug("callback-received")
+        guard let result else { throw FlowError.badResponse }
+        return result
     }
 
     /// Exchanges the authorization code for tokens or cookies.
@@ -206,6 +280,23 @@ final class NativePKCEFlow {
             throw FlowError.badResponse
         }
         return CallbackResult(code: code, state: query["state"]!)
+    }
+
+    /// Pure policy for the two callback transports. Closing the browser without
+    /// a callback starts a bounded grace period because the loopback redirect can
+    /// arrive just after the sheet disappears. Expiry returns control to the UI
+    /// so the user can start a fresh PKCE transaction instead of remaining stuck.
+    static func callbackRaceDecision(for event: CallbackRaceEvent) -> CallbackRaceDecision {
+        switch event {
+        case .callback(let callback):
+            return .finish(callback)
+        case .browserClosed, .browserReturnedToApp:
+            return .startGracePeriod
+        case .listenerEnded:
+            return .keepWaiting
+        case .graceExpired:
+            return .finish(nil)
+        }
     }
 
     /// Collects Set-Cookie name→value pairs from an HTTP response.

--- a/ios/Mercury/MercuryKit/Auth/NativePKCEFlow.swift
+++ b/ios/Mercury/MercuryKit/Auth/NativePKCEFlow.swift
@@ -33,12 +33,14 @@ final class NativePKCEFlow {
         case browserReturnedToApp
         case listenerEnded
         case graceExpired
+        case fatal(FlowError)
     }
 
     enum CallbackRaceDecision: Equatable {
         case keepWaiting
         case startGracePeriod
         case finish(CallbackResult?)
+        case fail(FlowError)
     }
 
     let origin: String
@@ -97,7 +99,7 @@ final class NativePKCEFlow {
         // ASWebAuthenticationSession and the final hop through loopback (or
         // vice versa). Do not discard the browser callback and wait forever on
         // only one transport: accept the first valid callback from either path.
-        let result = await withTaskGroup(of: CallbackRaceEvent.self) { group -> CallbackResult? in
+        let raceResult = await withTaskGroup(of: CallbackRaceEvent.self) { group -> Result<CallbackResult?, FlowError> in
             // Register before presenting ASWebAuthenticationSession so the
             // resign-active edge cannot be missed on a fast browser launch.
             group.addTask {
@@ -113,7 +115,7 @@ final class NativePKCEFlow {
                         try Self.validate(callbackURL: callbackURL, expectedState: expectedState)
                     )
                 } catch {
-                    return .listenerEnded
+                    return Self.callbackRaceEvent(for: error, fallback: .listenerEnded)
                 }
             }
             group.addTask {
@@ -126,7 +128,7 @@ final class NativePKCEFlow {
                         try Self.validate(callbackURL: callbackURL, expectedState: expectedState)
                     )
                 } catch {
-                    return .browserClosed
+                    return Self.callbackRaceEvent(for: error, fallback: .browserClosed)
                 }
             }
 
@@ -157,10 +159,17 @@ final class NativePKCEFlow {
                     await MainActor.run {
                         BrowserAuthenticationSession.shared.cancel()
                     }
-                    return callback
+                    return .success(callback)
+                case .fail(let error):
+                    group.cancelAll()
+                    listener.stop()
+                    await MainActor.run {
+                        BrowserAuthenticationSession.shared.cancel()
+                    }
+                    return .failure(error)
                 }
             }
-            return nil
+            return .success(nil)
         }
 
         listener.stop()
@@ -169,8 +178,13 @@ final class NativePKCEFlow {
         }
         self.listener = nil
         debug("callback-received")
-        guard let result else { throw FlowError.badResponse }
-        return result
+        switch raceResult {
+        case .success(let callback):
+            guard let callback else { throw FlowError.badResponse }
+            return callback
+        case .failure(let error):
+            throw error
+        }
     }
 
     /// Exchanges the authorization code for tokens or cookies.
@@ -296,7 +310,19 @@ final class NativePKCEFlow {
             return .keepWaiting
         case .graceExpired:
             return .finish(nil)
+        case .fatal(let error):
+            return .fail(error)
         }
+    }
+
+    /// Preserve security-sensitive validation failures instead of collapsing
+    /// them into an ordinary browser/listener completion signal.
+    static func callbackRaceEvent(for error: Error, fallback: CallbackRaceEvent) -> CallbackRaceEvent {
+        if let flowError = error as? FlowError,
+           case .stateMismatch = flowError {
+            return .fatal(flowError)
+        }
+        return fallback
     }
 
     /// Collects Set-Cookie name→value pairs from an HTTP response.

--- a/ios/Mercury/MercuryKit/Chat/ChatConnectionOwnership.swift
+++ b/ios/Mercury/MercuryKit/Chat/ChatConnectionOwnership.swift
@@ -30,3 +30,14 @@ struct ChatConnectionOwnership {
         generation &+= 1
     }
 }
+
+enum ChatDisappearanceAction: Equatable {
+    case preserveConnectionAndObserver
+    case tearDown
+}
+
+enum ChatDisappearancePolicy {
+    static func action(turnInFlight: Bool, isSending: Bool) -> ChatDisappearanceAction {
+        turnInFlight || isSending ? .preserveConnectionAndObserver : .tearDown
+    }
+}

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -357,13 +357,15 @@ struct ChatView: View {
         .toolbarBackground(Color.amoledBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .task {
+            // Visibility can change while SwiftUI retains this view and restarts
+            // its task. Restore it even when the connection is already owned.
+            appModel.setVisibleSession(notificationSessionID)
             // SwiftUI may recreate the task while the view is still mounted.
             // Android's ViewModel refuses a second open for an already-owned
             // session; make the same admission decision before any await.
             guard !didOpen else { return }
             didOpen = true
             applyIncomingShare()
-            appModel.setVisibleSession(notificationSessionID)
             if let notifyID = notificationSessionID {
                 // Engaged scope: background reconciliation may notify about a
                 // session only after the app has opened it (Android parity).
@@ -387,10 +389,11 @@ struct ChatView: View {
             // ViewModel; preserve the iOS connection while a turn is active so
             // the next foreground/open can resume the same runtime instead of
             // creating a second visible attempt.
-            guard !turnInFlight && !isSending else {
+            if ChatDisappearancePolicy.action(
+                turnInFlight: turnInFlight,
+                isSending: isSending
+            ) == .preserveConnectionAndObserver {
                 appModel.setVisibleSession(nil)
-                eventTask?.cancel()
-                eventTask = nil
                 return
             }
             // Deliberate teardown for an idle session: no reconnect may fire

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -357,6 +357,11 @@ struct ChatView: View {
         .toolbarBackground(Color.amoledBlack, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .task {
+            // SwiftUI may recreate the task while the view is still mounted.
+            // Android's ViewModel refuses a second open for an already-owned
+            // session; make the same admission decision before any await.
+            guard !didOpen else { return }
+            didOpen = true
             applyIncomingShare()
             appModel.setVisibleSession(notificationSessionID)
             if let notifyID = notificationSessionID {
@@ -377,7 +382,19 @@ struct ChatView: View {
             scheduleSlashCompletion(for: draft)
         }
         .onDisappear {
-            // Deliberate teardown: no reconnect may fire after dismissal.
+            // A transient SwiftUI disappearance must not interrupt an active
+            // server-side turn. Android keeps its live controller in the
+            // ViewModel; preserve the iOS connection while a turn is active so
+            // the next foreground/open can resume the same runtime instead of
+            // creating a second visible attempt.
+            guard !turnInFlight && !isSending else {
+                appModel.setVisibleSession(nil)
+                eventTask?.cancel()
+                eventTask = nil
+                return
+            }
+            // Deliberate teardown for an idle session: no reconnect may fire
+            // after dismissal.
             closedByUs = true
             appModel.setVisibleSession(nil)
             reconnectTask?.cancel()

--- a/ios/Mercury/Views/SignInView.swift
+++ b/ios/Mercury/Views/SignInView.swift
@@ -18,6 +18,13 @@ struct SignInView: View {
         appModel.authProviders.contains(where: \.supportsPassword)
     }
 
+    static func nousButtonTitle(isSigningIn: Bool, authenticationError: String?) -> String {
+        if !isSigningIn, authenticationError != nil {
+            return "Retry sign in"
+        }
+        return "Sign in with Nous"
+    }
+
     var body: some View {
         VStack(spacing: 24) {
             Spacer()
@@ -71,7 +78,10 @@ struct SignInView: View {
                         if appModel.isSigningIn {
                             ProgressView().controlSize(.small)
                         }
-                        Text("Sign in with Nous")
+                        Text(Self.nousButtonTitle(
+                            isSigningIn: appModel.isSigningIn,
+                            authenticationError: appModel.authenticationError
+                        ))
                             .fontWeight(.semibold)
                     }
                     .frame(maxWidth: .infinity)

--- a/ios/MercuryTests/AppFlowTests.swift
+++ b/ios/MercuryTests/AppFlowTests.swift
@@ -341,6 +341,27 @@ final class AppFlowTests: XCTestCase {
         XCTAssertNil(model.sessionsError)
     }
 
+    func testNousButtonBecomesRetryAfterIncompleteSignIn() {
+        XCTAssertEqual(
+            SignInView.nousButtonTitle(isSigningIn: false, authenticationError: nil),
+            "Sign in with Nous"
+        )
+        XCTAssertEqual(
+            SignInView.nousButtonTitle(
+                isSigningIn: false,
+                authenticationError: "Sign-in did not complete. Try again."
+            ),
+            "Retry sign in"
+        )
+        XCTAssertEqual(
+            SignInView.nousButtonTitle(
+                isSigningIn: true,
+                authenticationError: "Sign-in did not complete. Try again."
+            ),
+            "Sign in with Nous"
+        )
+    }
+
     func testSuccessfulPasswordSignInValidatesCookieAndConnects() async throws {
         let cookieStore = HTTPCookieStorage.shared
         func clearFixtureCookies() {

--- a/ios/MercuryTests/ChatConnectionOwnershipTests.swift
+++ b/ios/MercuryTests/ChatConnectionOwnershipTests.swift
@@ -32,4 +32,19 @@ final class ChatConnectionOwnershipTests: XCTestCase {
         XCTAssertFalse(ownership.isCurrent(published))
         XCTAssertFalse(ownership.release(ifCurrent: published))
     }
+
+    func testActiveTurnDisappearancePreservesConnectionAndObserver() {
+        XCTAssertEqual(
+            ChatDisappearancePolicy.action(turnInFlight: true, isSending: false),
+            .preserveConnectionAndObserver
+        )
+        XCTAssertEqual(
+            ChatDisappearancePolicy.action(turnInFlight: false, isSending: true),
+            .preserveConnectionAndObserver
+        )
+        XCTAssertEqual(
+            ChatDisappearancePolicy.action(turnInFlight: false, isSending: false),
+            .tearDown
+        )
+    }
 }

--- a/ios/MercuryTests/PKCETests.swift
+++ b/ios/MercuryTests/PKCETests.swift
@@ -130,6 +130,18 @@ final class PKCETests: XCTestCase {
         )
     }
 
+    func testStateMismatchRemainsFatalThroughCallbackRace() {
+        let event = NativePKCEFlow.callbackRaceEvent(
+            for: FlowError.stateMismatch,
+            fallback: .listenerEnded
+        )
+        XCTAssertEqual(event, .fatal(.stateMismatch))
+        XCTAssertEqual(
+            NativePKCEFlow.callbackRaceDecision(for: event),
+            .fail(.stateMismatch)
+        )
+    }
+
     @MainActor
     func testBrowserCompletionGateCancellationResumesExactlyOnce() async {
         let gate = BrowserAuthenticationSession.CompletionGate()

--- a/ios/MercuryTests/PKCETests.swift
+++ b/ios/MercuryTests/PKCETests.swift
@@ -98,4 +98,58 @@ final class PKCETests: XCTestCase {
         let callback = URL(string: "http://127.0.0.1:49152/callback?state=S")!
         XCTAssertThrowsError(try NativePKCEFlow.validate(callbackURL: callback, expectedState: "S"))
     }
+
+    // MARK: - Browser callback grace period
+
+    func testBrowserReturnToAppStartsGracePeriodEvenWithoutCompletionCallback() {
+        XCTAssertEqual(
+            NativePKCEFlow.callbackRaceDecision(for: .browserReturnedToApp),
+            .startGracePeriod
+        )
+    }
+
+    func testBrowserCloseStartsGracePeriodBeforeRetry() {
+        XCTAssertEqual(
+            NativePKCEFlow.callbackRaceDecision(for: .browserClosed),
+            .startGracePeriod
+        )
+    }
+
+    func testGraceExpiryFinishesWithoutCallback() {
+        XCTAssertEqual(
+            NativePKCEFlow.callbackRaceDecision(for: .graceExpired),
+            .finish(nil)
+        )
+    }
+
+    func testValidCallbackWinsDuringGracePeriod() {
+        let callback = CallbackResult(code: "fresh-code", state: "expected")
+        XCTAssertEqual(
+            NativePKCEFlow.callbackRaceDecision(for: .callback(callback)),
+            .finish(callback)
+        )
+    }
+
+    @MainActor
+    func testBrowserCompletionGateCancellationResumesExactlyOnce() async {
+        let gate = BrowserAuthenticationSession.CompletionGate()
+        let waiter = Task {
+            try await withCheckedThrowingContinuation { continuation in
+                gate.install(continuation)
+            } as URL
+        }
+        await Task.yield()
+
+        gate.resolve(.failure(CancellationError()))
+        gate.resolve(.success(URL(string: "http://127.0.0.1/late")!))
+
+        do {
+            _ = try await waiter.value
+            XCTFail("cancellation must terminate the suspended browser waiter")
+        } catch is CancellationError {
+            // Expected: the later callback must not double-resume or win.
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
 }

--- a/ios/MercuryUITests/LiveAuthDriverUITests.swift
+++ b/ios/MercuryUITests/LiveAuthDriverUITests.swift
@@ -4,7 +4,10 @@ import XCTest
 final class LiveAuthDriverUITests: XCTestCase {
     func testEnterPortalCodeAndVerifyMercury() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["-uitest-probe", try LiveUITestConfiguration.origin()]
+        app.launchArguments = [
+            "-uitest-probe", try LiveUITestConfiguration.origin(),
+            "-uitest-auth-debug",
+        ]
         app.launch()
 
         let signIn = app.buttons["Sign in with Nous"]
@@ -12,9 +15,12 @@ final class LiveAuthDriverUITests: XCTestCase {
         signIn.tap()
 
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        let continueButton = springboard.buttons["Continue"]
-        if continueButton.waitForExistence(timeout: 15) {
-            continueButton.tap()
+        let springboardContinue = springboard.buttons["Continue"]
+        let appContinue = app.buttons["Continue"]
+        if springboardContinue.waitForExistence(timeout: 8) {
+            springboardContinue.tap()
+        } else if appContinue.waitForExistence(timeout: 8) {
+            appContinue.tap()
         }
 
         // The Portal may land on its public overview page (no session


### PR DESCRIPTION
## Summary
- finish iOS native OAuth callback teardown so successful Portal redirects cannot leave sign-in permanently in flight
- preserve active iOS chat ownership across transient SwiftUI lifecycle changes
- keep Android Hermes Cloud device-token polling alive across background response-stream interruption
- bump the Android release version to 0.2.2 for a new signed APK release

## Verification
- iOS simulator: 634/634 tests passed
- live iOS OAuth passed against both the hosted Cloud agent and `ham.sdhost.cc`
- physical iPhone OAuth fix confirmed after installing the signed build
- Android: `testDebugUnitTest lintDebug assembleDebug validateDebugScreenshotTest`
- live Android Hermes Cloud approval, agent discovery, and force-stop/relaunch persistence passed
- local signed `assembleRelease bundleRelease` passed
- release APK verified with APK Signature Scheme v2; package and version metadata are `com.unsupportedpastels.hermesandroid` / `0.2.2`

## Scope and risk
- client-only changes; no Hermes server contract changes
- broader I/O retry is intentionally restricted to replayable RFC 8628 device-code polling and is not applied to refresh-token rotation
