### PR TITLE
feat(ios): show coarse min/hr recency in session inbox

### DIFF
--- a/ios/Mercury/MercuryKit/Sessions/SessionInboxModels.swift
+++ b/ios/Mercury/MercuryKit/Sessions/SessionInboxModels.swift
@@ -106,6 +106,15 @@ enum SessionInboxPolicy {
         return "\(model) · \(messages)"
     }
 
+    static func recency(since lastActive: Date, now: Date) -> String {
+        let elapsedSeconds = max(0, Int(now.timeIntervalSince(lastActive)))
+        let elapsedMinutes = elapsedSeconds / 60
+        if elapsedMinutes < 60 {
+            return "\(elapsedMinutes) min"
+        }
+        return "\(elapsedMinutes / 60) hr"
+    }
+
     private static func normalizedPath(_ path: String?) -> String? {
         guard var path = path?.trimmingCharacters(in: .whitespacesAndNewlines),
               path.hasPrefix("/") else { return nil }

--- a/ios/Mercury/Views/SessionInboxRow.swift
+++ b/ios/Mercury/Views/SessionInboxRow.swift
@@ -19,11 +19,13 @@ struct SessionInboxRow: View {
                         .lineLimit(1)
                     Spacer(minLength: 8)
                     if let lastActive = session.lastActive {
-                        Text(lastActive, style: .relative)
-                            .font(.caption)
-                            .foregroundStyle(Color.secondary)
-                            .lineLimit(1)
-                            .accessibilityLabel("Last active time")
+                        TimelineView(.periodic(from: .now, by: 60)) { context in
+                            Text(SessionInboxPolicy.recency(since: lastActive, now: context.date))
+                                .font(.caption)
+                                .foregroundStyle(Color.secondary)
+                                .lineLimit(1)
+                                .accessibilityLabel("Last active time")
+                        }
                     }
                 }
 

--- a/ios/MercuryTests/SessionInboxModelsTests.swift
+++ b/ios/MercuryTests/SessionInboxModelsTests.swift
@@ -82,4 +82,30 @@ final class SessionInboxModelsTests: XCTestCase {
         XCTAssertEqual(SessionInboxPolicy.metadata(model: "sol", messageCount: 12), "sol · 12 messages")
         XCTAssertEqual(SessionInboxPolicy.metadata(model: nil, messageCount: 0), "0 messages")
     }
+
+    func testRecencyUsesOnlyTheLargestMinuteOrHourUnit() {
+        let now = Date(timeIntervalSince1970: 10_000)
+
+        XCTAssertEqual(
+            SessionInboxPolicy.recency(since: now.addingTimeInterval(-(3 * 60 + 21)), now: now),
+            "3 min"
+        )
+        XCTAssertEqual(
+            SessionInboxPolicy.recency(since: now.addingTimeInterval(-(60 * 60 + 2 * 60)), now: now),
+            "1 hr"
+        )
+        XCTAssertEqual(
+            SessionInboxPolicy.recency(since: now.addingTimeInterval(-(2 * 60 * 60 + 59 * 60)), now: now),
+            "2 hr"
+        )
+    }
+
+    func testRecencyNeverDisplaysSeconds() {
+        let now = Date(timeIntervalSince1970: 10_000)
+
+        XCTAssertEqual(
+            SessionInboxPolicy.recency(since: now.addingTimeInterval(-59), now: now),
+            "0 min"
+        )
+    }
 }


### PR DESCRIPTION
Replaces the built-in `Text(date, style: .relative)` timestamp in the session inbox row with a `SessionInboxPolicy.recency(since:now:)` string that only ever shows the largest unit — `N min` under an hour, `N hr` after — refreshed once a minute via `TimelineView`. Never displays seconds.

Includes unit tests covering unit truncation (3 min 21 s → "3 min", 2 h 59 m → "2 hr") and the no-seconds rule (59 s → "0 min").