### PR TITLE
ci: pin vendored relay vectors to the public mercury-relay-plugin release

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      - name: Check vendored relay vectors against the public plugin release
+        run: tools/check-relay-vectors.sh
+
       - name: Verify fake Hermes contract rig
         shell: bash
         run: |

--- a/ios/README.md
+++ b/ios/README.md
@@ -15,9 +15,11 @@ Hermes JSON-RPC session contract — Hermes itself is unchanged — and relay
 pairings, keys, and state live fully apart from direct-mode servers and
 credentials. Relay protocol, framing, Noise state, and target validation are
 implemented once in `shared/mercury-core`; iOS keeps Keychain, URLSession, and
-SwiftUI integration native. The protocol contract and canonical
-interop vectors live in the private `mercury-relay` repository; the vectors are
-vendored under `MercuryTests/Fixtures/RelayProtocol/`.
+SwiftUI integration native. The host plugin, protocol contract, and canonical
+interop vectors are open source at
+<https://github.com/unsupportedpastels/mercury-relay-plugin>; the vectors are
+vendored under `MercuryTests/Fixtures/RelayProtocol/` and
+`tools/check-relay-vectors.sh` fails CI if they drift from the pinned release.
 
 Product boundary and protocol contracts are shared with the Android client and
 documented in [`../AGENTS.md`](../AGENTS.md) plus the repo's project-local skills.

--- a/tools/check-relay-vectors.sh
+++ b/tools/check-relay-vectors.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Fail if the vendored Mercury Relay protocol vectors drift from the pinned
+# public plugin release. Both ends of the encrypted channel test against the
+# same bytes, so a mismatch here means the phone and host no longer agree.
+set -euo pipefail
+RELAY_PLUGIN_REF="${RELAY_PLUGIN_REF:-v0.1.0}"
+BASE="https://raw.githubusercontent.com/unsupportedpastels/mercury-relay-plugin/${RELAY_PLUGIN_REF}/protocol/vectors"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCAL_DIR="$ROOT/ios/MercuryTests/Fixtures/RelayProtocol"
+status=0
+for pair in "frames/corpus.json:frames-corpus.json" "secure-channel/corpus.json:secure-channel-corpus.json"; do
+  remote="${pair%%:*}"; local_name="${pair##*:}"
+  expected=$(curl -fsSL "$BASE/$remote" | sha256sum | cut -d' ' -f1)
+  actual=$(sha256sum "$LOCAL_DIR/$local_name" | cut -d' ' -f1)
+  if [[ "$expected" == "$actual" ]]; then
+    echo "ok       $local_name matches mercury-relay-plugin@$RELAY_PLUGIN_REF"
+  else
+    echo "MISMATCH $local_name differs from mercury-relay-plugin@$RELAY_PLUGIN_REF" >&2
+    status=1
+  fi
+done
+exit $status


### PR DESCRIPTION
The Mercury Relay host plugin and its canonical protocol vectors are now open source at https://github.com/unsupportedpastels/mercury-relay-plugin (tag `v0.1.0`).

- Adds `tools/check-relay-vectors.sh`, which fails if the vendored iOS relay vectors differ byte for byte from the pinned plugin release. Bump `RELAY_PLUGIN_REF` in the script when adopting a new release.
- Runs the check as the first CI step.
- Points the iOS README at the public repository instead of a private one.

Verified locally: both vendored corpora match `mercury-relay-plugin@v0.1.0`.