### PR TITLE
feat(android): inline playback for managed video MEDIA artifacts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,4 +143,8 @@ dependencies {
   implementation(libs.androidx.navigation3.ui)
   implementation(libs.androidx.navigation3.runtime)
   implementation(libs.androidx.lifecycle.viewmodel.navigation3)
+
+  // Media playback (managed video artifacts)
+  implementation(libs.androidx.media3.exoplayer)
+  implementation(libs.androidx.media3.ui)
 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
@@ -530,6 +530,16 @@ internal fun HermesAppHost(
                 resultPreservingCancellation { viewModel.downloadManagedImage(path) }
             } ?: Result.failure(IllegalStateException("Managed images unavailable"))
         },
+        onLoadManagedVideo = { path ->
+            connectionViewModel?.let { viewModel ->
+                resultPreservingCancellation { viewModel.downloadManagedVideo(path) }
+            } ?: Result.failure(IllegalStateException("Managed videos unavailable"))
+        },
+        onPeekManagedVideo = { path ->
+            connectionViewModel?.let { viewModel ->
+                resultPreservingCancellation { viewModel.peekManagedVideo(path) }.getOrNull()
+            }
+        },
         modelPickerState = modelPickerState,
         onOpenModelPicker = { sessionId -> connectionViewModel?.openModelPicker(sessionId) },
         onDismissModelPicker = { connectionViewModel?.dismissModelPicker() },

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/artifacts/ArtifactExtractor.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/artifacts/ArtifactExtractor.kt
@@ -23,6 +23,9 @@ object ArtifactExtractor {
     private val typePrefixPattern = Regex("(?i)^(image|audio|file|video)\\s*:\\s*")
     private val imageExtensions = setOf("bmp", "gif", "heic", "jpeg", "jpg", "png", "tif", "tiff", "webp")
     private val audioExtensions = setOf("aac", "flac", "m4a", "mp3", "oga", "ogg", "opus", "wav")
+    // Mirrors ui/RemoteMediaImage.kt so the browser and the inline chat player
+    // agree on which MEDIA sources count as video.
+    private val videoExtensions = setOf("m4v", "mkv", "mov", "mp4", "webm")
 
     /** Extract from the text field of every transcript message, in message order. */
     fun extract(
@@ -258,8 +261,10 @@ object ArtifactExtractor {
         val extension = name.substringAfterLast('.', "").lowercase(Locale.ROOT)
         return when {
             extension in imageExtensions -> ArtifactType.Image
+            extension in videoExtensions -> ArtifactType.Video
             extension in audioExtensions -> ArtifactType.Audio
             typePrefixPattern.find(labelHint.orEmpty())?.groupValues?.get(1)?.lowercase(Locale.ROOT) == "image" -> ArtifactType.Image
+            typePrefixPattern.find(labelHint.orEmpty())?.groupValues?.get(1)?.lowercase(Locale.ROOT) == "video" -> ArtifactType.Video
             typePrefixPattern.find(labelHint.orEmpty())?.groupValues?.get(1)?.lowercase(Locale.ROOT) == "audio" -> ArtifactType.Audio
             else -> ArtifactType.File
         }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/artifacts/ArtifactModels.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/artifacts/ArtifactModels.kt
@@ -3,6 +3,7 @@ package com.unsupportedpastels.hermesandroid.artifacts
 /** The safe presentation category of a transcript-delivered artifact. */
 enum class ArtifactType {
     Image,
+    Video,
     Audio,
     File,
 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
@@ -26,6 +26,7 @@ import com.unsupportedpastels.hermesandroid.gateway.parseOperationalStatus
 import com.unsupportedpastels.hermesandroid.files.HostFileContent
 import com.unsupportedpastels.hermesandroid.files.HostFileEntry
 import com.unsupportedpastels.hermesandroid.files.HostFileListing
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
 import com.unsupportedpastels.hermesandroid.files.MAX_HOST_FILE_BYTES
 import com.unsupportedpastels.hermesandroid.files.MAX_HOST_FILE_ENTRIES
 import com.unsupportedpastels.hermesandroid.files.validCanonicalHostFilePath
@@ -79,6 +80,8 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
+import java.io.File
+import java.io.FileOutputStream
 import java.util.Base64
 
 @Serializable
@@ -335,6 +338,8 @@ private const val MAX_SESSION_PAGE_SIZE = 500
 private const val MAX_HOST_DIRECTORY_ENTRIES = 500
 internal const val MAX_CRON_RUNS = 20
 private const val MAX_MANAGED_IMAGE_BYTES = 10 * 1024 * 1024
+private const val MAX_MANAGED_VIDEO_BYTES = 256L * 1024 * 1024
+private const val DEFAULT_VIDEO_STREAM_BUFFER_BYTES = 64 * 1024
 internal const val MAX_EFFECTIVE_CONTEXT_LENGTH = 100_000_000
 private const val MAX_HOST_FILE_LISTING_BODY_BYTES = 512 * 1024
 private const val MAX_HOST_FILE_READ_BODY_BYTES = 1024 * 1024
@@ -544,6 +549,20 @@ interface HermesConnectionClient {
         accessToken: String?,
         path: String,
     ): ByteArray = throw UnsupportedOperationException()
+
+    /**
+     * Stream the managed video at [path] into [destination] (which must live in a
+     * per-origin cache directory). Requires a video response content type,
+     * streams to disk without buffering the body in memory, and lands the file
+     * atomically via a `.part` rename so [destination] only ever denotes a
+     * complete download.
+     */
+    suspend fun streamManagedVideoToFile(
+        serverOrigin: ServerOrigin,
+        accessToken: String?,
+        path: String,
+        destination: File,
+    ): ManagedVideoMedia = throw UnsupportedOperationException()
 
     suspend fun updateSession(
         serverOrigin: ServerOrigin,
@@ -1851,6 +1870,100 @@ class HttpHermesConnectionClient(
         throw error
     } catch (error: Exception) {
         throw HermesConnectionException("Could not download Hermes managed image", error)
+    }
+
+    override suspend fun streamManagedVideoToFile(
+        serverOrigin: ServerOrigin,
+        accessToken: String?,
+        path: String,
+        destination: File,
+    ): ManagedVideoMedia = streamManagedVideoToFile(
+        serverOrigin = serverOrigin,
+        accessToken = accessToken,
+        path = path,
+        destination = destination,
+        maxBytes = MAX_MANAGED_VIDEO_BYTES,
+    )
+
+    internal suspend fun streamManagedVideoToFile(
+        serverOrigin: ServerOrigin,
+        accessToken: String?,
+        path: String,
+        destination: File,
+        maxBytes: Long,
+    ): ManagedVideoMedia = try {
+        val canonicalPath = validCanonicalHostFilePath(path)
+            ?: throw HermesConnectionException("Host file path is invalid")
+        val response = client.get("${serverOrigin.value}/api/files/download") {
+            accessToken?.let { bearerAuth(it) }
+            parameter("path", canonicalPath)
+        }
+        if (!response.status.isSuccess()) {
+            response.bodyAsChannel().cancel(null)
+            throw HermesConnectionException(
+                "Hermes managed video returned HTTP ${response.status.value}",
+            )
+        }
+        val mimeType = response.headers[io.ktor.http.HttpHeaders.ContentType]
+            ?.substringBefore(';')
+            ?.trim()
+            ?.lowercase()
+        if (mimeType?.startsWith("video/") != true) {
+            response.bodyAsChannel().cancel(null)
+            throw HermesConnectionException("Hermes managed file was not a video")
+        }
+        val declaredLength = response.headers[io.ktor.http.HttpHeaders.ContentLength]?.toLongOrNull()
+        if (declaredLength != null && declaredLength > maxBytes) {
+            response.bodyAsChannel().cancel(null)
+            throw HermesConnectionException("Hermes managed video was too large")
+        }
+        response.writeVideoBodyBounded(destination, maxBytes)
+        ManagedVideoMedia(destination, mimeType)
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (error: HermesConnectionException) {
+        throw error
+    } catch (error: Exception) {
+        throw HermesConnectionException("Could not download Hermes managed video", error)
+    }
+
+    /**
+     * Streams the response body into [destination] through a `.part` file so a
+     * failed or oversized download never leaves a half-written video behind.
+     */
+    private suspend fun HttpResponse.writeVideoBodyBounded(destination: File, maxBytes: Long) {
+        val channel = bodyAsChannel()
+        val part = File(destination.parentFile, destination.name + ".part")
+        try {
+            FileOutputStream(part).use { out ->
+                val buffer = ByteArray(DEFAULT_VIDEO_STREAM_BUFFER_BYTES)
+                var total = 0L
+                while (!channel.isClosedForRead) {
+                    val source = channel.readRemaining(DEFAULT_VIDEO_STREAM_BUFFER_BYTES.toLong())
+                    if (source.exhausted()) break
+                    while (!source.exhausted()) {
+                        val read = source.readAtMostTo(buffer, 0, buffer.size)
+                        if (read <= 0) break
+                        total += read
+                        if (total > maxBytes) {
+                            throw HermesConnectionException("Hermes managed video was too large")
+                        }
+                        out.write(buffer, 0, read)
+                    }
+                    source.close()
+                }
+                out.flush()
+            }
+            if (!part.renameTo(destination)) {
+                part.copyTo(destination, overwrite = true)
+                part.delete()
+            }
+        } catch (error: Throwable) {
+            part.delete()
+            throw error
+        } finally {
+            channel.cancel(null)
+        }
     }
 
     private suspend fun loadSessionsPage(

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
@@ -61,8 +61,10 @@ import io.ktor.http.encodeURLPathPart
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.readRemaining
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -1894,31 +1896,35 @@ class HttpHermesConnectionClient(
     ): ManagedVideoMedia = try {
         val canonicalPath = validCanonicalHostFilePath(path)
             ?: throw HermesConnectionException("Host file path is invalid")
-        val response = client.get("${serverOrigin.value}/api/files/download") {
-            accessToken?.let { bearerAuth(it) }
-            parameter("path", canonicalPath)
+        // The streamed body is written through FileOutputStream in chunks; keep
+        // that disk loop off the caller's (often Main) dispatcher.
+        withContext(Dispatchers.IO) {
+            val response = client.get("${serverOrigin.value}/api/files/download") {
+                accessToken?.let { bearerAuth(it) }
+                parameter("path", canonicalPath)
+            }
+            if (!response.status.isSuccess()) {
+                response.bodyAsChannel().cancel(null)
+                throw HermesConnectionException(
+                    "Hermes managed video returned HTTP ${response.status.value}",
+                )
+            }
+            val mimeType = response.headers[io.ktor.http.HttpHeaders.ContentType]
+                ?.substringBefore(';')
+                ?.trim()
+                ?.lowercase()
+            if (mimeType?.startsWith("video/") != true) {
+                response.bodyAsChannel().cancel(null)
+                throw HermesConnectionException("Hermes managed file was not a video")
+            }
+            val declaredLength = response.headers[io.ktor.http.HttpHeaders.ContentLength]?.toLongOrNull()
+            if (declaredLength != null && declaredLength > maxBytes) {
+                response.bodyAsChannel().cancel(null)
+                throw HermesConnectionException("Hermes managed video was too large")
+            }
+            response.writeVideoBodyBounded(destination, maxBytes)
+            ManagedVideoMedia(destination, mimeType)
         }
-        if (!response.status.isSuccess()) {
-            response.bodyAsChannel().cancel(null)
-            throw HermesConnectionException(
-                "Hermes managed video returned HTTP ${response.status.value}",
-            )
-        }
-        val mimeType = response.headers[io.ktor.http.HttpHeaders.ContentType]
-            ?.substringBefore(';')
-            ?.trim()
-            ?.lowercase()
-        if (mimeType?.startsWith("video/") != true) {
-            response.bodyAsChannel().cancel(null)
-            throw HermesConnectionException("Hermes managed file was not a video")
-        }
-        val declaredLength = response.headers[io.ktor.http.HttpHeaders.ContentLength]?.toLongOrNull()
-        if (declaredLength != null && declaredLength > maxBytes) {
-            response.bodyAsChannel().cancel(null)
-            throw HermesConnectionException("Hermes managed video was too large")
-        }
-        response.writeVideoBodyBounded(destination, maxBytes)
-        ManagedVideoMedia(destination, mimeType)
     } catch (cancelled: CancellationException) {
         throw cancelled
     } catch (error: HermesConnectionException) {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -131,6 +131,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -337,6 +338,10 @@ class HermesConnectionViewModel(
     private val speechStreamConnector: SpeechStreamConnector? = null,
     private val videoCache: ManagedVideoCache? = null,
 ) : ViewModel() {
+    // Serializes downloads targeting the same origin/path cache entry, so two
+    // concurrent players of the same path never race on the shared `.part` file.
+    private val videoDownloadLocks = ConcurrentHashMap<String, Mutex>()
+
     private val mutableSnapshots = MutableStateFlow(HermesGatewaySnapshot())
     val snapshots: StateFlow<HermesGatewaySnapshot> = mutableSnapshots.asStateFlow()
 
@@ -2536,20 +2541,28 @@ class HermesConnectionViewModel(
     /**
      * Download the managed video at [path] into the origin-scoped disk cache and
      * return the local file for playback. Previously completed downloads are
-     * reused without hitting the network.
+     * reused without hitting the network, and concurrent callers targeting the
+     * same entry are serialized behind a shared cache check.
      */
     suspend fun downloadManagedVideo(path: String): ManagedVideoMedia {
         val cache = videoCache ?: throw HermesConnectionException("Managed videos are unavailable")
         return withHermesRestOperation { serverOrigin, accessToken ->
-            cache.cached(serverOrigin, path) ?: run {
-                val media = client.streamManagedVideoToFile(
-                    serverOrigin,
-                    accessToken,
-                    path,
-                    cache.destinationFor(serverOrigin, path),
-                )
-                cache.prune(serverOrigin, keep = media.file)
-                media
+            val lock = videoDownloadLocks.computeIfAbsent(
+                "${serverOrigin.value}\u0000$path",
+            ) { Mutex() }
+            lock.withLock {
+                withContext(Dispatchers.IO) {
+                    cache.cached(serverOrigin, path) ?: run {
+                        val media = client.streamManagedVideoToFile(
+                            serverOrigin,
+                            accessToken,
+                            path,
+                            cache.destinationFor(serverOrigin, path),
+                        )
+                        cache.prune(serverOrigin, keep = media.file)
+                        media
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -32,6 +32,9 @@ import com.unsupportedpastels.hermesandroid.cache.EncryptedOfflineCacheRepositor
 import com.unsupportedpastels.hermesandroid.cache.OfflineCacheRepository
 import com.unsupportedpastels.hermesandroid.files.HostFileContent
 import com.unsupportedpastels.hermesandroid.files.HostFileListing
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoCache
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
+import java.io.File
 import com.unsupportedpastels.hermesandroid.gateway.AuthenticationState
 import com.unsupportedpastels.hermesandroid.gateway.ActiveRuntimeSession
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessage
@@ -108,6 +111,7 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.plugins.websocket.WebSockets
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
@@ -331,6 +335,7 @@ class HermesConnectionViewModel(
     private val notifications: TurnNotificationController = NoOpTurnNotificationController,
     private val sessionFilterRepository: SessionFilterRepository? = null,
     private val speechStreamConnector: SpeechStreamConnector? = null,
+    private val videoCache: ManagedVideoCache? = null,
 ) : ViewModel() {
     private val mutableSnapshots = MutableStateFlow(HermesGatewaySnapshot())
     val snapshots: StateFlow<HermesGatewaySnapshot> = mutableSnapshots.asStateFlow()
@@ -2517,6 +2522,37 @@ class HermesConnectionViewModel(
         withHermesRestOperation { serverOrigin, accessToken ->
             client.downloadManagedImage(serverOrigin, accessToken, path)
         }
+
+    /**
+     * Previously downloaded managed video for [path], if present in the
+     * origin-scoped cache. Never touches the network; powers poster previews.
+     */
+    suspend fun peekManagedVideo(path: String): ManagedVideoMedia? {
+        val cache = videoCache ?: return null
+        val origin = activeOrigin ?: return null
+        return withContext(Dispatchers.IO) { cache.cached(origin, path) }
+    }
+
+    /**
+     * Download the managed video at [path] into the origin-scoped disk cache and
+     * return the local file for playback. Previously completed downloads are
+     * reused without hitting the network.
+     */
+    suspend fun downloadManagedVideo(path: String): ManagedVideoMedia {
+        val cache = videoCache ?: throw HermesConnectionException("Managed videos are unavailable")
+        return withHermesRestOperation { serverOrigin, accessToken ->
+            cache.cached(serverOrigin, path) ?: run {
+                val media = client.streamManagedVideoToFile(
+                    serverOrigin,
+                    accessToken,
+                    path,
+                    cache.destinationFor(serverOrigin, path),
+                )
+                cache.prune(serverOrigin, keep = media.file)
+                media
+            }
+        }
+    }
 
     suspend fun createProject(
         name: String,
@@ -6146,6 +6182,7 @@ class HermesConnectionViewModel(
                     ticketClient = KtorWsTicketClient(httpClient),
                     socketFactory = KtorSpeechWebSocketFactory(httpClient),
                 ),
+                videoCache = ManagedVideoCache(File(context.cacheDir, "managed-video")),
             ) as T
         }
     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/files/HostFileModels.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/files/HostFileModels.kt
@@ -1,6 +1,7 @@
 package com.unsupportedpastels.hermesandroid.files
 
 import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import java.io.File
 
 const val MAX_HOST_FILE_ENTRIES = 500
 const val MAX_HOST_FILE_PATH_LENGTH = 1_024
@@ -41,6 +42,12 @@ data class HostFileContent(
 
     override fun hashCode(): Int = 31 * (31 * (31 * name.hashCode() + path.hashCode()) + mimeType.hashCode()) + bytes.contentHashCode()
 }
+
+/** A fully downloaded managed video cached on disk for local playback. */
+data class ManagedVideoMedia(
+    val file: File,
+    val mimeType: String,
+)
 
 data class HostFileScope(val origin: ServerOrigin, val profile: String) {
     init {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/files/ManagedVideoCache.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/files/ManagedVideoCache.kt
@@ -1,0 +1,90 @@
+package com.unsupportedpastels.hermesandroid.files
+
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import java.io.File
+import java.security.MessageDigest
+
+/** Per-file download bound for managed videos; videos stream to disk, never RAM. */
+const val MAX_MANAGED_VIDEO_BYTES = 256L * 1024 * 1024
+
+/** Total disk budget for cached managed videos per server origin. */
+const val MAX_MANAGED_VIDEO_CACHE_BYTES = 512L * 1024 * 1024
+
+private val MANAGED_VIDEO_CACHE_EXTENSION = Regex("^[a-z0-9]{1,5}$")
+
+/**
+ * Origin-scoped disk cache for downloaded managed videos.
+ *
+ * Entries are keyed by a SHA-256 of the server path inside a directory derived
+ * from the normalized server origin, so different servers never share cache
+ * entries and a server path can never escape or collide across directories.
+ * Downloads land through a `.part` file renamed into place, so an existing
+ * destination always denotes a complete download.
+ */
+class ManagedVideoCache(private val root: File?) {
+
+    fun directoryFor(origin: ServerOrigin): File? {
+        root ?: return null
+        return File(root, sha256Hex(origin.value))
+    }
+
+    /** Returns the previously downloaded media for [path], if still present. */
+    fun cached(origin: ServerOrigin, path: String): ManagedVideoMedia? {
+        directoryFor(origin) ?: return null
+        val file = destinationFor(origin, path)
+        if (!file.isFile || file.length() <= 0L) return null
+        return ManagedVideoMedia(file, mimeTypeFor(file))
+    }
+
+    fun destinationFor(origin: ServerOrigin, path: String): File {
+        val directory = requireNotNull(directoryFor(origin)) {
+            "Managed video cache root is unavailable"
+        }
+        directory.mkdirs()
+        val extension = path.substringAfterLast('.', "").lowercase()
+        val suffix = if (extension.matches(MANAGED_VIDEO_CACHE_EXTENSION)) ".$extension" else ""
+        return File(directory, sha256Hex(path) + suffix)
+    }
+
+    /**
+     * Keeps the origin directory within [budgetBytes]: stale `.part` leftovers are
+     * removed first, then the oldest entries are deleted (never [keep]) until the
+     * directory fits the budget.
+     */
+    fun prune(origin: ServerOrigin, keep: File? = null, budgetBytes: Long = MAX_MANAGED_VIDEO_CACHE_BYTES) {
+        val directory = directoryFor(origin) ?: return
+        val staleCutoff = System.currentTimeMillis() - STALE_PART_MILLIS
+        directory.listFiles().orEmpty()
+            .filter { it.isFile && it.name.endsWith(PART_SUFFIX) && it.lastModified() < staleCutoff }
+            .forEach(File::delete)
+
+        var total = directory.listFiles().orEmpty().filter(File::isFile).sumOf(File::length)
+        if (total <= budgetBytes) return
+        directory.listFiles().orEmpty()
+            .filter { it.isFile && it != keep }
+            .sortedBy(File::lastModified)
+            .forEach { file ->
+                if (total <= budgetBytes) return
+                total -= file.length()
+                file.delete()
+            }
+    }
+
+    private fun mimeTypeFor(file: File): String = when (file.extension) {
+        "webm" -> "video/webm"
+        "mov" -> "video/quicktime"
+        "m4v" -> "video/x-m4v"
+        "mkv" -> "video/x-matroska"
+        else -> "video/mp4"
+    }
+
+    companion object {
+        const val PART_SUFFIX = ".part"
+        private const val STALE_PART_MILLIS = 24 * 60 * 60 * 1000L
+
+        internal fun sha256Hex(value: String): String = MessageDigest
+            .getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
@@ -278,6 +278,7 @@ import com.unsupportedpastels.hermesandroid.gateway.SlashCompletionItem
 import com.unsupportedpastels.hermesandroid.gateway.ValidReasoningEfforts
 import com.unsupportedpastels.hermesandroid.files.HostFileContent
 import com.unsupportedpastels.hermesandroid.files.HostFileListing
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
 import com.unsupportedpastels.hermesandroid.navigation.HomeRoute
 import com.unsupportedpastels.hermesandroid.navigation.ProjectRoute
 import com.unsupportedpastels.hermesandroid.navigation.RecentSessionsRoute
@@ -501,6 +502,10 @@ fun HermesApp(
     onLoadManagedImage: suspend (String) -> Result<ByteArray> = {
         Result.failure(UnsupportedOperationException("Managed images are unavailable"))
     },
+    onLoadManagedVideo: suspend (String) -> Result<ManagedVideoMedia> = {
+        Result.failure(UnsupportedOperationException("Managed videos are unavailable"))
+    },
+    onPeekManagedVideo: suspend (String) -> ManagedVideoMedia? = { null },
     modelPickerState: ModelPickerState = ModelPickerState.Closed,
     onOpenModelPicker: (DurableSessionId) -> Unit = {},
     onDismissModelPicker: () -> Unit = {},
@@ -1104,6 +1109,8 @@ fun HermesApp(
                         showBack = !supportsListDetail,
                         onBack = navigateBack,
                         onLoadManagedImage = onLoadManagedImage,
+                        onLoadManagedVideo = onLoadManagedVideo,
+                        onPeekManagedVideo = onPeekManagedVideo,
                         onLoadHostFiles = onLoadHostFiles,
                         onLoadManagedFile = onLoadManagedFile,
                         onAttachHostReference = { reference ->
@@ -4936,6 +4943,8 @@ private fun SessionDetailScreen(
     showBack: Boolean,
     onBack: () -> Unit,
     onLoadManagedImage: suspend (String) -> Result<ByteArray>,
+    onLoadManagedVideo: suspend (String) -> Result<ManagedVideoMedia>,
+    onPeekManagedVideo: suspend (String) -> ManagedVideoMedia?,
     onLoadHostFiles: suspend (String?) -> Result<HostFileListing>,
     onLoadManagedFile: suspend (String) -> Result<HostFileContent>,
     onAttachHostReference: (String) -> Unit,
@@ -5189,6 +5198,8 @@ private fun SessionDetailScreen(
                                     loadManagedImage = { path ->
                                         onLoadManagedImage(path).getOrThrow()
                                     },
+                                    loadManagedVideo = onLoadManagedVideo,
+                                    peekManagedVideo = onPeekManagedVideo,
                                 )
                                 return@items
                             }
@@ -5227,6 +5238,8 @@ private fun SessionDetailScreen(
                                             loadManagedImage = { path ->
                                                 onLoadManagedImage(path).getOrThrow()
                                             },
+                                            loadManagedVideo = onLoadManagedVideo,
+                                            peekManagedVideo = onPeekManagedVideo,
                                         )
                                     }
                                     message.role == ChatMessageRole.User -> {
@@ -5256,6 +5269,8 @@ private fun SessionDetailScreen(
                                                     loadManagedImage = { path ->
                                                         onLoadManagedImage(path).getOrThrow()
                                                     },
+                                                    loadManagedVideo = onLoadManagedVideo,
+                                                    peekManagedVideo = onPeekManagedVideo,
                                                 )
                                             }
                                         }
@@ -5275,6 +5290,8 @@ private fun SessionDetailScreen(
                                                 loadManagedImage = { path ->
                                                     onLoadManagedImage(path).getOrThrow()
                                                 },
+                                                loadManagedVideo = onLoadManagedVideo,
+                                                peekManagedVideo = onPeekManagedVideo,
                                             )
                                         }
                                         val streamingTail = renderedText.substring(stableLength)
@@ -5292,6 +5309,8 @@ private fun SessionDetailScreen(
                                             loadManagedImage = { path ->
                                                 onLoadManagedImage(path).getOrThrow()
                                             },
+                                            loadManagedVideo = onLoadManagedVideo,
+                                            peekManagedVideo = onPeekManagedVideo,
                                         )
                                     }
                                 }
@@ -5882,6 +5901,8 @@ private fun SessionDetailScreen(
             artifacts = sessionArtifacts,
             onDismiss = { showArtifacts = false },
             onLoadManagedImage = onLoadManagedImage,
+            onLoadManagedVideo = onLoadManagedVideo,
+            onPeekManagedVideo = onPeekManagedVideo,
             onLoadManagedFile = onLoadManagedFile,
         )
     }
@@ -6003,6 +6024,8 @@ private fun ArtifactBrowserSheet(
     artifacts: List<Artifact>,
     onDismiss: () -> Unit,
     onLoadManagedImage: suspend (String) -> Result<ByteArray>,
+    onLoadManagedVideo: suspend (String) -> Result<ManagedVideoMedia>,
+    onPeekManagedVideo: suspend (String) -> ManagedVideoMedia?,
     onLoadManagedFile: suspend (String) -> Result<HostFileContent>,
 ) {
     val context = LocalContext.current
@@ -6190,6 +6213,16 @@ private fun ArtifactBrowserSheet(
                                 artifact.origin == ArtifactOrigin.ManagedPath
                             ) {
                                 ManagedAudioPlayer(artifact, onLoadManagedFile)
+                            }
+                            if (
+                                artifact.type == ArtifactType.Video &&
+                                artifact.origin == ArtifactOrigin.ManagedPath
+                            ) {
+                                ManagedVideoBlock(
+                                    source = artifact.source,
+                                    onLoadManagedVideo = onLoadManagedVideo,
+                                    onPeekManagedVideo = onPeekManagedVideo,
+                                )
                             }
                             HorizontalDivider()
                         }
@@ -7002,6 +7035,8 @@ private fun ToolMessageBlock(
     expanded: Boolean,
     onToggle: () -> Unit,
     loadManagedImage: (suspend (String) -> ByteArray)? = null,
+    loadManagedVideo: (suspend (String) -> Result<ManagedVideoMedia>)? = null,
+    peekManagedVideo: (suspend (String) -> ManagedVideoMedia?)? = null,
 ) {
     val preview = remember(text) {
         text.replace('\n', ' ').trim().take(80)
@@ -7057,6 +7092,8 @@ private fun ToolMessageBlock(
                 MarkdownMessage(
                     text,
                     loadManagedImage = loadManagedImage,
+                    loadManagedVideo = loadManagedVideo,
+                    peekManagedVideo = peekManagedVideo,
                 )
             }
         }
@@ -7076,6 +7113,8 @@ private fun TranscriptToolRunGroup(
     onToggle: () -> Unit,
     sessionKey: String,
     loadManagedImage: (suspend (String) -> ByteArray)? = null,
+    loadManagedVideo: (suspend (String) -> Result<ManagedVideoMedia>)? = null,
+    peekManagedVideo: (suspend (String) -> ManagedVideoMedia?)? = null,
 ) {
     val semanticColors = LocalHermesSemanticColors.current
     val noun = if (tools.size == 1) "action" else "actions"
@@ -7135,6 +7174,8 @@ private fun TranscriptToolRunGroup(
                             expanded = showToolMessage,
                             onToggle = { showToolMessage = !showToolMessage },
                             loadManagedImage = loadManagedImage,
+                            loadManagedVideo = loadManagedVideo,
+                            peekManagedVideo = peekManagedVideo,
                         )
                     }
                 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoPlayer.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoPlayer.kt
@@ -161,12 +161,22 @@ internal fun ManagedVideoBlock(
     var error by remember(source) { mutableStateOf<String?>(null) }
     var playbackError by remember(media) { mutableStateOf<String?>(null) }
     var fullscreen by remember(media) { mutableStateOf(false) }
-    var poster by remember(source) { mutableStateOf(ManagedVideoPosterRuntime.get(source)) }
+    var poster by remember(source) { mutableStateOf<ImageBitmap?>(null) }
+
+    // Poster cache entries are keyed by the origin-scoped cache file, never by
+    // the raw source path: different servers may reference the same path, and
+    // the frame must always come from the file this server's cache owns.
+    fun posterKey(media: ManagedVideoMedia): String = media.file.absolutePath
 
     LaunchedEffect(source, onPeekManagedVideo) {
-        if (poster != null) return@LaunchedEffect
         val peek = onPeekManagedVideo ?: return@LaunchedEffect
         val cached = runCatching { peek(source) }.getOrNull() ?: return@LaunchedEffect
+        val key = posterKey(cached)
+        val existing = ManagedVideoPosterRuntime.get(key)
+        if (existing != null) {
+            poster = existing
+            return@LaunchedEffect
+        }
         val posterFile = posterFileFor(cached)
         val frame = if (posterFile.isFile) {
             decodePosterFile(posterFile)
@@ -174,7 +184,7 @@ internal fun ManagedVideoBlock(
             extractPosterFrame(cached.file, posterFile)
         }
         if (frame != null) {
-            ManagedVideoPosterRuntime.put(source, frame)
+            ManagedVideoPosterRuntime.put(key, frame)
             poster = frame
         }
     }
@@ -219,10 +229,11 @@ internal fun ManagedVideoBlock(
             loader(source).fold(
                 onSuccess = { loaded ->
                     media = loaded
-                    if (ManagedVideoPosterRuntime.get(source) == null) {
+                    val key = posterKey(loaded)
+                    if (ManagedVideoPosterRuntime.get(key) == null) {
                         val frame = extractPosterFrame(loaded.file, posterFileFor(loaded))
                         if (frame != null) {
-                            ManagedVideoPosterRuntime.put(source, frame)
+                            ManagedVideoPosterRuntime.put(key, frame)
                             poster = frame
                         }
                     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoPlayer.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoPlayer.kt
@@ -1,0 +1,416 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Fullscreen
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private const val DEFAULT_VIDEO_ASPECT = 16f / 9f
+private const val MIN_VIDEO_ASPECT = 0.4f
+private const val MAX_VIDEO_ASPECT = 2.5f
+private const val MAX_POSTER_DIMENSION = 720
+private const val MAX_POSTER_CACHE_ENTRIES = 8
+
+/** Small in-memory LRU of poster frames keyed by the MEDIA source. */
+private object ManagedVideoPosterRuntime {
+    private val cache = object : LinkedHashMap<String, ImageBitmap>(
+        MAX_POSTER_CACHE_ENTRIES,
+        0.75f,
+        true,
+    ) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, ImageBitmap>?): Boolean =
+            size > MAX_POSTER_CACHE_ENTRIES
+    }
+
+    @Synchronized
+    fun get(source: String): ImageBitmap? = cache[source]
+
+    @Synchronized
+    fun put(source: String, bitmap: ImageBitmap) {
+        cache[source] = bitmap
+    }
+}
+
+private fun posterFileFor(media: ManagedVideoMedia): File =
+    File(media.file.parentFile, media.file.nameWithoutExtension + ".jpg")
+
+private fun decodePosterFile(file: File): ImageBitmap? =
+    BitmapFactory.decodeFile(file.absolutePath)?.asImageBitmap()
+
+/**
+ * Extracts a downscaled first frame from the downloaded video and, when
+ * [destination] is given, persists it as a JPEG poster next to the video.
+ */
+private suspend fun extractPosterFrame(file: File, destination: File?): ImageBitmap? =
+    withContext(Dispatchers.IO) {
+        runCatching {
+            MediaMetadataRetriever().use { retriever ->
+                retriever.setDataSource(file.absolutePath)
+                val frame = retriever.getFrameAtTime(
+                    0L,
+                    MediaMetadataRetriever.OPTION_CLOSEST_SYNC,
+                ) ?: return@runCatching null
+                val scale = minOf(
+                    1f,
+                    MAX_POSTER_DIMENSION.toFloat() / maxOf(frame.width, frame.height),
+                )
+                val bitmap = if (scale < 1f) {
+                    Bitmap.createScaledBitmap(
+                        frame,
+                        (frame.width * scale).toInt().coerceAtLeast(1),
+                        (frame.height * scale).toInt().coerceAtLeast(1),
+                        true,
+                    )
+                } else {
+                    frame
+                }
+                destination?.let { poster ->
+                    runCatching {
+                        FileOutputStream(poster).use { out ->
+                            bitmap.compress(Bitmap.CompressFormat.JPEG, 80, out)
+                        }
+                    }
+                }
+                bitmap.asImageBitmap()
+            }
+        }.getOrNull()
+    }
+
+/**
+ * Inline managed-video player for chat MEDIA blocks and the artifact browser.
+ *
+ * Playback is always fed from a fully downloaded, origin-scoped cache file: the
+ * bearer token never reaches the player and no streaming URL is embedded in the
+ * view hierarchy. Downloaded videos start playing immediately; a poster frame
+ * extracted from the file is shown while idle once the video is in cache.
+ */
+// PlayerView.switchTargetView (fullscreen hand-off) is UnstableApi in media3.
+@androidx.annotation.OptIn(UnstableApi::class)
+@Composable
+internal fun ManagedVideoBlock(
+    source: String,
+    modifier: Modifier = Modifier,
+    onLoadManagedVideo: (suspend (String) -> Result<ManagedVideoMedia>)? = null,
+    onPeekManagedVideo: (suspend (String) -> ManagedVideoMedia?)? = null,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var media by remember(source) { mutableStateOf<ManagedVideoMedia?>(null) }
+    var loading by remember(source) { mutableStateOf(false) }
+    var error by remember(source) { mutableStateOf<String?>(null) }
+    var playbackError by remember(media) { mutableStateOf<String?>(null) }
+    var fullscreen by remember(media) { mutableStateOf(false) }
+    var poster by remember(source) { mutableStateOf(ManagedVideoPosterRuntime.get(source)) }
+
+    LaunchedEffect(source, onPeekManagedVideo) {
+        if (poster != null) return@LaunchedEffect
+        val peek = onPeekManagedVideo ?: return@LaunchedEffect
+        val cached = runCatching { peek(source) }.getOrNull() ?: return@LaunchedEffect
+        val posterFile = posterFileFor(cached)
+        val frame = if (posterFile.isFile) {
+            decodePosterFile(posterFile)
+        } else {
+            extractPosterFrame(cached.file, posterFile)
+        }
+        if (frame != null) {
+            ManagedVideoPosterRuntime.put(source, frame)
+            poster = frame
+        }
+    }
+
+    val player = remember(media) {
+        media?.let { loaded ->
+            ExoPlayer.Builder(context).build().apply {
+                setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(C.USAGE_MEDIA)
+                        .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+                        .build(),
+                    /* handleAudioFocus = */ true,
+                )
+                setMediaItem(MediaItem.fromUri(Uri.fromFile(loaded.file)))
+                addListener(
+                    object : Player.Listener {
+                        override fun onPlayerError(failure: PlaybackException) {
+                            playbackError = failure.message?.take(120) ?: "Playback failed"
+                        }
+                    },
+                )
+                prepare()
+                // One tap starts the whole flow: download, then playback.
+                playWhenReady = true
+            }
+        }
+    }
+    DisposableEffect(player) {
+        onDispose { player?.release() }
+    }
+
+    fun startLoading() {
+        val loader = onLoadManagedVideo
+        if (loader == null) {
+            error = "Video playback is unavailable"
+            return
+        }
+        scope.launch {
+            loading = true
+            error = null
+            loader(source).fold(
+                onSuccess = { loaded ->
+                    media = loaded
+                    if (ManagedVideoPosterRuntime.get(source) == null) {
+                        val frame = extractPosterFrame(loaded.file, posterFileFor(loaded))
+                        if (frame != null) {
+                            ManagedVideoPosterRuntime.put(source, frame)
+                            poster = frame
+                        }
+                    }
+                },
+                onFailure = { failure ->
+                    error = failure.message?.take(120) ?: "Could not load video"
+                },
+            )
+            loading = false
+        }
+    }
+
+    val aspect = poster?.let { bitmap ->
+        (bitmap.width.toFloat() / bitmap.height.coerceAtLeast(1))
+            .coerceIn(MIN_VIDEO_ASPECT, MAX_VIDEO_ASPECT)
+    } ?: DEFAULT_VIDEO_ASPECT
+    val surfaceModifier = modifier
+        .fillMaxWidth()
+        .aspectRatio(aspect)
+        .clip(RoundedCornerShape(8.dp))
+    if (media == null) {
+        Box(
+            modifier = surfaceModifier.background(
+                MaterialTheme.colorScheme.surfaceVariant,
+                RoundedCornerShape(8.dp),
+            ),
+            contentAlignment = Alignment.Center,
+        ) {
+            poster?.let { frame ->
+                Image(
+                    bitmap = frame,
+                    contentDescription = null,
+                    modifier = Modifier.matchParentSize(),
+                    contentScale = ContentScale.Crop,
+                )
+            }
+            when {
+                loading -> Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(Color.Black.copy(alpha = 0.35f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        CircularProgressIndicator(color = Color.White)
+                        Text("Loading video…", color = Color.White)
+                    }
+                }
+                error != null -> Column(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        error.orEmpty(),
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    TextButton(onClick = { startLoading() }) { Text("Retry") }
+                }
+                else -> PlayOverlayButton(
+                    description = "Play video",
+                    onClick = { startLoading() },
+                )
+            }
+        }
+    } else {
+        val inlineView = remember { mutableStateOf<PlayerView?>(null) }
+        Box(modifier = surfaceModifier) {
+            AndroidView(
+                factory = { holder -> PlayerView(holder).apply { useController = true } },
+                update = { view ->
+                    inlineView.value = view
+                    if (!fullscreen && view.player !== player) {
+                        view.player = player
+                    }
+                },
+                modifier = Modifier.fillMaxSize(),
+            )
+            IconButton(
+                onClick = { fullscreen = true },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .size(40.dp)
+                    .semantics { contentDescription = "Open fullscreen video" },
+            ) {
+                Icon(
+                    Icons.Rounded.Fullscreen,
+                    contentDescription = null,
+                    tint = Color.White,
+                )
+            }
+        }
+
+        if (fullscreen && player != null) {
+            var dialogView by remember { mutableStateOf<PlayerView?>(null) }
+            fun closeFullscreen() {
+                val dialog = dialogView
+                val inline = inlineView.value
+                if (dialog != null && inline != null) {
+                    PlayerView.switchTargetView(player, dialog, inline)
+                }
+                fullscreen = false
+            }
+            Dialog(
+                onDismissRequest = { closeFullscreen() },
+                properties = DialogProperties(
+                    usePlatformDefaultWidth = false,
+                    decorFitsSystemWindows = false,
+                ),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black)
+                        .safeDrawingPadding(),
+                ) {
+                    AndroidView(
+                        factory = { holder ->
+                            PlayerView(holder).apply {
+                                useController = true
+                                val previous = inlineView.value
+                                if (previous != null) {
+                                    PlayerView.switchTargetView(player, previous, this)
+                                } else {
+                                    this.player = player
+                                }
+                            }
+                        },
+                        update = { view -> dialogView = view },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    IconButton(
+                        onClick = { closeFullscreen() },
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .size(48.dp),
+                    ) {
+                        Icon(
+                            Icons.Rounded.Close,
+                            contentDescription = "Close fullscreen video",
+                            tint = Color.White,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    playbackError?.let { message ->
+        Text(
+            text = message,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 4.dp),
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+@Composable
+private fun BoxScope.PlayOverlayButton(
+    description: String,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        shape = CircleShape,
+        color = Color.Black.copy(alpha = 0.55f),
+        modifier = Modifier
+            .align(Alignment.Center)
+            .size(56.dp)
+            .semantics { contentDescription = description },
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                Icons.Rounded.PlayArrow,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(36.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
 
 internal sealed interface MarkdownBlock
 
@@ -81,6 +82,10 @@ internal data class MarkdownCodeBlock(
 ) : MarkdownBlock
 
 internal data class MarkdownImageBlock(
+    val url: String,
+) : MarkdownBlock
+
+internal data class MarkdownVideoBlock(
     val url: String,
 ) : MarkdownBlock
 
@@ -309,6 +314,12 @@ internal fun parseMessageMarkdown(source: String): List<MarkdownBlock> {
             if (validateRemoteMediaUrl(source) || validateGatewayMediaPath(source)) {
                 flushParagraph()
                 blocks += MarkdownImageBlock(source)
+                index += 1
+                continue
+            }
+            if (validateGatewayVideoPath(source)) {
+                flushParagraph()
+                blocks += MarkdownVideoBlock(source)
                 index += 1
                 continue
             }
@@ -547,6 +558,8 @@ internal fun MarkdownMessage(
     text: String,
     modifier: Modifier = Modifier,
     loadManagedImage: (suspend (String) -> ByteArray)? = null,
+    loadManagedVideo: (suspend (String) -> Result<ManagedVideoMedia>)? = null,
+    peekManagedVideo: (suspend (String) -> ManagedVideoMedia?)? = null,
 ) {
     val displayText = remember(text) { compactEmbeddedPayloads(text) }
     var requestedCharacters by rememberSaveable(displayText) {
@@ -574,6 +587,11 @@ internal fun MarkdownMessage(
                         is MarkdownImageBlock -> RemoteMediaImage(
                             source = block.url,
                             loadManagedImage = loadManagedImage,
+                        )
+                        is MarkdownVideoBlock -> ManagedVideoBlock(
+                            source = block.url,
+                            onLoadManagedVideo = loadManagedVideo,
+                            onPeekManagedVideo = peekManagedVideo,
                         )
                         is MarkdownTableBlock -> MarkdownTable(block)
                     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImage.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImage.kt
@@ -111,12 +111,25 @@ internal fun hostResolvesToPublicNetwork(
 internal fun resolveHostToAddresses(host: String): List<InetAddress> =
     runCatching { InetAddress.getAllByName(host).toList() }.getOrElse { emptyList() }
 
+internal val gatewayImageMediaExtensions = setOf("png", "jpg", "jpeg", "webp", "gif")
+
+// Mirrors artifacts/ArtifactExtractor.kt so the artifact browser and the inline
+// chat player agree on which MEDIA sources count as video.
+internal val gatewayVideoMediaExtensions = setOf("m4v", "mkv", "mov", "mp4", "webm")
+
 internal fun validateGatewayMediaPath(value: String): Boolean =
     value.startsWith('/') &&
         '\u0000' !in value &&
         value.length in 2..4_096 &&
         value.substringAfterLast('.', missingDelimiterValue = "")
-            .lowercase() in setOf("png", "jpg", "jpeg", "webp", "gif")
+            .lowercase() in gatewayImageMediaExtensions
+
+internal fun validateGatewayVideoPath(value: String): Boolean =
+    value.startsWith('/') &&
+        '\u0000' !in value &&
+        value.length in 2..4_096 &&
+        value.substringAfterLast('.', missingDelimiterValue = "")
+            .lowercase() in gatewayVideoMediaExtensions
 
 internal fun HttpClientConfig<*>.configureRemoteImageHttpClient() {
     followRedirects = false

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/artifacts/ArtifactExtractorTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/artifacts/ArtifactExtractorTest.kt
@@ -63,6 +63,28 @@ class ArtifactExtractorTest {
     }
 
     @Test
+    fun classifiesManagedAndRemoteVideoSources() {
+        val artifacts = ArtifactExtractor.extract(
+            """
+            MEDIA:/workspace/scene-00/preview.mp4
+            [Video: moving preview](https://cdn.example/previews/scene.webm?dl=1)
+            """.trimIndent(),
+        )
+
+        assertEquals(listOf(ArtifactType.Video, ArtifactType.Video), artifacts.map { it.type })
+        assertEquals(ArtifactOrigin.ManagedPath, artifacts[0].origin)
+        assertEquals(ArtifactOrigin.RemoteUrl, artifacts[1].origin)
+        assertEquals("preview.mp4", artifacts[0].displayName)
+    }
+
+    @Test
+    fun videoLabelPrefixClassifiesWithoutExtension() {
+        val artifacts = ArtifactExtractor.extract("[Video: demo](https://files.example/download)")
+
+        assertEquals(ArtifactType.Video, artifacts.single().type)
+    }
+
+    @Test
     fun rejectsUnsafeUrlsMalformedSourcesAndArbitraryProse() {
         val credentialedUrl = "https://user" + ":pass@example.com/secret.png"
         val artifacts = ArtifactExtractor.extract(

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
@@ -19,10 +19,14 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
 import com.unsupportedpastels.hermesandroid.app.DurableSessionId
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessage
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessageRole
@@ -392,6 +396,111 @@ class HermesConnectionClientTest {
         )
 
         assertTrue(downloaded.contentEquals(bytes))
+    }
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun managedVideoStreamsAuthenticatedBodyIntoDestinationFile() = runTest {
+        val bytes = byteArrayOf(9, 8, 7, 6, 5)
+        val engine = MockEngine { request ->
+            assertEquals("/api/files/download", request.url.encodedPath)
+            assertEquals("/workspace/scene-00/preview.mp4", request.url.parameters["path"])
+            assertEquals("Bearer opaque-access", request.headers[HttpHeaders.Authorization])
+            respond(
+                content = bytes,
+                headers = headersOf(HttpHeaders.ContentType, "video/mp4"),
+            )
+        }
+        val client = HttpHermesConnectionClient(HttpClient(engine))
+        val destination = File(tempFolder.root, "preview.mp4")
+
+        val media = client.streamManagedVideoToFile(
+            ServerOrigin.parse("https://hermes.example"),
+            "opaque-access",
+            "/workspace/scene-00/preview.mp4",
+            destination,
+        )
+
+        assertEquals("video/mp4", media.mimeType)
+        assertEquals(destination.absolutePath, media.file.absolutePath)
+        assertArrayEquals(bytes, destination.readBytes())
+        assertFalse(File(tempFolder.root, "preview.mp4.part").exists())
+    }
+
+    @Test
+    fun managedVideoRejectsNonVideoContentTypeWithoutWritingDestination() = runTest {
+        val engine = MockEngine {
+            respond(
+                content = ByteArray(4),
+                headers = headersOf(HttpHeaders.ContentType, "image/jpeg"),
+            )
+        }
+        val client = HttpHermesConnectionClient(HttpClient(engine))
+        val destination = File(tempFolder.root, "clip.mp4")
+
+        val failure = runCatching {
+            client.streamManagedVideoToFile(
+                ServerOrigin.parse("https://hermes.example"),
+                "opaque-access",
+                "/workspace/scene-00/clip.mp4",
+                destination,
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is HermesConnectionException)
+        assertFalse(destination.exists())
+    }
+
+    @Test
+    fun managedVideoRejectsRelativePathBeforeAnyRequest() = runTest {
+        var requests = 0
+        val engine = MockEngine {
+            requests += 1
+            respond(content = ByteArray(0), headers = headersOf(HttpHeaders.ContentType, "video/mp4"))
+        }
+        val client = HttpHermesConnectionClient(HttpClient(engine))
+
+        val failure = runCatching {
+            client.streamManagedVideoToFile(
+                ServerOrigin.parse("https://hermes.example"),
+                "opaque-access",
+                "relative/clip.mp4",
+                File(tempFolder.root, "clip.mp4"),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is HermesConnectionException)
+        assertEquals(0, requests)
+    }
+
+    @Test
+    fun managedVideoRejectsBodyLargerThanCapAndLeavesNoPartialFile() = runTest {
+        val engine = MockEngine {
+            respond(
+                content = ByteArray(64),
+                headers = headersOf(HttpHeaders.ContentType, "video/mp4"),
+            )
+        }
+        val client = HttpHermesConnectionClient(HttpClient(engine))
+        val destination = File(tempFolder.root, "clip.mp4")
+
+        val failure = runCatching {
+            client.streamManagedVideoToFile(
+                ServerOrigin.parse("https://hermes.example"),
+                "opaque-access",
+                "/workspace/scene-00/clip.mp4",
+                destination,
+                maxBytes = 16L,
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is HermesConnectionException)
+        assertFalse(destination.exists())
+        tempFolder.root.listFiles().orEmpty().forEach { file ->
+            assertFalse("leftover ${file.name}", file.name.endsWith(".part"))
+        }
     }
 
     @Test

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
@@ -4,6 +4,8 @@ import com.unsupportedpastels.hermesandroid.cache.CacheScope
 import com.unsupportedpastels.hermesandroid.cache.CachedSession
 import com.unsupportedpastels.hermesandroid.cache.OfflineCacheRepository
 import com.unsupportedpastels.hermesandroid.cache.OfflineCacheSnapshot
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoCache
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
 import com.unsupportedpastels.hermesandroid.gateway.CacheSource
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessage
 import com.unsupportedpastels.hermesandroid.gateway.AuthenticationState
@@ -64,6 +66,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.nio.file.Files
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -126,6 +130,49 @@ class HermesConnectionViewModelTest {
         assertTrue(snapshot.nativeOAuthSupported)
         assertEquals(listOf("nous"), snapshot.authProviders.map { it.name })
         assertEquals(listOf(origin), client.probedOrigins)
+    }
+
+    @Test
+    fun concurrentDownloadsOfTheSamePathSerializeBehindOneCacheEntry() = runTest(dispatcher) {
+        val origin = ServerOrigin.parse("https://hermes.example")
+        val settings = MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin))
+        val cacheRoot = Files.createTempDirectory("video-cache").toFile()
+        val client = GatedVideoDownloadClient()
+        val viewModel = HermesConnectionViewModel(
+            settings,
+            client,
+            videoCache = ManagedVideoCache(cacheRoot),
+        )
+
+        runCurrent()
+        client.connection.complete(
+            HermesConnectionInfo(
+                version = "0.20.0",
+                authRequired = false,
+                nativeOAuthSupported = false,
+                providers = emptyList(),
+            ),
+        )
+        advanceUntilIdle()
+
+        val first = async { viewModel.downloadManagedVideo("/a/clip.mp4") }
+        val second = async { viewModel.downloadManagedVideo("/a/clip.mp4") }
+        client.firstDownloadStarted.await()
+
+        // The second caller must wait behind the first instead of streaming into
+        // the same .part file concurrently.
+        assertEquals(1, client.started)
+        assertEquals(1, client.active)
+        client.gate.complete(Unit)
+        advanceUntilIdle()
+
+        val firstMedia = first.await()
+        val secondMedia = second.await()
+        assertEquals(1, client.started)
+        assertEquals(firstMedia.file.absolutePath, secondMedia.file.absolutePath)
+        assertTrue(secondMedia.file.isFile)
+
+        cacheRoot.deleteRecursively()
     }
 
     @Test
@@ -3354,6 +3401,35 @@ private class FakeHermesConnectionClient : HermesConnectionClient {
     override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo {
         probedOrigins += serverOrigin
         return response.await()
+    }
+}
+
+private class GatedVideoDownloadClient : HermesConnectionClient {
+    val connection = CompletableDeferred<HermesConnectionInfo>()
+    val gate = CompletableDeferred<Unit>()
+    val firstDownloadStarted = CompletableDeferred<Unit>()
+    var started = 0
+    var active = 0
+
+    override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo = connection.await()
+
+    override suspend fun streamManagedVideoToFile(
+        serverOrigin: ServerOrigin,
+        accessToken: String?,
+        path: String,
+        destination: File,
+    ): ManagedVideoMedia {
+        started += 1
+        active += 1
+        firstDownloadStarted.complete(Unit)
+        try {
+            gate.await()
+            destination.parentFile?.mkdirs()
+            destination.writeBytes(byteArrayOf(1, 2, 3))
+        } finally {
+            active -= 1
+        }
+        return ManagedVideoMedia(destination, "video/mp4")
     }
 }
 

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/files/ManagedVideoCacheTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/files/ManagedVideoCacheTest.kt
@@ -1,0 +1,94 @@
+package com.unsupportedpastels.hermesandroid.files
+
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ManagedVideoCacheTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private val origin = ServerOrigin.parse("https://hermes.example")
+    private val otherOrigin = ServerOrigin.parse("https://other.example")
+
+    @Test
+    fun destinationsAreDeterministicOriginScopedAndExtensionTyped() {
+        val cache = ManagedVideoCache(tempFolder.root)
+
+        val first = cache.destinationFor(origin, "/workspace/clip.mp4")
+        val again = cache.destinationFor(origin, "/workspace/clip.mp4")
+        val other = cache.destinationFor(otherOrigin, "/workspace/clip.mp4")
+
+        assertEquals(first.absolutePath, again.absolutePath)
+        assertNotEquals(first.parentFile.absolutePath, other.parentFile.absolutePath)
+        assertTrue(first.name.endsWith(".mp4"))
+        assertEquals(ManagedVideoCache.sha256Hex("/workspace/clip.mp4") + ".mp4", first.name)
+    }
+
+    @Test
+    fun sanitizesHostileCacheExtensions() {
+        val cache = ManagedVideoCache(tempFolder.root)
+
+        val destination = cache.destinationFor(origin, "/workspace/clip.ELABORATE")
+
+        assertFalse(destination.name.endsWith(".ELABORATE"))
+        assertEquals(ManagedVideoCache.sha256Hex("/workspace/clip.ELABORATE"), destination.name)
+    }
+
+    @Test
+    fun cachedReturnsExistingCompleteDownloadOnly() {
+        val cache = ManagedVideoCache(tempFolder.root)
+        val destination = cache.destinationFor(origin, "/workspace/clip.mp4")
+        assertNull(cache.cached(origin, "/workspace/clip.mp4"))
+
+        destination.writeBytes(byteArrayOf(1, 2, 3))
+
+        val media = cache.cached(origin, "/workspace/clip.mp4")
+        assertEquals("video/mp4", media?.mimeType)
+        assertEquals(destination.absolutePath, media?.file?.absolutePath)
+        assertNull(cache.cached(otherOrigin, "/workspace/clip.mp4"))
+    }
+
+    @Test
+    fun pruneKeepsMostRecentDownloadWithinBudget() {
+        val cache = ManagedVideoCache(tempFolder.root)
+        val old = cache.destinationFor(origin, "/a/old.mp4")
+        val keep = cache.destinationFor(origin, "/b/keep.mp4")
+        old.writeBytes(ByteArray(600))
+        keep.writeBytes(ByteArray(400))
+        old.setLastModified(1_000L)
+        keep.setLastModified(2_000L)
+
+        cache.prune(origin, keep = keep, budgetBytes = 500L)
+
+        assertFalse(old.exists())
+        assertTrue(keep.exists())
+    }
+
+    @Test
+    fun pruneRemovesStalePartialDownloads() {
+        val cache = ManagedVideoCache(tempFolder.root)
+        val part = File(cache.directoryFor(origin), "pending.mp4.part")
+        part.parentFile.mkdirs()
+        part.writeBytes(ByteArray(16))
+        part.setLastModified(1_000L)
+
+        cache.prune(origin, budgetBytes = Long.MAX_VALUE)
+
+        assertFalse(part.exists())
+    }
+
+    @Test
+    fun cacheWithoutRootIsUnavailable() {
+        val cache = ManagedVideoCache(null)
+
+        assertNull(cache.directoryFor(origin))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
@@ -60,6 +60,38 @@ class MessageMarkdownTest {
     }
 
     @Test
+    fun parsesGatewayLocalVideoMediaDirectiveAsVideoBlockInsteadOfRawPath() {
+        val path = "/workspace/project/scene-00/preview.mp4"
+
+        val blocks = parseMessageMarkdown("Preview:\n\nMEDIA:$path\n\nDone")
+
+        val video = blocks.filterIsInstance<MarkdownVideoBlock>().single()
+        assertEquals(path, video.url)
+        assertTrue(blocks.filterIsInstance<MarkdownImageBlock>().isEmpty())
+        assertFalse(
+            blocks.filterIsInstance<MarkdownTextBlock>()
+                .any { it.plainText.contains("MEDIA:") },
+        )
+    }
+
+    @Test
+    fun videoMediaDirectiveCoversCaseInsensitivePreviewExtensions() {
+        for (path in listOf("/a/clip.MP4", "/a/clip.webm", "/a/clip.mov", "/a/clip.m4v", "/a/clip.mkv")) {
+            val blocks = parseMessageMarkdown("MEDIA:$path")
+            assertEquals(path, blocks.filterIsInstance<MarkdownVideoBlock>().single().url)
+        }
+    }
+
+    @Test
+    fun nonMediaManagedFileStaysPlainTextInsteadOfVideoBlock() {
+        val blocks = parseMessageMarkdown("MEDIA:/workspace/report.pdf")
+
+        assertTrue(blocks.filterIsInstance<MarkdownVideoBlock>().isEmpty())
+        assertTrue(blocks.filterIsInstance<MarkdownImageBlock>().isEmpty())
+        assertTrue(blocks.filterIsInstance<MarkdownTextBlock>().isNotEmpty())
+    }
+
+    @Test
     fun compactsEmbeddedImagePayloadAndHidesServerAttachmentPath() {
         val source = buildString {
             appendLine("before")

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImageTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImageTest.kt
@@ -99,6 +99,15 @@ class RemoteMediaImageTest {
     }
 
     @Test
+    fun acceptsVideoHostPathsButRejectsNonVideoAndMalformedPaths() {
+        assertTrue(validateGatewayVideoPath("/workspace/scene-00/preview.mp4"))
+        assertTrue(validateGatewayVideoPath("/workspace/scene-00/preview.WEBM"))
+        assertFalse(validateGatewayVideoPath("relative/preview.mp4"))
+        assertFalse(validateGatewayVideoPath("/workspace/scene-00/generated.jpg"))
+        assertFalse(validateGatewayVideoPath("/workspace/scene-00/no-extension"))
+    }
+
+    @Test
     fun oversizedImageBodyIsRejectedBeforeDecode() = runTest {
         val client = HttpClient(MockEngine {
             respond(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ datastore = "1.2.1"
 junit = "4.13.2"
 kotlin = "2.4.10"
 ktor = "3.5.2"
+media3 = "1.8.0"
 nav3Core = "1.1.5"
 robolectric = "4.16.1"
 screenshot = "0.0.1-alpha16"
@@ -61,6 +62,8 @@ screenshot-validation-api = { module = "com.android.tools.screenshot:screenshot-
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3Core" }
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNav3" }
+androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
+androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
## Problem

When the assistant sends a video (e.g. a generated preview clip) as a `MEDIA:` directive, the Android client renders it as raw text. Images have a complete pipeline — directive parsing, authenticated download, zoomable viewer — but there is nothing analogous for video, and the artifact model has no video category, so videos land in the artifact browser as generic "File" entries.

## What this does

- `MEDIA:` lines pointing at an absolute managed path with a video extension (`.mp4`, `.webm`, `.mov`, `.m4v`, `.mkv`) now parse into a video block and render an inline player — in assistant/user bubbles, expanded tool messages, and the artifact browser. `ArtifactExtractor` classifies these sources and explicit `video:` labels as a new `ArtifactType.Video`.
- Downloads go through a new `streamManagedVideoToFile` client call on the same official `/api/files/download` endpoint. It requires a `video/*` response, streams the body to disk with a 256 MB cap (never buffered in memory), and lands the file via a `.part` rename so a failed or oversized download never leaves a half-written video behind.
- Files are cached in a per-origin directory keyed by a SHA-256 of the server path, so entries from different servers never mix, repeat views don't re-fetch, and a 512 MB per-origin budget evicts the oldest entries.
- Playback is media3 ExoPlayer fed from the cached file only — the bearer token never reaches the player. A tap downloads and starts playback in one step, and a fullscreen dialog hands the active player over via `PlayerView.switchTargetView`. After the first download, a first-frame poster is extracted and shown as the preview (with the video's real aspect ratio) on subsequent views.

## Deliberate scope cuts

- Remote `https://` video URLs are classified as `Video` in the artifact browser (with the existing Open link) but do not get an inline player yet: streaming them with the same SSRF guards as images needs its own pass.
- Inline `data:video/...` payloads in message text remain collapsed to the existing hidden placeholder; handling those would mean background-downloading large blobs just from scrolling a transcript.

## Testing

New unit tests cover the markdown parsing, path validation, artifact classification, the download contract (endpoint, bearer auth, content-type gate, declared and streamed size caps, no partial files left behind), and cache scoping/pruning. `testDebugUnitTest`, `lintDebug`, and `assembleDebug` all pass locally, aside from the `NativeOAuthTest` loopback failures that already happen on a clean checkout of this machine. Playback was verified on a device against Hermes-generated mp4 previews.