### PR TITLE
Relay multi-session, Phase 0-4 alignment, device names and failure messaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,43 @@
 
 ## Product boundary
 
-This is a native Android client for the official interfaces of an unchanged shared `hermes serve` process. Direct mode must never add, require, or assume custom server routes, forks, dashboard extensions, or gateway workers, and must keep working with no Mercury plugin installed.
+Mercury is a native Android and iOS client for the official interfaces of an unchanged shared `hermes serve` process. Direct mode must never add, require, or assume custom server routes, forks, dashboard extensions, or gateway workers, and must keep working with no Mercury plugin installed.
 
 One scoped exception exists: **Mercury Relay** is an optional, separately paired transport (iOS first) that carries the same official Hermes JSON-RPC session contract end-to-end encrypted through the Mercury Relay host plugin and an opaque hosted router. Relay code must stay isolated from direct-mode connection, credential, and catalog state; it never changes Hermes itself, tunnels no private Hermes route, and is never a requirement for any direct-mode feature.
 
 Released Hermes compatibility is conservative: observe durable/live metadata without implicit transport takeover. Resume or activate another remote connected client's runtime only after explicit user action. Never close a shared runtime merely because this client disconnects. Capability-gate multi-subscriber streaming until a safe released transport advertises it.
+
+## Cross-platform rule
+
+Mercury ships the same product on Android (`app/`) and iOS (`ios/`) over one
+shared Kotlin Multiplatform core (`shared/mercury-core`). Every change is a
+cross-platform change until proven otherwise:
+
+- **Shared by design.** Protocol decoding, transcript reduction, origin and
+  attachment policy, notification text, slash-command policy, relay framing,
+  and any other deterministic client decision live in `shared/mercury-core`
+  and are consumed by both apps. Fix a bug there once; never patch the same
+  decision separately in Kotlin and Swift. If a decision is duplicated today,
+  the fix is to move it into the core, not to change both copies.
+- **Native by design.** Compose/Material 3 on Android and SwiftUI on iOS own
+  UI, navigation, adaptive layout, accessibility, ViewModels and observable
+  state, credential storage, browser auth presentation, notifications, Live
+  Activities, share extensions, pickers, voice, and process lifecycle. Do not
+  build a shared UI layer or make one platform imitate the other's controls.
+  Share destinations, hierarchy, content ordering, and the palette; keep the
+  chrome native.
+- **Replicate behavior, not code.** When a change lands in one app's native
+  layer (a screen, a flow, a fix in a ViewModel or controller), the same
+  user-visible behavior must land in the other app in the same PR, or the PR
+  must say explicitly which platform is deferred and why. Check the sibling
+  path before finishing: `app/src/main/java/.../ui` ↔ `ios/Mercury/Views`,
+  `connection/` ↔ `MercuryKit/AppFlow`, `gateway/` ↔ `MercuryKit/Chat`.
+- **Tests travel with the behavior.** A shared-core change ships with a
+  common test; a platform change ships with the matching test on each
+  platform it touches. Both gates below must be green before merge.
+- **Mercury Relay availability differs.** Relay features on either platform
+  are limited to what the paired transport advertises; never add relay
+  contracts or direct-mode dependencies to reach UI parity.
 
 ## Android architecture
 
@@ -51,6 +83,12 @@ or iOS changes still require the Mac/Xcode gate — a green Linux build does not
 prove the generated framework is usable from Swift.
 
 For adaptive UI changes, also run the configured screenshot/UI test gates and test compact, medium, and expanded windows. Do not update screenshot references without visual review.
+
+Required gates for changed iOS code (run on a Mac with Xcode; see `ios/README.md`):
+
+```bash
+cd ios && xcodegen generate && xcodebuild -project Mercury.xcodeproj -scheme Mercury -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build test
+```
 
 ## Official project-local skills
 

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
@@ -91,6 +91,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        com.unsupportedpastels.hermesandroid.relay.RelayDeviceIdentity.initialize(applicationContext)
         consumeIncomingShare(intent)
         enableEdgeToEdge()
         window.isNavigationBarContrastEnforced = false

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -23,6 +23,7 @@ import com.unsupportedpastels.hermesandroid.app.validProjectWorkspacePath
 import com.unsupportedpastels.mercury.core.attachment.AttachmentAddResult
 import com.unsupportedpastels.mercury.core.notifications.NotificationTextPolicy
 import com.unsupportedpastels.mercury.core.transcript.InterruptSentinel
+import com.unsupportedpastels.mercury.core.relay.RelayAdmissionEnvelope
 import com.unsupportedpastels.mercury.core.relay.RelayPairedTarget
 import com.unsupportedpastels.mercury.core.relay.RelayTargetStatus
 import com.unsupportedpastels.hermesandroid.attachment.AttachmentByteReader
@@ -317,7 +318,13 @@ class HermesConnectionViewModel(
     private val refreshClient: NativeRefreshClient? = null,
     private val chatConnector: HermesChatConnector? = null,
     private val projectConnector: HermesChatConnector? = null,
-    private val relaySessionFactory: (suspend (RelayPairedTarget, String) -> HermesChatSession)? = null,
+    /**
+     * Opens one admitted relay controller. The third argument is the lease
+     * channel: null borrows the device's default channel (reads and metadata,
+     * superseded by the next default open); chats pass a per-session channel
+     * so several sessions stay open on one phone at once.
+     */
+    private val relaySessionFactory: (suspend (RelayPairedTarget, String, String?) -> HermesChatSession)? = null,
     private val cacheRepository: OfflineCacheRepository? = null,
     private val nowEpochSeconds: () -> Long = { System.currentTimeMillis() / 1_000L },
     private val attachmentReader: AttachmentByteReader =
@@ -655,7 +662,7 @@ class HermesConnectionViewModel(
                 relayConnectionLock.lock()
                 admissionLocked = true
                 if (generation != currentGeneration || activeRelayTarget?.id != target.id) return@launch
-                session = factory(target, boundedProfile)
+                session = factory(target, boundedProfile, null)
                 val profiles = try {
                     session.loadProfiles()
                 } catch (cancelled: CancellationException) {
@@ -723,7 +730,6 @@ class HermesConnectionViewModel(
     }
 
     private fun refreshRelaySessions(target: RelayPairedTarget): Job {
-        if (liveControllers.isNotEmpty()) return viewModelScope.launch { }
         val expectedGeneration = generation
         val factory = relaySessionFactory ?: return viewModelScope.launch { }
         return viewModelScope.launch {
@@ -732,7 +738,7 @@ class HermesConnectionViewModel(
             val borrowed = liveControllers.values.firstOrNull()?.session
             try {
                 if (generation != expectedGeneration || activeRelayTarget?.id != target.id) return@launch
-                session = borrowed ?: factory(target, mutableSnapshots.value.selectedProfile)
+                session = borrowed ?: factory(target, mutableSnapshots.value.selectedProfile, null)
                 val result = session.relayRequest(
                     "relay.sessions.list",
                     buildJsonObject {
@@ -3065,7 +3071,7 @@ class HermesConnectionViewModel(
         val expectedGeneration = generation
         if (activeRelayTarget?.id != target.id) throw CancellationException("Relay target changed")
         val borrowed = liveControllers.values.firstOrNull()?.session
-        val session = borrowed ?: relaySessionFactory?.invoke(target, profile)
+        val session = borrowed ?: relaySessionFactory?.invoke(target, profile, null)
             ?: throw HermesConnectionException("Mercury Relay chat is unavailable")
         try {
             currentCoroutineContext().ensureActive()
@@ -4660,26 +4666,10 @@ class HermesConnectionViewModel(
             )
             return existing
         }
+        // Relay: every session owns its own lease channel on the host, so other
+        // open sessions on this phone are never closed or blocked by this one.
         val relayTarget = activeRelayTarget
             ?.takeIf { activeOrigin == origin && generation == originGeneration }
-        if (relayTarget != null) {
-            // Pending metadata/attachment staging owns admission just like an active turn.
-            // Only genuinely idle controllers may be replaced by an explicit Send.
-            val others = liveControllers.values.filter { it.durableSessionId != durableSessionId }
-            if (others.any {
-                    val chat = mutableSnapshots.value.chatSessions[it.durableSessionId]
-                    chat?.isSending == true || chat?.connectionPhase == ChatConnectionPhase.Connecting ||
-                        chat?.connectionPhase == ChatConnectionPhase.Submitting
-                }) {
-                throw HermesConnectionException("Another Relay session is active. Wait for it to finish before sending here.")
-            }
-            for (other in others) {
-                other.eventJob?.cancel()
-                sessionControllerRegistry.replaceControllerForRecovery(other.durableSessionId, other.session)
-                removeActiveRuntime(other.runtimeSessionId)
-                closeChatSessionNonCancellably(other.session)
-            }
-        }
         val connector = chatConnector
         if (relayTarget == null && connector == null) {
             throw HermesConnectionException("Live chat is unavailable")
@@ -4691,6 +4681,7 @@ class HermesConnectionViewModel(
             relaySessionFactory?.invoke(
                 relayTarget,
                 localDraftSession(durableSessionId)?.profile ?: mutableSnapshots.value.selectedProfile,
+                RelayAdmissionEnvelope.channelForSession(durableSessionId.value),
             ) ?: throw HermesConnectionException("Mercury Relay chat is unavailable")
         } else {
             connector!!.connect(origin, accessToken)
@@ -5208,8 +5199,11 @@ class HermesConnectionViewModel(
                 }
                 if (!isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) return
                 candidate = if (relayTarget != null) {
-                    relaySessionFactory?.invoke(relayTarget, mutableSnapshots.value.selectedProfile)
-                        ?: throw HermesConnectionException("Mercury Relay chat is unavailable")
+                    relaySessionFactory?.invoke(
+                        relayTarget,
+                        mutableSnapshots.value.selectedProfile,
+                        RelayAdmissionEnvelope.channelForSession(durableSessionId.value),
+                    ) ?: throw HermesConnectionException("Mercury Relay chat is unavailable")
                 } else {
                     connector!!.connect(origin, token)
                 }
@@ -6676,11 +6670,11 @@ class HermesConnectionViewModel(
             // Shared monotonic IDs fence late inner-controller RPC replies across
             // attachments; a random process prefix also fences Android relaunch.
             val relayRequestIds = java.util.concurrent.atomic.AtomicLong(java.security.SecureRandom().nextLong().ushr(12))
-            val relaySessionFactory: suspend (RelayPairedTarget, String) -> HermesChatSession = { target, profile ->
+            val relaySessionFactory: suspend (RelayPairedTarget, String, String?) -> HermesChatSession = { target, profile, channel ->
                 val checkpoint = synchronized(leaseCheckpoints) {
-                    val key = listOf(target.relayOrigin, target.id, target.deviceId, target.fingerprint, profile)
+                    val key = listOf(target.relayOrigin, target.id, target.deviceId, target.fingerprint, profile, channel.orEmpty())
                     leaseCheckpoints.getOrPut(key) {
-                        if (leaseCheckpoints.size >= 16) leaseCheckpoints.remove(leaseCheckpoints.keys.first())
+                        if (leaseCheckpoints.size >= 64) leaseCheckpoints.remove(leaseCheckpoints.keys.first())
                         RelayLeaseCheckpoint()
                     }
                 }
@@ -6690,6 +6684,7 @@ class HermesConnectionViewModel(
                     socketFactory = relaySocketFactory,
                     resumeCursor = checkpoint.cursor,
                     recoveryVersion = 1,
+                    leaseChannel = channel,
                 )
                 val socket = RelayLeaseRecoverySocket(RelayHermesChatSocket(connected), profile, checkpoint)
                 try {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -111,6 +111,8 @@ import com.unsupportedpastels.hermesandroid.session.evaluateBulkDeleteSelection
 import com.unsupportedpastels.hermesandroid.session.SessionListFilter
 import com.unsupportedpastels.hermesandroid.session.toggleBulkSelection
 import com.unsupportedpastels.hermesandroid.relay.TlsRelayBinarySocketFactory
+import com.unsupportedpastels.hermesandroid.relay.RelayConnectionException
+import com.unsupportedpastels.hermesandroid.relay.RelayConnectionFailure
 import com.unsupportedpastels.hermesandroid.relay.RelayConnector
 import com.unsupportedpastels.hermesandroid.relay.RelayHermesChatSocket
 import com.unsupportedpastels.hermesandroid.relay.RelayLeaseCheckpoint
@@ -701,14 +703,14 @@ class HermesConnectionViewModel(
                 )
             } catch (cancelled: CancellationException) {
                 throw cancelled
-            } catch (_: Exception) {
+            } catch (error: Exception) {
                 if (generation != currentGeneration || activeRelayTarget?.id != target.id) return@launch
                 mutableSnapshots.value = HermesGatewaySnapshot(
                     connectionState = ConnectionState.Disconnected,
                     authenticationState = AuthenticationState.Unknown,
                     relayTargetId = target.id,
                     relayTargetLabel = target.displayLabel,
-                    connectionError = "The relay or host is unreachable. Check that the host is online, then retry.",
+                    connectionError = relayConnectionErrorMessage(error),
                 )
             } finally {
                 try {
@@ -6666,6 +6668,7 @@ class HermesConnectionViewModel(
             val relayScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
             val relaySocketFactory = TlsRelayBinarySocketFactory()
             val relayNetwork = com.unsupportedpastels.hermesandroid.relay.RelayNetworkAvailability(context)
+            val relayTargetStore = com.unsupportedpastels.hermesandroid.relay.EncryptedRelayTargetStore(context)
             val leaseCheckpoints = mutableMapOf<List<String>, RelayLeaseCheckpoint>()
             // Shared monotonic IDs fence late inner-controller RPC replies across
             // attachments; a random process prefix also fences Android relaunch.
@@ -6689,6 +6692,11 @@ class HermesConnectionViewModel(
                 val socket = RelayLeaseRecoverySocket(RelayHermesChatSocket(connected), profile, checkpoint)
                 try {
                     kotlinx.coroutines.withTimeout(15_000L) { socket.initialize() }
+                    // The host renews the router token on every attach; keep the
+                    // pairing current so it never ages out and needs a re-pair.
+                    socket.snapshot?.routingToken?.takeIf { it != target.relayRoutingToken }?.let { renewed ->
+                        relayScope.launch { runCatching { relayTargetStore.updateRoutingToken(target.id, renewed) } }
+                    }
                     HermesChatConnection(socket, HERMES_CHAT_MAX_FRAME_BYTES, relayScope, relayRequestIds)
                 } catch (error: Throwable) {
                     withContext(NonCancellable) { socket.close() }
@@ -6810,4 +6818,18 @@ private fun JsonObject.transcriptToolText(): String? {
         .joinToString(" · ")
         .takeIf(String::isNotEmpty)
         ?.take(HERMES_CHAT_MAX_MESSAGE_TEXT_CHARS)
+}
+
+/** User-facing relay failure text, distinct per cause (iOS ConnectionController parity). */
+internal fun relayConnectionErrorMessage(error: Throwable): String {
+    val failure = generateSequence(error) { it.cause }.filterIsInstance<RelayConnectionException>().firstOrNull()?.failure
+    return when (failure) {
+        RelayConnectionFailure.RoutingRejected ->
+            "The relay refused this phone's pairing token. Remove this relay and pair again from your host's Mercury Relay page."
+        RelayConnectionFailure.NoHost ->
+            "Your Hermes host isn't connected to the relay. Start Hermes on the host, then retry."
+        RelayConnectionFailure.NotAuthorized ->
+            "The host hasn't approved this device, or it was revoked. Approve it on the host, then retry."
+        else -> "The relay or host is unreachable. Check that the host is online, then retry."
+    }
 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/ServerCatalog.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/ServerCatalog.kt
@@ -25,8 +25,11 @@ data class ServerCatalogEntry(
         }
     }
 
+    /** A user label wins; otherwise the hostname alone (shared display decision). */
     val displayLabel: String
-        get() = label.ifBlank { origin.value }
+        get() = label.ifBlank {
+            com.unsupportedpastels.mercury.core.origin.ServerOriginPolicy.displayHost(origin.value) ?: origin.value
+        }
 
     fun normalized(): ServerCatalogEntry = copy(label = label.trim())
 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayDeviceIdentity.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayDeviceIdentity.kt
@@ -1,0 +1,27 @@
+package com.unsupportedpastels.hermesandroid.relay
+
+import android.content.Context
+import android.os.Build
+import android.provider.Settings
+
+/**
+ * The name this phone reports to a relay host in its admission envelope, so
+ * the host's device list can show "Mark's Fold" instead of a fingerprint.
+ * The user's own device name wins; the model is the fallback.
+ */
+object RelayDeviceIdentity {
+    @Volatile
+    var name: String? = null
+        private set
+
+    fun initialize(context: Context) {
+        val userName = runCatching {
+            Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
+        }.getOrNull()?.trim().orEmpty()
+        val model = listOf(Build.MANUFACTURER, Build.MODEL)
+            .filter { !it.isNullOrBlank() }
+            .joinToString(" ")
+            .trim()
+        name = userName.ifEmpty { model }.ifEmpty { null }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayDiagnostics.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayDiagnostics.kt
@@ -355,8 +355,8 @@ internal suspend fun RelayBinarySocketFactory.connectRelaySocket(
 }
 
 internal fun RelayConnectionFailure.toDiagnosticReason(): RelayDiagnosticReason = when (this) {
-    RelayConnectionFailure.Offline -> RelayDiagnosticReason.Offline
-    RelayConnectionFailure.NotAuthorized -> RelayDiagnosticReason.NotAuthorized
+    RelayConnectionFailure.Offline, RelayConnectionFailure.NoHost -> RelayDiagnosticReason.Offline
+    RelayConnectionFailure.NotAuthorized, RelayConnectionFailure.RoutingRejected -> RelayDiagnosticReason.NotAuthorized
     RelayConnectionFailure.ProtocolViolation -> RelayDiagnosticReason.ProtocolViolation
 }
 
@@ -384,9 +384,10 @@ internal fun Exception.toOpenDiagnosticCategory(): RelayDiagnosticExceptionCateg
         is javax.net.ssl.SSLException -> RelayDiagnosticExceptionCategory.Tls
         is java.net.UnknownHostException -> RelayDiagnosticExceptionCategory.Dns
         is RelayConnectionException -> when (failure) {
-            RelayConnectionFailure.NotAuthorized -> RelayDiagnosticExceptionCategory.Authorization
+            RelayConnectionFailure.NotAuthorized, RelayConnectionFailure.RoutingRejected ->
+                RelayDiagnosticExceptionCategory.Authorization
             RelayConnectionFailure.ProtocolViolation -> RelayDiagnosticExceptionCategory.Protocol
-            RelayConnectionFailure.Offline -> RelayDiagnosticExceptionCategory.Connection
+            RelayConnectionFailure.Offline, RelayConnectionFailure.NoHost -> RelayDiagnosticExceptionCategory.Connection
         }
         is java.io.IOException -> RelayDiagnosticExceptionCategory.Connection
         else -> RelayDiagnosticExceptionCategory.Unknown

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayLeaseRecovery.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayLeaseRecovery.kt
@@ -18,10 +18,12 @@ data class RelayLeaseSnapshot(
     val bindings: List<RelayLeaseBinding>,
     val tasks: List<JsonObject>,
     val truncated: Boolean,
+    /** Renewed router token from the authenticated attach preamble, if the host sent one. */
+    val routingToken: String? = null,
 ) {
     fun hasLiveBinding(durableId: String, profile: String): Boolean = shared().hasLiveBinding(durableId, profile)
     internal fun shared() = com.unsupportedpastels.mercury.core.relay.RelayLeaseSnapshot(
-        leaseId, lastSeq, gap, reset, bindings, tasks.map { it.toString() }, truncated)
+        leaseId, lastSeq, gap, reset, bindings, tasks.map { it.toString() }, truncated, routingToken)
 }
 
 /** Native synchronization, shared immutable checkpoint decisions. Never persist this state. */
@@ -51,7 +53,8 @@ class RelayLeaseRecoverySocket(
         synchronized(this) {
             val shared = protocol { engine.initialize(raw) }
             snapshot = RelayLeaseSnapshot(shared.leaseId, shared.lastSeq, shared.gap, shared.reset,
-                shared.bindings, shared.tasks.map { Json.parseToJsonElement(it).jsonObject }, shared.truncated)
+                shared.bindings, shared.tasks.map { Json.parseToJsonElement(it).jsonObject }, shared.truncated,
+                shared.routingToken)
             checkpoint.bind(owner, shared.leaseId)
         }
     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayTargetStore.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayTargetStore.kt
@@ -33,6 +33,8 @@ interface RelayTargetRepository {
     suspend fun markApproved(id: String, nowEpochSeconds: Long)
     suspend fun touch(id: String, nowEpochSeconds: Long)
     suspend fun updateLabel(id: String, label: String)
+    /** Stores a router token renewed by the host over the authenticated channel. */
+    suspend fun updateRoutingToken(id: String, token: String) {}
     suspend fun remove(id: String)
 }
 
@@ -77,6 +79,10 @@ class EncryptedRelayTargetStore(
             fail(RelayTargetStoreFailure.InvalidLabel)
         }
         mutate(id) { target -> target.copy(label = trimmed) }
+    }
+
+    override suspend fun updateRoutingToken(id: String, token: String) {
+        mutate(id) { target -> target.copy(relayRoutingToken = token) }
     }
 
     override suspend fun remove(id: String) = withContext(ioDispatcher) {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayTransport.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayTransport.kt
@@ -27,7 +27,12 @@ interface RelayBinarySocket {
     suspend fun send(data: ByteArray)
     suspend fun receive(): ByteArray?
     suspend fun close()
+    /** Router/host WebSocket close code seen on this socket, when known. */
+    fun lastCloseCode(): Int? = null
 }
+
+/** Router close code: no Hermes host is attached to this installation. */
+const val RELAY_CLOSE_NO_HOST = 4004
 
 fun interface RelayBinarySocketFactory {
     suspend fun connect(url: String, routingToken: String?): RelayBinarySocket
@@ -35,8 +40,13 @@ fun interface RelayBinarySocketFactory {
 
 enum class RelayConnectionFailure {
     Offline,
+    /** The host closed the channel: this device is pending, denied, or revoked. */
     NotAuthorized,
     ProtocolViolation,
+    /** The router refused the socket: the pairing's routing token is missing, expired, or invalid. */
+    RoutingRejected,
+    /** The router accepted the socket but no Hermes host is attached right now. */
+    NoHost,
 }
 
 class RelayConnectionException(
@@ -100,7 +110,10 @@ object RelayConnector {
             val admitted = withTimeoutOrNull(RELAY_NOISE_NEGOTIATION_TIMEOUT_MILLIS) {
                 socket.send(createdChannel.writeHandshake())
                 val second = socket.receive()
-                    ?: throw RelayConnectionException(RelayConnectionFailure.NotAuthorized)
+                    ?: throw RelayConnectionException(
+                        if (socket.lastCloseCode() == RELAY_CLOSE_NO_HOST) RelayConnectionFailure.NoHost
+                        else RelayConnectionFailure.NotAuthorized,
+                    )
                 createdChannel.readHandshake(second)
                 attempt.recordSuccess(RelayDiagnosticPhase.Handshake)
                 phase = RelayDiagnosticPhase.Admission

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayTransport.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayTransport.kt
@@ -60,6 +60,8 @@ object RelayConnector {
         recoveryVersion: Int? = null,
         deterministicEphemeralPrivateKey: ByteArray? = null,
         diagnostics: RelayDiagnostics = RelayDiagnostics.shared,
+        /** Lease channel; null is the legacy default channel (one lease per device). */
+        leaseChannel: String? = null,
     ): RelayConnectedChannel {
         val attempt = diagnostics.beginAttempt(RelayDiagnosticOperation.Connection)
         val url = RelayPairingPayload.deviceSocketUrl(target.relayOrigin, target.installationId)
@@ -104,7 +106,7 @@ object RelayConnector {
                 phase = RelayDiagnosticPhase.Admission
                 socket.send(createdChannel.writeHandshake())
                 val envelope = RelayAdmissionEnvelope.controllerOpen(
-                    target.deviceId, profile, resumeCursor, recoveryVersion,
+                    target.deviceId, profile, resumeCursor, recoveryVersion, leaseChannel,
                 )
                 socket.send(createdChannel.encrypt(envelope))
                 attempt.recordSuccess(RelayDiagnosticPhase.Admission)

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayTransport.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayTransport.kt
@@ -120,6 +120,7 @@ object RelayConnector {
                 socket.send(createdChannel.writeHandshake())
                 val envelope = RelayAdmissionEnvelope.controllerOpen(
                     target.deviceId, profile, resumeCursor, recoveryVersion, leaseChannel,
+                    RelayDeviceIdentity.name,
                 )
                 socket.send(createdChannel.encrypt(envelope))
                 attempt.recordSuccess(RelayDiagnosticPhase.Admission)

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/TlsRelayBinarySocket.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/TlsRelayBinarySocket.kt
@@ -128,7 +128,7 @@ class TlsRelayBinarySocketFactory(
     private fun validateHandshake(input: InputStream, key: String) {
         val status = input.readAsciiLine() ?: fail(RelayConnectionFailure.Offline)
         val statusCode = status.split(' ').getOrNull(1)?.toIntOrNull()
-        if (statusCode == 401 || statusCode == 403) fail(RelayConnectionFailure.NotAuthorized)
+        if (statusCode == 401 || statusCode == 403) fail(RelayConnectionFailure.RoutingRejected)
         if (statusCode != 101) fail(RelayConnectionFailure.Offline)
         val headers = LinkedHashMap<String, String>()
         repeat(MAX_RELAY_HANDSHAKE_HEADERS) {
@@ -182,6 +182,9 @@ private class TlsRelayBinarySocket(
     private val sendMutex = Mutex()
     private val receiveMutex = Mutex()
     private val closed = AtomicBoolean(false)
+    @Volatile private var closeCode: Int? = null
+
+    override fun lastCloseCode(): Int? = closeCode
 
     override suspend fun send(data: ByteArray) {
         if (data.size > MAX_RELAY_WEBSOCKET_MESSAGE_BYTES) fail(RelayConnectionFailure.ProtocolViolation)
@@ -206,6 +209,9 @@ private class TlsRelayBinarySocket(
                     fragmented = payload
                 }
                 0x8 -> {
+                    if (payload.size >= 2) {
+                        closeCode = ((payload[0].toInt() and 0xff) shl 8) or (payload[1].toInt() and 0xff)
+                    }
                     closeImmediately()
                     return@withLock null
                 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesCloudConnectPanel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesCloudConnectPanel.kt
@@ -153,14 +153,14 @@ internal fun HermesCloudConnectPanel(
                         val connectable = agent.isConnectable
                         ListItem(
                             headlineContent = {
-                                Text(agent.name, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                                Text(cloudAgentDisplayLabel(agent), maxLines = 1, overflow = TextOverflow.Ellipsis)
                             },
                             supportingContent = {
                                 Text(
                                     if (connectable) {
-                                        agent.dashboardUrl.orEmpty()
+                                        agent.name
                                     } else {
-                                        "${agent.status.lowercase()} · provisioning…"
+                                        "${agent.name} · ${agent.status.lowercase()} · provisioning…"
                                     },
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
@@ -218,3 +218,12 @@ internal fun rememberConnectMode(initialCloud: Boolean): androidx.compose.runtim
         mutableStateOf(if (initialCloud) ConnectMode.Cloud else ConnectMode.ServerUrl)
     }
 }
+
+/**
+ * Cloud agents are labelled by the hostname of their dashboard, like server
+ * rows, and fall back to the agent name while provisioning (no dashboard yet).
+ */
+internal fun cloudAgentDisplayLabel(agent: CloudAgent): String =
+    agent.dashboardUrl
+        ?.let { com.unsupportedpastels.mercury.core.origin.ServerOriginPolicy.displayHost(it) }
+        ?: agent.name

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetail.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetail.kt
@@ -718,6 +718,25 @@ internal fun SessionDetailScreen(
                                 )
                                 return@items
                             }
+                            if (entry is TranscriptEntry.WorkBurst) {
+                                var burstExpanded by rememberSaveable(
+                                    session.id.value,
+                                    transcriptEntryKey(entry, chat),
+                                ) {
+                                    mutableStateOf(false)
+                                }
+                                WorkBurstGroup(
+                                    reasoning = entry.reasoning,
+                                    tools = entry.tools,
+                                    expanded = burstExpanded,
+                                    onToggle = { burstExpanded = !burstExpanded },
+                                    sessionKey = session.id.value,
+                                    loadManagedImage = { path ->
+                                        onLoadManagedImage(path).getOrThrow()
+                                    },
+                                )
+                                return@items
+                            }
                             val messageIndex = (entry as TranscriptEntry.Single).index
                             val message = entry.message
                             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -2344,6 +2363,15 @@ internal sealed interface TranscriptEntry {
     data class Single(val index: Int, val message: ChatMessage) : TranscriptEntry
 
     data class ToolRun(val tools: List<IndexedChatMessage>) : TranscriptEntry
+
+    /**
+     * Consecutive reasoning-only assistant steps bundled with their tool runs
+     * into one compact, expandable activity line (iOS WorkBurstView parity).
+     */
+    data class WorkBurst(
+        val reasoning: List<IndexedChatMessage>,
+        val tools: List<IndexedChatMessage>,
+    ) : TranscriptEntry
 }
 
 /** Retained reducer IDs survive streaming and removal of earlier rows. */
@@ -2351,35 +2379,47 @@ internal fun transcriptEntryKey(entry: TranscriptEntry, chat: ChatSessionSnapsho
     val index = when (entry) {
         is TranscriptEntry.Single -> entry.index
         is TranscriptEntry.ToolRun -> entry.tools.first().index
+        is TranscriptEntry.WorkBurst -> entry.reasoning.first().index
     }
     val presentation = chat.transcriptPresentation?.takeIf { it.messages === chat.messages }
     val identity = presentation?.state?.rows?.getOrNull(index)?.id?.let { "row:$it" } ?: "index:$index"
-    return if (entry is TranscriptEntry.ToolRun) "tool-run:$identity" else "message:$identity"
+    return when (entry) {
+        is TranscriptEntry.ToolRun -> "tool-run:$identity"
+        is TranscriptEntry.WorkBurst -> "work-burst:$identity"
+        is TranscriptEntry.Single -> "message:$identity"
+    }
 }
 
 /**
- * Fold a flat transcript into renderable entries, coalescing every maximal run
- * of adjacent `Tool` messages into a single [TranscriptEntry.ToolRun]. Original
- * message indices are preserved so per-message expansion state stays stable.
+ * Fold a flat transcript into renderable entries using the shared engine's
+ * grouping decision (`coalesceTranscriptEntries` in mercury-core): adjacent
+ * tool messages collapse into one [TranscriptEntry.ToolRun], and reasoning-only
+ * assistant steps followed by tool runs collapse into one
+ * [TranscriptEntry.WorkBurst]. Original message indices are preserved so
+ * per-message expansion state stays stable.
  */
 internal fun coalesceTranscriptEntries(messages: List<ChatMessage>): List<TranscriptEntry> {
-    val entries = mutableListOf<TranscriptEntry>()
-    var run: MutableList<IndexedChatMessage>? = null
-    fun flush() {
-        run?.let { entries.add(TranscriptEntry.ToolRun(it.toList())) }
-        run = null
+    val rows = messages.mapIndexed { index, message ->
+        com.unsupportedpastels.mercury.core.transcript.TranscriptRow(
+            id = index.toLong(),
+            role = message.role.name.lowercase(),
+            text = message.text,
+            completed = !message.isStreaming,
+            reasoningText = message.reasoningText,
+        )
     }
-    messages.forEachIndexed { index, message ->
-        if (message.role == ChatMessageRole.Tool) {
-            (run ?: mutableListOf<IndexedChatMessage>().also { run = it })
-                .add(IndexedChatMessage(index, message))
-        } else {
-            flush()
-            entries.add(TranscriptEntry.Single(index, message))
+    fun indexed(row: com.unsupportedpastels.mercury.core.transcript.TranscriptRow) =
+        IndexedChatMessage(row.id.toInt(), messages[row.id.toInt()])
+    return com.unsupportedpastels.mercury.core.transcript.coalesceTranscriptEntries(rows).map { entry ->
+        when (entry) {
+            is com.unsupportedpastels.mercury.core.transcript.TranscriptEntry.Message ->
+                TranscriptEntry.Single(entry.row.id.toInt(), messages[entry.row.id.toInt()])
+            is com.unsupportedpastels.mercury.core.transcript.TranscriptEntry.ToolRun ->
+                TranscriptEntry.ToolRun(entry.rows.map(::indexed))
+            is com.unsupportedpastels.mercury.core.transcript.TranscriptEntry.WorkBurst ->
+                TranscriptEntry.WorkBurst(entry.reasoning.map(::indexed), entry.tools.map(::indexed))
         }
     }
-    flush()
-    return entries
 }
 
 /**
@@ -2682,6 +2722,94 @@ private fun TranscriptToolRunGroup(
                             loadManagedImage = loadManagedImage,
                         )
                     }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * One collapsed work burst (iOS WorkBurstView parity): consecutive reasoning
+ * steps bundled with their tool runs into a single compact activity line.
+ * Expanding reveals each thinking block and tool result in original order.
+ */
+@Composable
+private fun WorkBurstGroup(
+    reasoning: List<IndexedChatMessage>,
+    tools: List<IndexedChatMessage>,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    sessionKey: String,
+    loadManagedImage: (suspend (String) -> ByteArray)? = null,
+) {
+    val stepCount = reasoning.size + tools.size
+    val noun = if (stepCount == 1) "step" else "steps"
+    val working = reasoning.any { it.message.isStreaming }
+    val summary = "${if (working) "Working" else "Activity"} · $stepCount $noun"
+    Surface(
+        onClick = onToggle,
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription = "$summary, ${if (expanded) "expanded" else "collapsed"}"
+                stateDescription = if (expanded) "Expanded" else "Collapsed"
+            },
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    Icons.Outlined.Psychology,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    summary,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Icon(
+                    if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (expanded) {
+                reasoning.forEach { indexed ->
+                    key(indexed.index) {
+                        var showReasoning by rememberSaveable(sessionKey, indexed.index) {
+                            mutableStateOf(false)
+                        }
+                        ThinkingBlock(
+                            reasoning = indexed.message.reasoningText,
+                            streaming = indexed.message.isStreaming,
+                            expanded = showReasoning,
+                            onToggle = { showReasoning = !showReasoning },
+                        )
+                    }
+                }
+                if (tools.isNotEmpty()) {
+                    var toolsExpanded by rememberSaveable(sessionKey, tools.first().index) {
+                        mutableStateOf(false)
+                    }
+                    TranscriptToolRunGroup(
+                        tools = tools,
+                        expanded = toolsExpanded,
+                        onToggle = { toolsExpanded = !toolsExpanded },
+                        sessionKey = sessionKey,
+                        loadManagedImage = loadManagedImage,
+                    )
                 }
             }
         }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/RelayConnectionErrorMessageTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/RelayConnectionErrorMessageTest.kt
@@ -1,0 +1,24 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import com.unsupportedpastels.hermesandroid.relay.RelayConnectionException
+import com.unsupportedpastels.hermesandroid.relay.RelayConnectionFailure
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Each relay failure cause gets its own actionable message (iOS parity). */
+class RelayConnectionErrorMessageTest {
+    @Test
+    fun messagesAreDistinctPerCause() {
+        val rejected = relayConnectionErrorMessage(RelayConnectionException(RelayConnectionFailure.RoutingRejected))
+        val noHost = relayConnectionErrorMessage(RelayConnectionException(RelayConnectionFailure.NoHost))
+        val unapproved = relayConnectionErrorMessage(RelayConnectionException(RelayConnectionFailure.NotAuthorized))
+        val offline = relayConnectionErrorMessage(IllegalStateException("socket"))
+        assertTrue(rejected.contains("pair again"))
+        assertTrue(noHost.contains("isn't connected"))
+        assertTrue(unapproved.contains("approved"))
+        assertTrue(offline.contains("unreachable"))
+        assertTrue(setOf(rejected, noHost, unapproved, offline).size == 4)
+        // The cause is found through wrapping exceptions too.
+        assertTrue(relayConnectionErrorMessage(RuntimeException("wrapped", RelayConnectionException(RelayConnectionFailure.NoHost))).contains("isn't connected"))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayTest.kt
@@ -572,6 +572,42 @@ class HermesChatGatewayTest {
     }
 
     @Test
+    fun terminalErrorEventWithoutMessageStillReachesTheClientWithAFallback() = runTest {
+        val socket = ScriptedSocket()
+        socket.onSend = { frame ->
+            val request = Json.parseToJsonElement(frame).jsonObject
+            if (request["method"]?.jsonPrimitive?.content == "prompt.submit") {
+                val id = request["id"]!!.jsonPrimitive.content
+                socket.offer("""{"jsonrpc":"2.0","method":"event","params":{"type":"error","session_id":"runtime-1","payload":{}}}""")
+                socket.offer("""{"jsonrpc":"2.0","method":"event","params":{"type":"error","session_id":"runtime-1","payload":{"message":null}}}""")
+                socket.offer("""{"jsonrpc":"2.0","method":"event","params":{"type":"error","session_id":"runtime-1","payload":{"message":"   "}}}""")
+                socket.offer("""{"jsonrpc":"2.0","method":"event","params":{"type":"error","session_id":"runtime-1","payload":{"message":"boom"}}}""")
+                socket.offer("""{"jsonrpc":"2.0","id":$id,"result":{"status":"streaming"}}""")
+            }
+        }
+        val connection = HermesChatGateway(
+            origin = ServerOrigin.parse("https://hermes.example"),
+            accessToken = "opaque-access",
+            ticketClient = RecordingTicketClient("ticket-1"),
+            socketFactory = RecordingSocketFactory(socket),
+            parentScope = backgroundScope,
+        ).connect()
+
+        connection.submitPrompt(RuntimeSessionId("runtime-1"), "hello")
+        val events = connection.events.take(4).toList()
+
+        val fallback = HermesChatEvent.Error(
+            RuntimeSessionId("runtime-1"),
+            com.unsupportedpastels.mercury.core.transcript.ChatEventDecoder.ERROR_MESSAGE_FALLBACK,
+        )
+        assertEquals(
+            listOf(fallback, fallback, fallback, HermesChatEvent.Error(RuntimeSessionId("runtime-1"), "boom")),
+            events,
+        )
+        connection.close()
+    }
+
+    @Test
     fun malformedFrameFailsPendingRequestInsteadOfLeavingItSuspended() = runTest {
         val ticketClient = RecordingTicketClient("ticket-1")
         val socket = ScriptedSocket()

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/relay/RelayConnectionViewModelTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/relay/RelayConnectionViewModelTest.kt
@@ -193,11 +193,15 @@ class RelayConnectionViewModelTest {
     }
 
     @Test
-    fun competingSendCannotEvictAttachmentStagingController() = pendingSendCannotBeEvicted(false)
+    fun competingSendOpensItsOwnChannelBesideAttachmentStagingController() = pendingSendCannotBeEvicted(false)
 
     @Test
-    fun competingSendCannotEvictConnectingControllerDuringMetadata() = pendingSendCannotBeEvicted(true)
+    fun competingSendOpensItsOwnChannelBesideConnectingControllerDuringMetadata() = pendingSendCannotBeEvicted(true)
 
+    /**
+     * A second session on the same phone never waits for, evicts, or closes
+     * the first: it opens its own lease channel and its send is accepted.
+     */
     private fun pendingSendCannotBeEvicted(connecting: Boolean) = runTest(dispatcher) {
         val sessions = mutableListOf<FakeRelaySession>()
         val viewModel = relayViewModel { FakeRelaySession().also { sessions += it } }
@@ -225,7 +229,9 @@ class RelayConnectionViewModelTest {
         val count = sessions.size
         viewModel.sendMessage(DurableSessionId("relay-session-2"), "competing").join()
         assertEquals("pending controller must not be closed", 0, controller.closeCalls)
-        assertEquals(count, sessions.size)
+        assertEquals("competing send opens its own channel", count + 1, sessions.size)
+        assertEquals("competing", sessions.last().lastSubmitted)
+        assertEquals(1L, viewModel.snapshots.value.chatSessions.getValue(DurableSessionId("relay-session-2")).acceptedSubmissionCount)
         barrier.complete(Unit)
         first.join()
         assertEquals(1, controller.submitCalls)
@@ -430,7 +436,7 @@ class RelayConnectionViewModelTest {
             override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo = error("no direct probe")
         },
         attachmentReader = com.unsupportedpastels.hermesandroid.attachment.AttachmentByteReader { "hello".toByteArray() },
-        relaySessionFactory = { _, _ -> factory() },
+        relaySessionFactory = { _, _, _ -> factory() },
     )
 
     @Test
@@ -441,7 +447,7 @@ class RelayConnectionViewModelTest {
             client = object : HermesConnectionClient {
                 override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo = error("no direct probe")
             },
-            relaySessionFactory = { _, _ -> session },
+            relaySessionFactory = { _, _, _ -> session },
         )
         advanceUntilIdle()
         viewModel.connectRelay(target()).join()
@@ -465,7 +471,7 @@ class RelayConnectionViewModelTest {
             client = object : HermesConnectionClient {
                 override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo = error("no direct probe")
             },
-            relaySessionFactory = { _, _ -> session },
+            relaySessionFactory = { _, _, _ -> session },
         )
         advanceUntilIdle()
         viewModel.connectRelay(target()).join()
@@ -499,7 +505,7 @@ class RelayConnectionViewModelTest {
             client = object : HermesConnectionClient {
                 override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo = error("no direct probe")
             },
-            relaySessionFactory = { _, _ -> FakeRelaySession().also { sessions += it } },
+            relaySessionFactory = { _, _, _ -> FakeRelaySession().also { sessions += it } },
         )
         advanceUntilIdle()
         viewModel.connectRelay(target()).join()
@@ -516,28 +522,38 @@ class RelayConnectionViewModelTest {
     }
 
     @Test
-    fun transcriptReaderDoesNotOpenASecondAdmittedRelaySocket() = runTest(dispatcher) {
+    fun readersBorrowTheAdmittedSocketAndSessionsGetTheirOwnChannels() = runTest(dispatcher) {
         val sessions = mutableListOf<FakeRelaySession>()
+        val channels = mutableListOf<String?>()
         val viewModel = HermesConnectionViewModel(
             settingsStates = MutableStateFlow(ServerSettingsState.Ready(ServerCatalog.empty())),
             client = object : HermesConnectionClient {
                 override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo = error("no direct probe")
             },
-            relaySessionFactory = { _, _ -> FakeRelaySession().also { sessions += it } },
+            relaySessionFactory = { _, _, channel -> channels += channel; FakeRelaySession().also { sessions += it } },
         )
         advanceUntilIdle()
         viewModel.connectRelay(target()).join()
         viewModel.openSession(DurableSessionId("relay-session-1")).join()
         val count = sessions.size
+        // Reads and metadata borrow the open controller instead of admitting again.
         viewModel.loadRecentSessions().join()
         viewModel.openProject(ProjectId("relay-project-1")).join()
-        viewModel.sendMessage(DurableSessionId("relay-session-1"), "active turn").join()
-        viewModel.openSession(DurableSessionId("relay-session-2")).join()
-        viewModel.sendMessage(DurableSessionId("relay-session-2"), "must not evict active turn").join()
         assertEquals(count, sessions.size)
-        assertEquals(0, sessions.last().closeCalls)
-        assertEquals("active turn", sessions.last().lastSubmitted)
-        assertEquals(true, viewModel.snapshots.value.chatSessions.getValue(DurableSessionId("relay-session-2")).error != null)
+        viewModel.sendMessage(DurableSessionId("relay-session-1"), "active turn").join()
+        val first = sessions.last()
+        // A second session opens its own lease channel and does not disturb the first.
+        viewModel.openSession(DurableSessionId("relay-session-2")).join()
+        viewModel.sendMessage(DurableSessionId("relay-session-2"), "second session").join()
+        assertEquals(count + 1, sessions.size)
+        assertEquals(0, first.closeCalls)
+        assertEquals("active turn", first.lastSubmitted)
+        assertEquals("second session", sessions.last().lastSubmitted)
+        assertEquals(null, viewModel.snapshots.value.chatSessions.getValue(DurableSessionId("relay-session-2")).error)
+        // Connect and reads use the default channel; each session its own.
+        assertEquals(null, channels.first())
+        assertEquals("s-relay-session-1", channels[channels.size - 2])
+        assertEquals("s-relay-session-2", channels.last())
     }
 
     @Test
@@ -549,7 +565,7 @@ class RelayConnectionViewModelTest {
             client = object : HermesConnectionClient {
                 override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo = error("no direct probe")
             },
-            relaySessionFactory = { _, _ ->
+            relaySessionFactory = { _, _, _ ->
                 connections += 1
                 if (connections == 3) blocked else FakeRelaySession()
             },
@@ -584,7 +600,7 @@ class RelayConnectionViewModelTest {
         val viewModel = HermesConnectionViewModel(
             settingsStates = settings,
             client = client,
-            relaySessionFactory = { _, _ -> FakeRelaySession() },
+            relaySessionFactory = { _, _, _ -> FakeRelaySession() },
         )
         advanceUntilIdle()
         viewModel.connectRelay(target()).join()
@@ -618,7 +634,7 @@ class RelayConnectionViewModelTest {
                     error("direct server offline")
                 }
             },
-            relaySessionFactory = { _, _ -> FakeRelaySession() },
+            relaySessionFactory = { _, _, _ -> FakeRelaySession() },
         )
         advanceUntilIdle()
         viewModel.connectRelay(target()).join()
@@ -644,7 +660,7 @@ class RelayConnectionViewModelTest {
                 override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo =
                     error("direct probe must not run")
             },
-            relaySessionFactory = { _, _ ->
+            relaySessionFactory = { _, _, _ ->
                 attempts += 1
                 if (attempts == 1) error("temporary relay failure")
                 FakeRelaySession()
@@ -674,7 +690,7 @@ class RelayConnectionViewModelTest {
         val viewModel = HermesConnectionViewModel(
             settingsStates = MutableStateFlow(ServerSettingsState.Ready(ServerCatalog.empty())),
             client = client,
-            relaySessionFactory = { _, _ -> relaySession },
+            relaySessionFactory = { _, _, _ -> relaySession },
         )
         advanceUntilIdle()
 
@@ -771,7 +787,7 @@ class RelayConnectionViewModelTest {
             client = object : HermesConnectionClient {
                 override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo = error("No direct HTTP")
             },
-            relaySessionFactory = { _, _ -> factories++; imageSession },
+            relaySessionFactory = { _, _, _ -> factories++; imageSession },
         )
         advanceUntilIdle()
         viewModel.connectRelay(target()).join()

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/relay/RelayTransportTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/relay/RelayTransportTest.kt
@@ -213,4 +213,27 @@ class RelayTransportTest {
         private val DEVICE_EPHEMERAL = ByteArray(32) { (it + 0x40).toByte() }
         private val HOST_EPHEMERAL = ByteArray(32) { (it + 0x60).toByte() }
     }
+
+    private class SilentlyClosingSocket(private val closeCode: Int?) : RelayBinarySocket {
+        override suspend fun send(data: ByteArray) = Unit
+        override suspend fun receive(): ByteArray? = null
+        override suspend fun close() = Unit
+        override fun lastCloseCode(): Int? = closeCode
+    }
+
+    /** The router's 4004 close means no host is attached; any other silent close is the host refusing us. */
+    @Test
+    fun silentCloseIsNoHostOnlyForTheRouterCloseCode() = runTest {
+        suspend fun failure(closeCode: Int?): RelayConnectionFailure? = runCatching {
+            RelayConnector.connect(
+                target = target(),
+                profile = "default",
+                socketFactory = RelayBinarySocketFactory { _, _ -> SilentlyClosingSocket(closeCode) },
+                diagnostics = RelayDiagnostics(capacity = 8, logger = {}),
+            )
+        }.exceptionOrNull().let { (it as? RelayConnectionException)?.failure }
+        assertEquals(RelayConnectionFailure.NoHost, failure(RELAY_CLOSE_NO_HOST))
+        assertEquals(RelayConnectionFailure.NotAuthorized, failure(null))
+        assertEquals(RelayConnectionFailure.NotAuthorized, failure(1000))
+    }
 }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/DisplayLabelTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/DisplayLabelTest.kt
@@ -1,0 +1,26 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import com.unsupportedpastels.hermesandroid.connection.CloudAgent
+import com.unsupportedpastels.hermesandroid.connection.ServerCatalogEntry
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Server and cloud-agent rows show hostnames unless the user set a label (iOS parity). */
+class DisplayLabelTest {
+    @Test
+    fun serverEntryShowsHostnameUnlessLabelled() {
+        val plain = ServerCatalogEntry(ServerOrigin.parse("https://hermes.example.com:8443"))
+        assertEquals("hermes.example.com", plain.displayLabel)
+        val labelled = ServerCatalogEntry(ServerOrigin.parse("https://hermes.example.com"), label = "Home box")
+        assertEquals("Home box", labelled.displayLabel)
+    }
+
+    @Test
+    fun cloudAgentShowsDashboardHostAndFallsBackToNameWhileProvisioning() {
+        val ready = CloudAgent("a", "Atlas", "active", "https://atlas.hermes.cloud/dashboard", "active")
+        assertEquals("atlas.hermes.cloud", cloudAgentDisplayLabel(ready))
+        val provisioning = CloudAgent("b", "Beacon", "provisioning", null, "unknown")
+        assertEquals("Beacon", cloudAgentDisplayLabel(provisioning))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/TranscriptToolGroupingTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/TranscriptToolGroupingTest.kt
@@ -64,4 +64,43 @@ class TranscriptToolGroupingTest {
         assertEquals("terminal", transcriptToolName("terminal · curl -fsSL https://example.com"))
         assertEquals("bare", transcriptToolName("bare"))
     }
+
+    /** iOS WorkBurstView parity, decided once in the shared engine. */
+    @Test
+    fun reasoningOnlyStepsAndTheirToolsCoalesceIntoAWorkBurst() {
+        val messages = listOf(
+            message(ChatMessageRole.User, "find the bug"),
+            ChatMessage(ChatMessageRole.Assistant, "", reasoningText = "let me look"),
+            message(ChatMessageRole.Tool, "read_file · Main.kt"),
+            message(ChatMessageRole.Tool, "grep · TODO"),
+            message(ChatMessageRole.Assistant, "Found it."),
+            message(ChatMessageRole.Tool, "patch · Main.kt"),
+        )
+
+        val entries = coalesceTranscriptEntries(messages)
+
+        assertEquals(4, entries.size)
+        assertEquals(TranscriptEntry.Single(0, messages[0]), entries[0])
+        assertEquals(
+            TranscriptEntry.WorkBurst(
+                reasoning = listOf(IndexedChatMessage(1, messages[1])),
+                tools = listOf(IndexedChatMessage(2, messages[2]), IndexedChatMessage(3, messages[3])),
+            ),
+            entries[1],
+        )
+        assertEquals(TranscriptEntry.Single(4, messages[4]), entries[2])
+        assertEquals(TranscriptEntry.ToolRun(listOf(IndexedChatMessage(5, messages[5]))), entries[3])
+    }
+
+    @Test
+    fun streamingReasoningOnlyStepIsStillAWorkBurst() {
+        val messages = listOf(
+            ChatMessage(ChatMessageRole.Assistant, "", isStreaming = true, reasoningText = "thinking"),
+        )
+        val entries = coalesceTranscriptEntries(messages)
+        assertEquals(
+            listOf(TranscriptEntry.WorkBurst(reasoning = listOf(IndexedChatMessage(0, messages[0])), tools = emptyList())),
+            entries,
+        )
+    }
 }

--- a/ios/Mercury/AppModel.swift
+++ b/ios/Mercury/AppModel.swift
@@ -35,6 +35,9 @@ final class AppModel {
     /// origin-scoped REST features guard on `serverOrigin` and quietly stand
     /// down because it stays nil.
     private(set) var activeRelayTarget: RelayPairedTarget?
+    /// The relay the user selected, kept across a failed or pending connect so
+    /// Settings can still disconnect from it and remove its pairing.
+    private(set) var selectedRelayTarget: RelayPairedTarget?
     private(set) var relaySelectionGeneration: UInt64 = 0
     private(set) var hermesVersion: String?
     var profiles: [String] = ["default"]
@@ -631,7 +634,7 @@ final class AppModel {
     /// (origin-scoped Keychain delete) and its host's cookies, then resets
     /// transient connection state. No-op when no server origin is set.
     func signOut() async {
-        if activeRelayTarget != nil {
+        if activeRelayTarget != nil || selectedRelayTarget != nil {
             // Relay "sign out" is a local disconnect. The pairing — and the
             // host-side authorization — stays until removed or revoked
             // explicitly from the pairing management surfaces.
@@ -972,6 +975,8 @@ final class AppModel {
     func disconnect() {
         endRelaySelection()
         activeRelayTarget = nil
+        selectedRelayTarget = nil
+        sessionsError = nil
         connectionPhase = .disconnected
     }
 
@@ -979,6 +984,7 @@ final class AppModel {
     /// the normal connected experience.
     func connectRelay(_ target: RelayPairedTarget) async {
         relaySelectionGeneration &+= 1
+        selectedRelayTarget = target
         await controller.connectRelay(target: target)
     }
 
@@ -999,6 +1005,7 @@ final class AppModel {
     func reset() {
         endRelaySelection()
         activeRelayTarget = nil
+        selectedRelayTarget = nil
         serverOrigin = nil
         hermesVersion = nil
         sessionsError = nil

--- a/ios/Mercury/MercuryApp.swift
+++ b/ios/Mercury/MercuryApp.swift
@@ -86,7 +86,6 @@ struct MercuryApp: App {
                 #endif
             }
                 .environment(appModel)
-                .preferredColorScheme(.dark)
                 .task {
                     #if DEBUG
                     if ProcessInfo.processInfo.arguments.contains("-uitest-background-tasks") { return }

--- a/ios/Mercury/MercuryKit/AppFlow/ConnectionController.swift
+++ b/ios/Mercury/MercuryKit/AppFlow/ConnectionController.swift
@@ -356,14 +356,7 @@ final class ConnectionController {
             "relay.sessions.list",
             params: ["profile": profile, "limit": limit, "offset": offset]
         )
-        guard let rawRows = result["sessions"] as? [[String: Any]] else {
-            return SessionPage(rows: [], total: 0, hasMore: false)
-        }
-        let data = try JSONSerialization.data(withJSONObject: rawRows)
-        let rows = (try? JSONDecoder().decode([SessionRow].self, from: data)) ?? []
-        let total = result["total"] as? Int
-        let hasMore = total.map { offset + rows.count < $0 } ?? (rows.count == limit)
-        return SessionPage(rows: rows, total: total, hasMore: hasMore)
+        return try RelaySessionPage.decode(result, offset: offset, limit: limit)
     }
 
     // MARK: - Sessions

--- a/ios/Mercury/MercuryKit/AppFlow/ConnectionController.swift
+++ b/ios/Mercury/MercuryKit/AppFlow/ConnectionController.swift
@@ -329,16 +329,27 @@ final class ConnectionController {
             appModel.setSessionsError(nil)
             appModel.setHermesVersion(nil)
             appModel.setPhase(.connected)
-        } catch let error as RelayConnectionError where error == .notAuthorized {
-            guard appModel.relaySelectionGeneration == generation else { return }
-            appModel.setPhase(.failed(
-                "The host hasn't approved this device — or it was revoked. Approve it on the host, then try again."
-            ))
         } catch {
             guard appModel.relaySelectionGeneration == generation else { return }
-            appModel.setPhase(.failed(
-                "The relay or host is unreachable. Check that your Hermes host is online, then retry."
-            ))
+            let message = Self.relayFailureMessage(error)
+            // Cached sessions keep the list on screen; the banner carries the
+            // reason so a stale list is never mistaken for a live one.
+            appModel.setSessionsError(message)
+            appModel.setPhase(.failed(message))
+        }
+    }
+
+    /// User-facing relay failure text, distinct per cause (Android parity).
+    static func relayFailureMessage(_ error: Error) -> String {
+        switch error as? RelayConnectionError {
+        case .routingRejected:
+            return "The relay refused this phone's pairing token. Remove this relay and pair again from your host's Mercury Relay page."
+        case .noHost:
+            return "Your Hermes host isn't connected to the relay. Start Hermes on the host, then retry."
+        case .notAuthorized:
+            return "The host hasn't approved this device — or it was revoked. Approve it on the host, then try again."
+        default:
+            return "The relay or host is unreachable. Check that your Hermes host is online, then retry."
         }
     }
 
@@ -378,9 +389,7 @@ final class ConnectionController {
                 )
             } catch {
                 guard appModel.activeRelayTarget?.id == target.id else { return nil }
-                appModel.setSessionsError(
-                    "The relay host could not be reached. It may be offline — pull to retry."
-                )
+                appModel.setSessionsError(Self.relayFailureMessage(error))
                 return nil
             }
         }

--- a/ios/Mercury/MercuryKit/AppFlow/ConnectionController.swift
+++ b/ios/Mercury/MercuryKit/AppFlow/ConnectionController.swift
@@ -342,9 +342,7 @@ final class ConnectionController {
         }
     }
 
-    /// One short-lived relay connection serving one `relay.sessions.list`
-    /// read. Sequential short-lived connections keep the single device-socket
-    /// slot free for an open chat.
+    /// One `relay.sessions.list` read over the pool's default lease channel.
     static func relaySessionsPage(
         target: RelayPairedTarget,
         profile: String,
@@ -369,10 +367,8 @@ final class ConnectionController {
         guard case .connected = appModel.connectionPhase else { return nil }
 
         if let target = appModel.activeRelayTarget {
-            // The router permits one device socket per installation. An open
-            // chat owns it, so refreshes stand down until the chat closes and
-            // the visible list refreshes again.
-            guard appModel.visibleSessionID == nil else { return nil }
+            // Reads use the default lease channel; open chats own their own
+            // channels, so a visible chat never blocks a list refresh.
             do {
                 return try await Self.relaySessionsPage(
                     target: target,

--- a/ios/Mercury/MercuryKit/Auth/NativePKCEFlow.swift
+++ b/ios/Mercury/MercuryKit/Auth/NativePKCEFlow.swift
@@ -205,7 +205,7 @@ final class NativePKCEFlow {
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await HermesURLSession.noRedirects.data(for: request)
         let httpResponse = try Self.requireHTTP(response)
         debug("token-http-\(httpResponse.statusCode)")
 

--- a/ios/Mercury/MercuryKit/Auth/NativeRefreshClient.swift
+++ b/ios/Mercury/MercuryKit/Auth/NativeRefreshClient.swift
@@ -76,7 +76,7 @@ final class NativeRefreshClient: @unchecked Sendable {
             let config = URLSessionConfiguration.ephemeral
             config.timeoutIntervalForRequest = 20
             config.requestCachePolicy = .reloadIgnoringLocalCacheData
-            self.session = URLSession(configuration: config)
+            self.session = HermesURLSession.make(config)
             self.ownsSession = true
         }
     }

--- a/ios/Mercury/MercuryKit/Auth/PasswordLoginClient.swift
+++ b/ios/Mercury/MercuryKit/Auth/PasswordLoginClient.swift
@@ -26,7 +26,7 @@ struct PasswordLoginClient: @unchecked Sendable {
 
     private let session: URLSession
 
-    init(session: URLSession = .shared) {
+    init(session: URLSession = HermesURLSession.noRedirects) {
         self.session = session
     }
 

--- a/ios/Mercury/MercuryKit/Chat/WsTicketClient.swift
+++ b/ios/Mercury/MercuryKit/Chat/WsTicketClient.swift
@@ -17,7 +17,7 @@ final class WsTicketClient: WsTicketClienting, @unchecked Sendable {
 
     /// Creates a ticket client with an injectable session so unit tests can
     /// route requests through a per-file URLProtocol without real networking.
-    init(session: URLSession = .shared) {
+    init(session: URLSession = HermesURLSession.noRedirects) {
         self.session = session
         self.defaultOrigin = nil
     }
@@ -26,7 +26,7 @@ final class WsTicketClient: WsTicketClienting, @unchecked Sendable {
     /// bearer-auth HTTP client. The origin is retained for the convenience
     /// overload below; the gateway still supplies its origin explicitly so it
     /// cannot accidentally mint against a different configured host.
-    convenience init(client: HermesHTTPClient, session: URLSession = .shared) {
+    convenience init(client: HermesHTTPClient, session: URLSession = HermesURLSession.noRedirects) {
         self.init(session: session, defaultOrigin: client.origin)
     }
 

--- a/ios/Mercury/MercuryKit/Cloud/PortalModels.swift
+++ b/ios/Mercury/MercuryKit/Cloud/PortalModels.swift
@@ -90,6 +90,12 @@ public struct TokenSet: Codable, Equatable {
 
 /// One agent row from portal agent discovery (`GET {portal}/api/agents`).
 public struct CloudAgent: Codable, Equatable {
+    /// Cloud agents are labelled by the hostname of their dashboard, like
+    /// server rows, and fall back to the agent name while provisioning.
+    var displayLabel: String {
+        dashboardURL.flatMap(ServerOrigin.displayHost) ?? name
+    }
+
     public let id: String
     public let name: String
     public let status: String

--- a/ios/Mercury/MercuryKit/Files/HostFilesClient.swift
+++ b/ios/Mercury/MercuryKit/Files/HostFilesClient.swift
@@ -43,7 +43,7 @@ final class HostFilesClient {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.timeoutIntervalForRequest = 30
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
-        let session = URLSession(configuration: configuration)
+        let session = HermesURLSession.make(configuration)
         try self.init(
             origin: origin,
             bearerToken: bearerToken,
@@ -61,7 +61,7 @@ final class HostFilesClient {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.timeoutIntervalForRequest = 30
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
-        let session = URLSession(configuration: configuration)
+        let session = HermesURLSession.make(configuration)
         try self.init(
             origin: origin,
             bearerToken: bearerToken,
@@ -85,7 +85,7 @@ final class HostFilesClient {
     /// Cookie-authenticated variant used by the Android-parity basic login.
     /// The supplied session must share the cookie store that received the
     /// `/auth/password-login` response.
-    convenience init(cookieAuthenticatedOrigin origin: String, session: URLSession = .shared) throws {
+    convenience init(cookieAuthenticatedOrigin origin: String, session: URLSession = HermesURLSession.noRedirects) throws {
         try self.init(
             origin: origin,
             bearerToken: nil,

--- a/ios/Mercury/MercuryKit/Networking/HermesHTTPClient.swift
+++ b/ios/Mercury/MercuryKit/Networking/HermesHTTPClient.swift
@@ -58,7 +58,7 @@ final class HermesHTTPClient {
         config.httpShouldSetCookies = true
         config.timeoutIntervalForRequest = 20
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
-        self.session = URLSession(configuration: config)
+        self.session = HermesURLSession.make(config)
         self.ownsSession = true
     }
 

--- a/ios/Mercury/MercuryKit/Networking/HermesURLSession.swift
+++ b/ios/Mercury/MercuryKit/Networking/HermesURLSession.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Redirect policy for Hermes-origin requests, matching Android's
+/// `followRedirects = false` on the connection and media clients: a redirect
+/// is never followed, so a bearer token, cookie, or ticket scoped to the
+/// configured origin can never be forwarded to another host or replayed over
+/// a plain-HTTP downgrade. The 3xx response surfaces to the caller unchanged
+/// and is classified like any other non-2xx status.
+final class RedirectRefusingSessionDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    static let shared = RedirectRefusingSessionDelegate()
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}
+
+enum HermesURLSession {
+    /// A session over `configuration` that refuses every redirect.
+    static func make(_ configuration: URLSessionConfiguration) -> URLSession {
+        URLSession(
+            configuration: configuration,
+            delegate: RedirectRefusingSessionDelegate.shared,
+            delegateQueue: nil
+        )
+    }
+
+    /// Process-wide default for Hermes-origin clients. Same configuration as
+    /// `URLSession.shared` (default, shared cookie storage) minus redirects.
+    static let noRedirects: URLSession = make(.default)
+}

--- a/ios/Mercury/MercuryKit/Operations/CronClient.swift
+++ b/ios/Mercury/MercuryKit/Operations/CronClient.swift
@@ -65,7 +65,7 @@ struct CronRESTClient: @unchecked Sendable {
         self.transport = transport
     }
 
-    init(origin: URL, accessToken: String?, profile: String, session: URLSession = .shared) {
+    init(origin: URL, accessToken: String?, profile: String, session: URLSession = HermesURLSession.noRedirects) {
         self.init(origin: origin, accessToken: accessToken, profile: profile) { request in
             do {
                 let (data, response) = try await session.data(for: request)

--- a/ios/Mercury/MercuryKit/Relay/RelayAppModel.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayAppModel.swift
@@ -35,6 +35,12 @@ final class RelayAppModel {
     ) {
         self.store = store
         coordinator = RelayPairingCoordinator(socketFactory: socketFactory, store: store)
+        let store = store
+        Task {
+            await RelayConnectionPool.shared.setRoutingTokenSink { target, token in
+                try? await store.updateRoutingToken(id: target.id, token: token)
+            }
+        }
     }
 
     func loadTargets() async {

--- a/ios/Mercury/MercuryKit/Relay/RelayConnection.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayConnection.swift
@@ -68,6 +68,12 @@ private final class URLSessionRelaySocket: RelayBinarySocketing, @unchecked Send
         errorLock.unlock()
     }
 
+    /// The HTTP status the router answered the upgrade with, when it refused.
+    private var refusedUpgradeStatus: Int? {
+        guard let http = task.response as? HTTPURLResponse else { return nil }
+        return http.statusCode == 101 ? nil : http.statusCode
+    }
+
     func send(_ data: Data) async throws {
         do {
             try await task.send(.data(data))
@@ -75,6 +81,9 @@ private final class URLSessionRelaySocket: RelayBinarySocketing, @unchecked Send
             throw error
         } catch {
             record(error)
+            if let status = refusedUpgradeStatus, status == 401 || status == 403 {
+                throw RelayConnectionError.routingRejected
+            }
             // Ciphertext must never appear in errors.
             throw RelayConnectionError.offline
         }
@@ -96,6 +105,9 @@ private final class URLSessionRelaySocket: RelayBinarySocketing, @unchecked Send
             throw error
         } catch {
             record(error)
+            if let status = refusedUpgradeStatus, status == 401 || status == 403 {
+                throw RelayConnectionError.routingRejected
+            }
             // Peer close and receive errors share nil, like ChatSocketing.
             return nil
         }
@@ -133,7 +145,15 @@ enum RelayConnectionError: Error, Equatable {
     /// The pairing offer was rejected (consumed, expired host-side, or
     /// capability mismatch).
     case pairingRejected
+    /// The router refused the socket: the pairing's routing token is
+    /// missing, expired, or invalid. Only re-pairing fixes it.
+    case routingRejected
+    /// The router accepted the socket but no Hermes host is attached.
+    case noHost
 }
+
+/// Router close code: no Hermes host is attached to this installation.
+let relayCloseNoHost = 4004
 
 // MARK: - Established connection
 
@@ -183,7 +203,11 @@ enum RelayConnector {
             )
             try await socket.send(channel.writeHandshake())
             guard let second = try await socket.receive() else {
-                throw RelayConnectionError.notAuthorized
+                // The router closes with 4004 when no host is attached; any
+                // other silent close is the host refusing this device.
+                throw socket.lastCloseCode() == relayCloseNoHost
+                    ? RelayConnectionError.noHost
+                    : RelayConnectionError.notAuthorized
             }
             try Task.checkCancellation()
             _ = try channel.readHandshake(second)

--- a/ios/Mercury/MercuryKit/Relay/RelayConnection.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayConnection.swift
@@ -187,6 +187,7 @@ enum RelayConnector {
         resumeCursor: Int64? = nil,
         recoveryVersion: Int32? = nil,
         channel leaseChannel: String? = nil,
+        deviceName: String? = RelayDeviceIdentity.name,
         socketFactory: any RelayBinarySocketFactorying = URLSessionRelaySocketFactory()
     ) async throws -> RelayConnectedChannel {
         guard let url = RelayPairingPayload.deviceSocketURL(
@@ -218,7 +219,8 @@ enum RelayConnector {
                 profile: profile,
                 resumeCursor: resumeCursor,
                 recoveryVersion: recoveryVersion,
-                channel: leaseChannel
+                channel: leaseChannel,
+                deviceName: deviceName
             )
             try await socket.send(channel.encrypt(envelope))
             try Task.checkCancellation()

--- a/ios/Mercury/MercuryKit/Relay/RelayConnection.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayConnection.swift
@@ -166,6 +166,7 @@ enum RelayConnector {
         profile: String,
         resumeCursor: Int64? = nil,
         recoveryVersion: Int32? = nil,
+        channel leaseChannel: String? = nil,
         socketFactory: any RelayBinarySocketFactorying = URLSessionRelaySocketFactory()
     ) async throws -> RelayConnectedChannel {
         guard let url = RelayPairingPayload.deviceSocketURL(
@@ -192,7 +193,8 @@ enum RelayConnector {
                 deviceID: target.deviceID,
                 profile: profile,
                 resumeCursor: resumeCursor,
-                recoveryVersion: recoveryVersion
+                recoveryVersion: recoveryVersion,
+                channel: leaseChannel
             )
             try await socket.send(channel.encrypt(envelope))
             try Task.checkCancellation()

--- a/ios/Mercury/MercuryKit/Relay/RelayConnectionPool.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayConnectionPool.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-/// A single authenticated admission, borrowed by chat and auxiliary readers.
-/// No metadata view can displace or close a live retained controller.
+/// Authenticated relay admissions, one per lease channel, borrowed by chat and
+/// auxiliary readers. No metadata view can displace or close a live retained
+/// controller, and no chat can displace another chat's channel.
 actor RelayConnectionPool {
     static let shared = RelayConnectionPool(selectionRequired: true)
     private struct Scope: Equatable {
@@ -17,15 +18,23 @@ actor RelayConnectionPool {
                 && lhs.target.relayRoutingToken == rhs.target.relayRoutingToken
         }
     }
+    /// One admitted controller per lease channel. The default channel (nil)
+    /// serves auxiliary readers and metadata; each open chat owns its own
+    /// channel, so several sessions stay open on one phone at once. The host
+    /// keeps one lease per (device, channel); the router multiplexes sockets.
+    private final class Slot {
+        var scope: Scope?
+        var connection: ChatConnection?
+        var checkpoint = RelayRecoveryCheckpoint()
+        var taskOwner = RelayTaskOwner()
+        var opening: Task<ChatConnection, Error>?
+        var generation = UUID()
+    }
     private var selectedScope: Scope?
     private var selectionRequired: Bool
     private var selecting = false
-    private var scope: Scope?
-    private var connection: ChatConnection?
-    private var checkpoint = RelayRecoveryCheckpoint()
-    private var taskOwner = RelayTaskOwner()
-    private var opening: Task<ChatConnection, Error>?
-    private var generation = UUID()
+    private var slots: [String: Slot] = [:]
+    private var selectionGeneration = UUID()
     private let socketFactory: any RelayBinarySocketFactorying
 
     init(socketFactory: any RelayBinarySocketFactorying = URLSessionRelaySocketFactory(),
@@ -34,55 +43,67 @@ actor RelayConnectionPool {
         self.socketFactory = socketFactory
     }
 
+    private func slot(for channel: String?) -> Slot {
+        let key = channel ?? ""
+        if let existing = slots[key] { return existing }
+        let created = Slot()
+        slots[key] = created
+        return created
+    }
+
     /// Only explicit app transport/profile selection may replace the admission scope.
+    /// Selection drops every channel's controller.
     func select(target: RelayPairedTarget?, profile: String) async {
         let requested = target.map { Scope(target: $0, profile: profile) }
         selectionRequired = true
-        guard selectedScope != requested || scope != requested else { return }
+        guard selectedScope != requested || slots.values.contains(where: { $0.scope != requested }) else { return }
         selectedScope = requested
-        generation = UUID()
-        let token = generation
+        selectionGeneration = UUID()
+        let token = selectionGeneration
         selecting = true
-        let oldFlight = opening
-        let old = connection
-        opening = nil
-        connection = nil
-        scope = nil
-        checkpoint = RelayRecoveryCheckpoint()
-        taskOwner = RelayTaskOwner()
-        oldFlight?.cancel()
-        if let old { await old.close() }
-        if let oldFlight, let stale = try? await oldFlight.value { await stale.close() }
-        if generation == token { selecting = false }
+        let old = slots
+        slots = [:]
+        for slot in old.values {
+            slot.generation = UUID()
+            slot.opening?.cancel()
+        }
+        for slot in old.values {
+            if let connection = slot.connection { await connection.close() }
+            if let flight = slot.opening, let stale = try? await flight.value { await stale.close() }
+        }
+        if selectionGeneration == token { selecting = false }
     }
 
-    func acquire(target: RelayPairedTarget, profile: String) async throws -> ChatConnection {
+    func acquire(
+        target: RelayPairedTarget, profile: String, channel: String? = nil
+    ) async throws -> ChatConnection {
         let requested = Scope(target: target, profile: profile)
         guard !selecting, !selectionRequired || selectedScope == requested else {
             throw CancellationError()
         }
-        if scope == requested {
-            if let connection, !connection.isClosed { return connection }
-            if let opening {
-                let token = generation
+        let slot = slot(for: channel)
+        if slot.scope == requested {
+            if let connection = slot.connection, !connection.isClosed { return connection }
+            if let opening = slot.opening {
+                let token = slot.generation
                 let candidate = try await opening.value
-                guard generation == token, scope == requested else { throw CancellationError() }
+                guard slot.generation == token, slot.scope == requested else { throw CancellationError() }
                 return candidate
             }
         }
-        let previousOpening = opening
-        let previousConnection = connection
-        if scope != requested {
-            checkpoint = RelayRecoveryCheckpoint()
-            taskOwner = RelayTaskOwner()
+        let previousOpening = slot.opening
+        let previousConnection = slot.connection
+        if slot.scope != requested {
+            slot.checkpoint = RelayRecoveryCheckpoint()
+            slot.taskOwner = RelayTaskOwner()
         }
-        let checkpoint = self.checkpoint
-        let taskOwner = self.taskOwner
+        let checkpoint = slot.checkpoint
+        let taskOwner = slot.taskOwner
         previousOpening?.cancel()
-        generation = UUID()
-        let token = generation
-        scope = requested
-        connection = nil
+        slot.generation = UUID()
+        let token = slot.generation
+        slot.scope = requested
+        slot.connection = nil
         let factory = socketFactory
         // Publish the flight BEFORE any await, including cursor acquisition and
         // old-channel draining. Actor reentrancy must not create two candidates.
@@ -94,7 +115,7 @@ actor RelayConnectionPool {
             let cursor = checkpointOwner.cursor
             let connected = try await RelayConnector.connect(
                 target: target, profile: profile, resumeCursor: cursor, recoveryVersion: 1,
-                socketFactory: factory
+                channel: channel, socketFactory: factory
             )
             let socket = RelayChatSocket(connected: connected, recoveryProfile: profile,
                 checkpoint: checkpoint, checkpointGeneration: checkpointOwner.generation,
@@ -119,18 +140,18 @@ actor RelayConnectionPool {
                 throw error
             }
         }
-        opening = task
+        slot.opening = task
         do {
             let candidate = try await task.value
-            guard generation == token, scope == requested else {
+            guard slot.generation == token, slot.scope == requested else {
                 await candidate.close()
                 throw CancellationError()
             }
-            connection = candidate
-            opening = nil
+            slot.connection = candidate
+            slot.opening = nil
             return candidate
         } catch {
-            if generation == token { opening = nil }
+            if slot.generation == token { slot.opening = nil }
             throw error
         }
     }

--- a/ios/Mercury/MercuryKit/Relay/RelayConnectionPool.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayConnectionPool.swift
@@ -36,6 +36,12 @@ actor RelayConnectionPool {
     private var slots: [String: Slot] = [:]
     private var selectionGeneration = UUID()
     private let socketFactory: any RelayBinarySocketFactorying
+    /// Receives a router token the host renewed inside the attach preamble.
+    private var routingTokenSink: (@Sendable (RelayPairedTarget, String) async -> Void)?
+
+    func setRoutingTokenSink(_ sink: (@Sendable (RelayPairedTarget, String) async -> Void)?) {
+        routingTokenSink = sink
+    }
 
     init(socketFactory: any RelayBinarySocketFactorying = URLSessionRelaySocketFactory(),
          selectionRequired: Bool = false) {
@@ -105,6 +111,7 @@ actor RelayConnectionPool {
         slot.scope = requested
         slot.connection = nil
         let factory = socketFactory
+        let tokenSink = routingTokenSink
         // Publish the flight BEFORE any await, including cursor acquisition and
         // old-channel draining. Actor reentrancy must not create two candidates.
         let task = Task<ChatConnection, Error> {
@@ -132,6 +139,12 @@ actor RelayConnectionPool {
                     _ = try await group.next()
                 }
                 try Task.checkCancellation()
+                // The host renews the router token on every attach; persist
+                // it so the pairing never ages out and needs a re-pair.
+                if let tokenSink, let renewed = await socket.recoverySnapshot()?.routingToken,
+                   renewed != target.relayRoutingToken {
+                    await tokenSink(target, renewed)
+                }
                 let candidate = try ChatConnection(socket: socket)
                 candidate.startReading()
                 return candidate

--- a/ios/Mercury/MercuryKit/Relay/RelayDeviceIdentity.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayDeviceIdentity.swift
@@ -1,0 +1,19 @@
+import Foundation
+import UIKit
+
+/// The name this phone reports to a relay host in its admission envelope, so
+/// the host's device list can show the phone by name instead of a fingerprint.
+/// iOS returns a generic "iPhone" for the user-set name on recent systems, so
+/// the model name is appended when the two differ.
+enum RelayDeviceIdentity {
+    static let name: String? = {
+        let device = UIDevice.current
+        let userName = device.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = device.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        let combined: String
+        if userName.isEmpty { combined = model }
+        else if userName.caseInsensitiveCompare(model) == .orderedSame { combined = model }
+        else { combined = userName }
+        return combined.isEmpty ? nil : combined
+    }()
+}

--- a/ios/Mercury/MercuryKit/Relay/RelayIdentityStore.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayIdentityStore.swift
@@ -45,7 +45,8 @@ struct RelayPairedTarget: Identifiable, Equatable, Sendable {
     var status: RelayTargetStatus
     let createdAtEpochSeconds: Int64
     var lastUsedEpochSeconds: Int64?
-    let relayRoutingToken: String?
+    /// Router admission token; renewed by the host on every lease attach.
+    var relayRoutingToken: String?
 
     init(
         id: UUID,
@@ -199,6 +200,20 @@ actor RelayTargetStore {
             throw RelayTargetStoreError.unknownTarget
         }
         targets[index].lastUsedEpochSeconds = epochSeconds()
+        try persist(targets)
+    }
+
+    /// Stores a router token the host renewed over the authenticated channel.
+    func updateRoutingToken(id: UUID, token: String) throws {
+        var targets = try load()
+        guard let index = targets.firstIndex(where: { $0.id == id }) else {
+            throw RelayTargetStoreError.unknownTarget
+        }
+        guard !token.isEmpty,
+              token.count <= Int(MercuryCore.RelayProtocolPolicy.shared.maxRoutingTokenCharacters),
+              token.utf8.allSatisfy({ $0 >= 0x21 && $0 <= 0x7e })
+        else { throw RelayTargetStoreError.corruptState }
+        targets[index].relayRoutingToken = token
         try persist(targets)
     }
 

--- a/ios/Mercury/MercuryKit/Relay/RelayKmpBridge.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayKmpBridge.swift
@@ -168,18 +168,25 @@ enum RelayAdmissionEnvelope {
         deviceID: String,
         profile: String,
         resumeCursor: Int64? = nil,
-        recoveryVersion: Int32? = nil
+        recoveryVersion: Int32? = nil,
+        channel: String? = nil
     ) throws -> Data {
         do {
             return try MercuryCore.RelayAdmissionEnvelope.shared.controllerOpen(
                 deviceId: deviceID,
                 profile: profile,
                 resumeCursor: resumeCursor.map(KotlinLong.init(value:)),
-                recoveryVersion: recoveryVersion.map(KotlinInt.init(value:))
+                recoveryVersion: recoveryVersion.map(KotlinInt.init(value:)),
+                channel: channel
             ).relayData
         } catch {
             throw RelayProtocolError.invalidEnvelope
         }
+    }
+
+    /// Deterministic lease channel for one session key (shared with Android).
+    static func channelForSession(_ sessionKey: String) -> String {
+        MercuryCore.RelayAdmissionEnvelope.shared.channelForSession(sessionKey: sessionKey)
     }
 }
 

--- a/ios/Mercury/MercuryKit/Relay/RelayKmpBridge.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayKmpBridge.swift
@@ -169,7 +169,8 @@ enum RelayAdmissionEnvelope {
         profile: String,
         resumeCursor: Int64? = nil,
         recoveryVersion: Int32? = nil,
-        channel: String? = nil
+        channel: String? = nil,
+        deviceName: String? = nil
     ) throws -> Data {
         do {
             return try MercuryCore.RelayAdmissionEnvelope.shared.controllerOpen(
@@ -177,7 +178,8 @@ enum RelayAdmissionEnvelope {
                 profile: profile,
                 resumeCursor: resumeCursor.map(KotlinLong.init(value:)),
                 recoveryVersion: recoveryVersion.map(KotlinInt.init(value:)),
-                channel: channel
+                channel: channel,
+                deviceName: deviceName
             ).relayData
         } catch {
             throw RelayProtocolError.invalidEnvelope

--- a/ios/Mercury/MercuryKit/Relay/RelayPairingCoordinator.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayPairingCoordinator.swift
@@ -164,34 +164,55 @@ actor RelayPairingCoordinator {
     /// One approval probe: a fresh handshake plus admission envelope, proven
     /// by a `gateway.ping` round trip. Pending or revoked devices see the
     /// host close the socket instead.
+    ///
+    /// The router allows one device socket per installation, so the probe's
+    /// socket is closed and awaited on every exit path (approved, rejected,
+    /// early EOF, thrown error, cancellation) before this returns. A caller
+    /// that opens the chat right after a probe must never race a socket that
+    /// is still being torn down.
     func probeApproval(target: RelayPairedTarget, profile: String) async -> Bool {
+        let connected: RelayConnectedChannel
         do {
-            let connected = try await RelayConnector.connect(
+            connected = try await RelayConnector.connect(
                 target: target,
                 profile: profile,
                 socketFactory: socketFactory
             )
-            let chatSocket = RelayChatSocket(connected: connected)
-            defer { Task { await chatSocket.close() } }
+        } catch {
+            // RelayConnector closes its own socket on every failure.
+            return false
+        }
+        let chatSocket = RelayChatSocket(connected: connected)
+        let approved = await withTaskCancellationHandler {
+            await Self.runProbe(on: chatSocket)
+        } onCancel: {
+            Task { await chatSocket.close() }
+        }
+        await chatSocket.close()
+        guard approved else { return false }
+        try? await store.markApproved(id: target.id)
+        return true
+    }
+
+    /// The ping round trip only; never touches the store or closes the socket.
+    private static func runProbe(on chatSocket: RelayChatSocket) async -> Bool {
+        do {
             try await chatSocket.sendText(
                 #"{"jsonrpc":"2.0","id":"pairing-probe","method":"gateway.ping","params":{}}"#
             )
-            var approved = false
             for _ in 0..<32 {
+                try Task.checkCancellation()
                 guard let reply = try await chatSocket.receiveText() else { return false }
                 switch RelayApprovalProbe.evaluateGatewayPing(reply) {
                 case .approved:
-                    approved = true
+                    return true
                 case .rejected:
                     return false
                 case .ignore:
                     continue
                 }
-                break
             }
-            guard approved else { return false }
-            try? await store.markApproved(id: target.id)
-            return true
+            return false
         } catch {
             return false
         }

--- a/ios/Mercury/MercuryKit/Relay/RelayPairingCoordinator.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayPairingCoordinator.swift
@@ -165,11 +165,11 @@ actor RelayPairingCoordinator {
     /// by a `gateway.ping` round trip. Pending or revoked devices see the
     /// host close the socket instead.
     ///
-    /// The router allows one device socket per installation, so the probe's
-    /// socket is closed and awaited on every exit path (approved, rejected,
-    /// early EOF, thrown error, cancellation) before this returns. A caller
-    /// that opens the chat right after a probe must never race a socket that
-    /// is still being torn down.
+    /// The probe uses the device's default lease channel, which the next
+    /// default-channel open supersedes, so its socket is closed and awaited
+    /// on every exit path (approved, rejected, early EOF, thrown error,
+    /// cancellation) before this returns. A caller that opens a connection
+    /// right after a probe must never race a socket still being torn down.
     func probeApproval(target: RelayPairedTarget, profile: String) async -> Bool {
         let connected: RelayConnectedChannel
         do {

--- a/ios/Mercury/MercuryKit/Relay/RelaySessionPage.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelaySessionPage.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Decodes one `relay.sessions.list` result. Any shape the contract does not
+/// permit is a protocol violation, never an authoritative empty list: a
+/// malformed reply must not make the inbox look empty or clear cached rows.
+enum RelaySessionPage {
+    static func decode(_ result: [String: Any], offset: Int, limit: Int) throws -> SessionPage {
+        guard let rawRows = result["sessions"] as? [[String: Any]] else {
+            throw RelayConnectionError.protocolViolation
+        }
+        let rows: [SessionRow]
+        do {
+            let data = try JSONSerialization.data(withJSONObject: rawRows)
+            rows = try JSONDecoder().decode([SessionRow].self, from: data)
+        } catch {
+            throw RelayConnectionError.protocolViolation
+        }
+        let total = result["total"] as? Int
+        let hasMore = total.map { offset + rows.count < $0 } ?? (rows.count == limit)
+        return SessionPage(rows: rows, total: total, hasMore: hasMore)
+    }
+}

--- a/ios/Mercury/ServerCatalog.swift
+++ b/ios/Mercury/ServerCatalog.swift
@@ -37,7 +37,10 @@ struct ServerCatalogEntry: Identifiable, Equatable, Sendable {
     var label: String
     var lastUsedEpochSeconds: Int64?
 
-    var displayLabel: String { label.isEmpty ? origin : label }
+    /// A user label wins; otherwise the hostname alone (shared display decision).
+    var displayLabel: String {
+        label.isEmpty ? (ServerOrigin.displayHost(origin) ?? origin) : label
+    }
 
     init(
         id: UUID,

--- a/ios/Mercury/ServerOrigin.swift
+++ b/ios/Mercury/ServerOrigin.swift
@@ -16,6 +16,14 @@ enum ServerOrigin {
         return (result as? MercuryCore.OriginParseResultValid)?.origin
     }
 
+    /// The shared policy's reason when `input` is not a valid origin, or nil
+    /// when it is valid. Surfaces the same wording Android shows, including
+    /// the public plain-HTTP rejection, instead of a generic message.
+    static func validationFailure(_ input: String, useTls: Bool = true) -> String? {
+        let result = MercuryCore.ServerOriginPolicy.shared.canonicalize(input: input, useTls: useTls)
+        return (result as? MercuryCore.OriginParseResultInvalid)?.reason
+    }
+
     /// Converts an explicit HTTP(S) origin to the matching WebSocket scheme.
     static func webSocketValue(_ origin: String) -> String? {
         MercuryCore.ServerOriginPolicy.shared.webSocketValue(origin: origin)

--- a/ios/Mercury/ServerOrigin.swift
+++ b/ios/Mercury/ServerOrigin.swift
@@ -29,6 +29,12 @@ enum ServerOrigin {
         MercuryCore.ServerOriginPolicy.shared.webSocketValue(origin: origin)
     }
 
+    /// The host to show for an origin or dashboard URL in lists (shared
+    /// display decision: no scheme, port, or path). Nil when there is no host.
+    static func displayHost(_ originOrURL: String) -> String? {
+        MercuryCore.ServerOriginPolicy.shared.displayHost(originOrUrl: originOrURL)
+    }
+
     /// True when the host of a normalized origin is loopback or RFC1918-private.
     static func isLoopbackOrPrivate(_ origin: String) -> Bool {
         MercuryCore.ServerOriginPolicy.shared.isLoopbackOrPrivate(origin: origin)

--- a/ios/Mercury/Theme.swift
+++ b/ios/Mercury/Theme.swift
@@ -1,83 +1,99 @@
 import SwiftUI
+import UIKit
 
-// MARK: - AMOLED-first dark theme
+// MARK: - Mercury design tokens
 //
-// Every color in Mercury is defined here exactly once. No hardcoded hex
-// anywhere else in the app — views reach for these statics (or the system
-// .primary/.secondary text colors) only.
+// Every color in Mercury is defined here exactly once, as a light/dark pair
+// derived from the Android Material 3 scheme in
+// app/src/main/java/.../theme/Theme.kt (the source of truth; see the local
+// design-tokens spec). No hardcoded hex anywhere else in the app — views
+// reach for these roles (or the system .primary/.secondary text colors) only.
+// Dark is AMOLED-first: a pure #000000 canvas with neutral gray tiers.
+
+private extension Color {
+    /// One adaptive role from its light and dark hex values.
+    static func token(light: UInt32, dark: UInt32) -> Color {
+        Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark ? UIColor(hex: dark) : UIColor(hex: light)
+        })
+    }
+}
+
+private extension UIColor {
+    convenience init(hex: UInt32) {
+        self.init(
+            red: CGFloat((hex >> 16) & 0xFF) / 255.0,
+            green: CGFloat((hex >> 8) & 0xFF) / 255.0,
+            blue: CGFloat(hex & 0xFF) / 255.0,
+            alpha: 1
+        )
+    }
+}
 
 extension Color {
-    /// Pure #000000. The app background on AMOLED hardware: true pixels-off black.
-    static let amoledBlack = Color(red: 0, green: 0, blue: 0)
+    // MARK: Canvas and surfaces (Material background / surfaceContainer*)
 
-    /// Raised surface steps above AMOLED black, subtle and monotonic.
-    static let surfaceLow = Color(red: 0x0A / 255.0, green: 0x0A / 255.0, blue: 0x0A / 255.0)   // #0A0A0A
-    static let surfaceMid = Color(red: 0x14 / 255.0, green: 0x14 / 255.0, blue: 0x14 / 255.0)   // #141414
-    static let surfaceHigh = Color(red: 0x1E / 255.0, green: 0x1E / 255.0, blue: 0x1E / 255.0)  // #1E1E1E
+    /// App background: Material `background`. Pure black on AMOLED hardware.
+    static let canvas = Color.token(light: 0xFAFCFB, dark: 0x000000)
+    /// Material `surfaceContainerLowest`.
+    static let surfaceLowest = Color.token(light: 0xFFFFFF, dark: 0x0A0A0A)
+    /// Material `surfaceContainerLow`: the first raised step above the canvas.
+    static let surfaceLow = Color.token(light: 0xF4F7F5, dark: 0x141414)
+    /// Material `surfaceContainer`: cards, the composer, sheets.
+    static let surfaceMid = Color.token(light: 0xECF2EF, dark: 0x1C1C1C)
+    /// Material `surfaceContainerHigh`.
+    static let surfaceHigh = Color.token(light: 0xE6ECE9, dark: 0x232323)
+    /// Material `surfaceContainerHighest`.
+    static let surfaceHighest = Color.token(light: 0xE0E5E2, dark: 0x2B2B2B)
+    /// Material `onSurfaceVariant`: secondary content on surfaces.
+    static let secondaryContent = Color.token(light: 0x3F4947, dark: 0xC5C5C5)
+    /// Material `outline`.
+    static let outline = Color.token(light: 0x6F7977, dark: 0x8A8A8A)
+    /// Material `outlineVariant`: hairlines and borders between surfaces.
+    static let separatorSubtle = Color.token(light: 0xBEC9C6, dark: 0x3A3A3A)
 
-    /// Accent: system indigo keeps the native iOS feel; mint is reserved for
-    /// "connected/healthy" states so the accent never fights status semantics.
-    static let accentPrimary = Color.indigo
-    static let statusHealthy = Color.mint
-    static let statusAlert = Color.red
+    // MARK: Accent (Hermes teal, Material primary)
 
-    // Android composer parity. These are deliberately scoped semantic roles
-    // rather than replacements for Mercury's native iOS accent: the chat bar
-    // should match the authoritative Android client without recoloring the
-    // rest of the app.
-    static let composerPrimary = Color(
-        red: 0x80 / 255.0,
-        green: 0xD5 / 255.0,
-        blue: 0xCF / 255.0
-    ) // Android dark primary #80D5CF
-    static let composerOnPrimary = Color(
-        red: 0x00 / 255.0,
-        green: 0x37 / 255.0,
-        blue: 0x35 / 255.0
-    ) // Android dark onPrimary #003735
-    static let composerSurface = Color(
-        red: 0x1C / 255.0,
-        green: 0x1C / 255.0,
-        blue: 0x1C / 255.0
-    ) // Android dark surfaceContainer #1C1C1C
-    static let composerSecondaryContent = Color(
-        red: 0xC5 / 255.0,
-        green: 0xC5 / 255.0,
-        blue: 0xC5 / 255.0
-    ) // Android dark onSurfaceVariant #C5C5C5
-    static let composerActive = Color(
-        red: 0xF2 / 255.0,
-        green: 0xC6 / 255.0,
-        blue: 0x4D / 255.0
-    ) // Android semantic active #F2C64D
-    static let composerOnActive = Color(
-        red: 0x24 / 255.0,
-        green: 0x1A / 255.0,
-        blue: 0x00 / 255.0
-    ) // Android semantic onActive #241A00
+    static let accentPrimary = Color.token(light: 0x1B6969, dark: 0x9BD0CF)
+    static let onAccentPrimary = Color.token(light: 0xE0FFFE, dark: 0x0C4848)
+    static let accentContainer = Color.token(light: 0xA8EFEE, dark: 0x255A5A)
+    static let onAccentContainer = Color.token(light: 0x005C5C, dark: 0xB7EDEC)
 
-    /// Hairlines/borders between raised surfaces.
-    static let separatorSubtle = Color.primary.opacity(0.12)
+    // MARK: Status (Android semantic roles)
+
+    /// A running turn, the new-session control: Android `active`.
+    static let statusActive = Color.token(light: 0xC68A16, dark: 0xF2C64D)
+    static let onStatusActive = Color.token(light: 0x241A00, dark: 0x241A00)
+    /// Connected/healthy and completed runs share Android `completed`.
+    static let statusHealthy = Color.token(light: 0x2D6A43, dark: 0x8ED6A5)
+    static let onStatusHealthy = Color.token(light: 0xFFFFFF, dark: 0x0C3A1E)
+    /// Material `error`.
+    static let statusAlert = Color.token(light: 0xBA1A1A, dark: 0xFFB4AB)
+    static let onStatusAlert = Color.token(light: 0xFFFFFF, dark: 0x690005)
+    static let alertContainer = Color.token(light: 0xFFDAD6, dark: 0x93000A)
+    static let onAlertContainer = Color.token(light: 0x410002, dark: 0xFFDAD6)
 }
 
 extension ShapeStyle where Self == Color {
-    /// `some ShapeStyle` ergonomics: `.background(.amoledBlack)` etc.
-    static var amoledBlack: Color { .amoledBlack }
+    /// `some ShapeStyle` ergonomics: `.background(.canvas)` etc.
+    static var canvas: Color { .canvas }
+    static var surfaceLowest: Color { .surfaceLowest }
     static var surfaceLow: Color { .surfaceLow }
     static var surfaceMid: Color { .surfaceMid }
     static var surfaceHigh: Color { .surfaceHigh }
+    static var surfaceHighest: Color { .surfaceHighest }
 }
 
 extension View {
-    /// Applies the AMOLED background edge-to-edge beneath safe-area content.
+    /// Applies the canvas background edge-to-edge beneath safe-area content.
     func amoledScreen() -> some View {
-        background(Color.amoledBlack.ignoresSafeArea(edges: .all))
+        background(Color.canvas.ignoresSafeArea(edges: .all))
     }
 }
 
 /// Android-parity new-session floating action button: the 48dp rounded-square
 /// `Surface` from `SessionListScreen`'s `floatingActionButton` slot (amber
-/// `semanticColors.active` #F2C64D, dark `onActive` content, shapes.small),
+/// `semanticColors.active`, dark `onActive` content, shapes.small),
 /// anchored bottom-trailing. The SAME control appears on Home and on the
 /// project sessions screen so session creation looks identical everywhere.
 struct NewTaskFloatingButton: View {
@@ -87,9 +103,9 @@ struct NewTaskFloatingButton: View {
         Button(action: action) {
             Image(systemName: "plus")
                 .font(.system(size: 22, weight: .medium))
-                .foregroundStyle(Color.composerOnActive)
+                .foregroundStyle(Color.onStatusActive)
                 .frame(width: 48, height: 48)
-                .background(Color.composerActive, in: RoundedRectangle(cornerRadius: 8))
+                .background(Color.statusActive, in: RoundedRectangle(cornerRadius: 8))
         }
         .accessibilityLabel("New session")
         .padding(.trailing, 28)

--- a/ios/Mercury/Views/ActivityStackView.swift
+++ b/ios/Mercury/Views/ActivityStackView.swift
@@ -92,7 +92,7 @@ struct ActivityStackView: View {
     private func todoRow(_ todo: ActivityTodo) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text(todoMarker(todo.status))
-                .foregroundStyle(todo.status == .completed ? Color.green : Color.accentColor)
+                .foregroundStyle(todo.status == .completed ? Color.statusHealthy : Color.accentPrimary)
             Text(todo.content).font(.caption).frame(maxWidth: .infinity, alignment: .leading)
             Text(todoLabel(todo.status)).font(.caption2).foregroundStyle(.secondary)
         }

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -257,6 +257,10 @@ struct ChatView: View {
         currentModelSelection?.model.split(separator: "/").last.map(String.init)
     }
 
+    private var contextControlsSupported: Bool {
+        usageSupported || breakdownSupported || compressSupported || undoSupported || branchSupported
+    }
+
     private var composerContextPercent: Double? {
         if let percent = sessionUsage?.contextPercent { return percent }
         if let used = sessionUsage?.contextUsedTokens,
@@ -364,15 +368,24 @@ struct ChatView: View {
                 onOpenModelPicker: modelFeatureSupported ? openModelPicker : nil,
                 onReasoningSelected: applyReasoning,
                 onFastSelected: applyFast,
-                onOpenContext: (usageSupported || breakdownSupported || compressSupported || undoSupported || branchSupported)
-                    ? openContextSheet
-                    : nil
+                onOpenContext: contextControlsSupported ? openContextSheet : nil
             )
         }
         .navigationTitle(titleText.isEmpty ? "Session" : titleText)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.canvas, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
+        .toolbar {
+            if contextControlsSupported {
+                ToolbarItem(placement: .topBarTrailing) {
+                    ContextRingButton(
+                        percent: composerContextPercent,
+                        artifactCount: 0,
+                        action: openContextSheet
+                    )
+                }
+            }
+        }
         .task {
             // Visibility can change while SwiftUI retains this view and restarts
             // its task. Restore it even when the connection is already owned.
@@ -596,6 +609,9 @@ struct ChatView: View {
                         Label(generating, systemImage: "gearshape")
                             .font(.caption)
                             .foregroundStyle(Color.secondary)
+                    }
+                    if turnInFlight, let status = transcript.latestStatusText, !status.isEmpty {
+                        RunStatusPill(text: status)
                     }
                     Color.clear.frame(height: 1).id(lastRowID)
                 }

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -371,7 +371,7 @@ struct ChatView: View {
         }
         .navigationTitle(titleText.isEmpty ? "Session" : titleText)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(.amoledBlack, for: .navigationBar)
+        .toolbarBackground(.canvas, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .task {
             // Visibility can change while SwiftUI retains this view and restarts
@@ -706,12 +706,11 @@ struct ChatView: View {
             let fetched: [TranscriptMessage]
             var relayPage: RelayTranscriptPage?
             if isRelay {
-                // The router permits one device socket: a standalone read
-                // while any chat connection exists (or is mid-handshake in a
-                // reconnect) would supersede it and force a reconnect loop.
-                // Standalone is safe only for the initial pre-connect load;
-                // later reads must ride an existing connection, and
-                // reconnects refresh from the resume snapshot anyway.
+                // Reads ride the live chat connection when one exists (it
+                // already carries this session's lease). A standalone read
+                // over the pool's default channel serves only the initial
+                // pre-connect load; reconnects refresh from the resume
+                // snapshot anyway.
                 let live = liveConnection ?? connection
                 if live == nil && !allowStandaloneRelayRead { return false }
                 let page = try await relayTranscriptMessages(
@@ -758,9 +757,8 @@ struct ChatView: View {
 
     /// Fetches one transcript page over the relay's in-process read
     /// (`relay.session.transcript`, same shape as the REST endpoint). The
-    /// live chat connection carries the read on its own encrypted channel;
-    /// before one exists, a short-lived relay connection serves it (the
-    /// router permits one device socket, so never both at once).
+    /// live chat connection carries the read on its own lease channel;
+    /// before one exists, the pool's default channel serves it.
     private func relayTranscriptMessages(
         transcriptID: String,
         limit: Int,
@@ -822,8 +820,8 @@ struct ChatView: View {
             let fetchedOlder: [TranscriptMessage]
             var relayPage: RelayTranscriptPage?
             if isRelay {
-                // Backfill only rides the live chat connection; a standalone
-                // socket would supersede it (one device socket per install).
+                // Backfill only rides the live chat connection, which owns
+                // this session's lease and its recovery cursor.
                 guard let live = connection else { return }
                 let page = try await relayTranscriptMessages(
                     transcriptID: transcriptID,
@@ -931,12 +929,13 @@ struct ChatView: View {
             let candidate: ChatConnection
             if let relayTarget = appModel.activeRelayTarget {
                 // Relay mode: same Hermes JSON-RPC contract through the
-                // E2EE channel. The router permits one device socket per
-                // installation, so while this chat is open it owns the app's
-                // only relay connection (list refreshes pause while a chat
-                // is visible).
+                // E2EE channel. Each chat owns its own lease channel on the
+                // host, so several sessions can be open at once and list
+                // refreshes keep using the default channel.
                 candidate = try await RelayConnectionPool.shared.acquire(
-                    target: relayTarget, profile: appModel.activeProfile
+                    target: relayTarget,
+                    profile: appModel.activeProfile,
+                    channel: RelayAdmissionEnvelope.channelForSession(durableID ?? sessionID)
                 )
             } else {
                 guard let origin = appModel.serverOrigin else { return false }

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -1930,7 +1930,9 @@ struct ChatView: View {
             }
 
         case .approvalExpire, .clarifyExpire:
-            if pendingRequest != nil { pendingRequest = nil }
+            // The reducer clears only an exact kind + request-id match; a
+            // stale or unrelated expiry must not dismiss a newer prompt.
+            if transcript.pendingRequest == nil, pendingRequest != nil { pendingRequest = nil }
 
         case .sessionTitle:
             if let adopted = transcript.adoptedTitle {

--- a/ios/Mercury/Views/ComposerBar.swift
+++ b/ios/Mercury/Views/ComposerBar.swift
@@ -132,7 +132,7 @@ struct ComposerBar: View {
             }
             .padding(6)
             .background(
-                Color.composerSurface,
+                Color.surfaceMid,
                 in: RoundedRectangle(cornerRadius: 30, style: .continuous)
             )
 
@@ -218,7 +218,7 @@ struct ComposerBar: View {
         } label: {
             Image(systemName: "plus")
                 .font(.title3)
-                .foregroundStyle(Color.composerSecondaryContent)
+                .foregroundStyle(Color.secondaryContent)
                 .frame(width: 44, height: 44)
         }
         .accessibilityLabel("Attach files")
@@ -398,12 +398,12 @@ struct ComposerBar: View {
 
     private var primaryActionBackground: Color {
         guard primaryActionEnabled else { return Color.white.opacity(0.10) }
-        return showStop ? .composerActive : .composerPrimary
+        return showStop ? .statusActive : .accentPrimary
     }
 
     private var primaryActionForeground: Color {
         guard primaryActionEnabled else { return Color.white.opacity(0.38) }
-        return showStop ? .composerOnActive : .composerOnPrimary
+        return showStop ? .onStatusActive : .onAccentPrimary
     }
 
     private var dictationStatePublisher: AnyPublisher<DictationState, Never> {

--- a/ios/Mercury/Views/ConnectView.swift
+++ b/ios/Mercury/Views/ConnectView.swift
@@ -388,3 +388,9 @@ struct ConnectView: View {
         .environment(AppModel())
         .preferredColorScheme(.dark)
 }
+
+#Preview("Light") {
+    ConnectView()
+        .environment(AppModel())
+        .preferredColorScheme(.light)
+}

--- a/ios/Mercury/Views/ConnectView.swift
+++ b/ios/Mercury/Views/ConnectView.swift
@@ -229,8 +229,8 @@ struct ConnectView: View {
                     } label: {
                         HStack {
                             VStack(alignment: .leading, spacing: 2) {
-                                Text(agent.name).fontWeight(.semibold)
-                                Text(agent.gatewayState ?? agent.status)
+                                Text(agent.displayLabel).fontWeight(.semibold)
+                                Text("\(agent.name) · \(agent.gatewayState ?? agent.status)")
                                     .font(.caption)
                                     .foregroundStyle(Color.secondary)
                             }

--- a/ios/Mercury/Views/ConnectView.swift
+++ b/ios/Mercury/Views/ConnectView.swift
@@ -340,24 +340,24 @@ struct ConnectView: View {
                         }
                     }
                 }
-                .confirmationDialog(
-                    "Remove this relay pairing from this phone?",
-                    isPresented: Binding(
-                        get: { relayPendingRemoval != nil },
-                        set: { if !$0 { relayPendingRemoval = nil } }
-                    ),
-                    titleVisibility: .visible,
-                    presenting: relayPendingRemoval
-                ) { target in
-                    Button("Remove \(target.displayLabel)", role: .destructive) {
-                        Task {
-                            if appModel.activeRelayTarget?.id == target.id { appModel.disconnect() }
-                            await relay.removeTarget(target)
-                        }
+            }
+            .confirmationDialog(
+                "Remove this relay pairing from this phone?",
+                isPresented: Binding(
+                    get: { relayPendingRemoval != nil },
+                    set: { if !$0 { relayPendingRemoval = nil } }
+                ),
+                titleVisibility: .visible,
+                presenting: relayPendingRemoval
+            ) { target in
+                Button("Remove \(target.displayLabel)", role: .destructive) {
+                    Task {
+                        if appModel.activeRelayTarget?.id == target.id { appModel.disconnect() }
+                        await relay.removeTarget(target)
                     }
-                } message: { _ in
-                    Text("The host still lists this device until you revoke it there. You can pair again with a new QR code.")
                 }
+            } message: { _ in
+                Text("The host still lists this device until you revoke it there. You can pair again with a new QR code.")
             }
         }
 

--- a/ios/Mercury/Views/ConnectView.swift
+++ b/ios/Mercury/Views/ConnectView.swift
@@ -290,31 +290,35 @@ struct ConnectView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Paired hosts").font(.headline)
                 ForEach(relay.targets) { target in
-                    Button {
-                        if target.status == .approved {
-                            Task { await appModel.connectRelay(target) }
-                        } else {
-                            showRelayPairing = true
-                        }
-                    } label: {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(target.displayLabel).fontWeight(.semibold)
-                                Text(
-                                    target.status == .approved
-                                        ? "Approved"
-                                        : "Waiting for host approval"
-                                )
-                                .font(.caption)
-                                .foregroundStyle(Color.secondary)
+                    // Two sibling buttons: the row connects, the trash removes.
+                    // A button nested inside the row's label would lose every
+                    // tap to the row.
+                    HStack(spacing: 8) {
+                        Button {
+                            if target.status == .approved {
+                                Task { await appModel.connectRelay(target) }
+                            } else {
+                                showRelayPairing = true
                             }
-                            Spacer()
-                            Image(systemName: "chevron.right")
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(target.displayLabel).fontWeight(.semibold)
+                                    Text(
+                                        target.status == .approved
+                                            ? "Approved"
+                                            : "Waiting for host approval"
+                                    )
+                                    .font(.caption)
+                                    .foregroundStyle(Color.secondary)
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                            }
+                            .frame(maxWidth: .infinity)
                         }
-                        .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.bordered)
-                    .overlay(alignment: .trailing) {
+                        .buttonStyle(.bordered)
+
                         // Visible removal, like Android's RelayConnectPanel trash
                         // icon. Local removal only: revoking the device record
                         // stays a host/dashboard management action.
@@ -324,9 +328,8 @@ struct ConnectView: View {
                             Image(systemName: "trash")
                                 .frame(width: 44, height: 44)
                         }
-                        .buttonStyle(.plain)
-                        .foregroundStyle(Color.statusAlert)
-                        .padding(.trailing, 36)
+                        .buttonStyle(.bordered)
+                        .tint(Color.statusAlert)
                         .accessibilityLabel("Remove relay \(target.displayLabel)")
                     }
                     .contextMenu {

--- a/ios/Mercury/Views/ConnectView.swift
+++ b/ios/Mercury/Views/ConnectView.swift
@@ -355,7 +355,8 @@ struct ConnectView: View {
         guard canContinue else { return }
         validationError = nil
         guard let canonical = ServerOrigin.normalize(originText, useTls: useTls) else {
-            validationError = "That doesn't look like a server address. Try something like hermes.example.com or 192.168.1.20:8080."
+            validationError = ServerOrigin.validationFailure(originText, useTls: useTls)
+                ?? "That doesn't look like a server address. Try something like hermes.example.com or 192.168.1.20:8080."
             return
         }
         Task { await appModel.probeSelfHosted(origin: canonical) }

--- a/ios/Mercury/Views/ConnectView.swift
+++ b/ios/Mercury/Views/ConnectView.swift
@@ -331,6 +331,29 @@ struct ConnectView: View {
                         .buttonStyle(.bordered)
                         .tint(Color.statusAlert)
                         .accessibilityLabel("Remove relay \(target.displayLabel)")
+                        // Presented from this row's own button so the sheet
+                        // anchors to it; bound to this row's id so no other row
+                        // ever presents for the same state.
+                        .confirmationDialog(
+                            "Remove \(target.displayLabel) from this phone?",
+                            isPresented: Binding(
+                                get: { relayPendingRemoval?.id == target.id },
+                                set: { if !$0, relayPendingRemoval?.id == target.id { relayPendingRemoval = nil } }
+                            ),
+                            titleVisibility: .visible
+                        ) {
+                            Button("Remove pairing", role: .destructive) {
+                                Task {
+                                    if appModel.activeRelayTarget?.id == target.id
+                                        || appModel.selectedRelayTarget?.id == target.id {
+                                        appModel.disconnect()
+                                    }
+                                    await relay.removeTarget(target)
+                                }
+                            }
+                        } message: {
+                            Text("The host still lists this device until you revoke it there. You can pair again with a new QR code.")
+                        }
                     }
                     .contextMenu {
                         Button(role: .destructive) {
@@ -340,24 +363,6 @@ struct ConnectView: View {
                         }
                     }
                 }
-            }
-            .confirmationDialog(
-                "Remove this relay pairing from this phone?",
-                isPresented: Binding(
-                    get: { relayPendingRemoval != nil },
-                    set: { if !$0 { relayPendingRemoval = nil } }
-                ),
-                titleVisibility: .visible,
-                presenting: relayPendingRemoval
-            ) { target in
-                Button("Remove \(target.displayLabel)", role: .destructive) {
-                    Task {
-                        if appModel.activeRelayTarget?.id == target.id { appModel.disconnect() }
-                        await relay.removeTarget(target)
-                    }
-                }
-            } message: { _ in
-                Text("The host still lists this device until you revoke it there. You can pair again with a new QR code.")
             }
         }
 

--- a/ios/Mercury/Views/ConnectView.swift
+++ b/ios/Mercury/Views/ConnectView.swift
@@ -14,6 +14,7 @@ struct ConnectView: View {
     @State private var validationError: String?
     @State private var showSavedServers = false
     @State private var relay = RelayAppModel()
+    @State private var relayPendingRemoval: RelayPairedTarget?
     @State private var showRelayPairing = false
     /// Error banner text injected when arriving via `.failed(_)` phase.
     private let bannerMessage: String?
@@ -313,15 +314,46 @@ struct ConnectView: View {
                         .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.bordered)
+                    .overlay(alignment: .trailing) {
+                        // Visible removal, like Android's RelayConnectPanel trash
+                        // icon. Local removal only: revoking the device record
+                        // stays a host/dashboard management action.
+                        Button(role: .destructive) {
+                            relayPendingRemoval = target
+                        } label: {
+                            Image(systemName: "trash")
+                                .frame(width: 44, height: 44)
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(Color.statusAlert)
+                        .padding(.trailing, 36)
+                        .accessibilityLabel("Remove relay \(target.displayLabel)")
+                    }
                     .contextMenu {
                         Button(role: .destructive) {
-                            Task { await relay.removeTarget(target) }
+                            relayPendingRemoval = target
                         } label: {
-                            // Local removal only: revoking the device record
-                            // stays a host/dashboard management action.
                             Label("Remove from this device", systemImage: "trash")
                         }
                     }
+                }
+                .confirmationDialog(
+                    "Remove this relay pairing from this phone?",
+                    isPresented: Binding(
+                        get: { relayPendingRemoval != nil },
+                        set: { if !$0 { relayPendingRemoval = nil } }
+                    ),
+                    titleVisibility: .visible,
+                    presenting: relayPendingRemoval
+                ) { target in
+                    Button("Remove \(target.displayLabel)", role: .destructive) {
+                        Task {
+                            if appModel.activeRelayTarget?.id == target.id { appModel.disconnect() }
+                            await relay.removeTarget(target)
+                        }
+                    }
+                } message: { _ in
+                    Text("The host still lists this device until you revoke it there. You can pair again with a new QR code.")
                 }
             }
         }

--- a/ios/Mercury/Views/CronPanel.swift
+++ b/ios/Mercury/Views/CronPanel.swift
@@ -59,7 +59,7 @@ struct CronPanel: View {
                 Spacer()
                 Text(job.displayStatus)
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(job.requiresAttention ? Color.red : Color.secondary)
+                    .foregroundStyle(job.requiresAttention ? Color.statusAlert : Color.secondary)
             }
             Text(job.schedule).font(.subheadline.monospaced()).foregroundStyle(.secondary)
             detail("Next run", job.nextRunAt)

--- a/ios/Mercury/Views/ModelPickerSheet.swift
+++ b/ios/Mercury/Views/ModelPickerSheet.swift
@@ -184,7 +184,7 @@ struct ModelPickerSheet: View {
                 Text(provider.name)
                     .font(.subheadline.weight(.semibold))
             }
-            .foregroundStyle(selected ? Color.amoledBlack : Color.primary)
+            .foregroundStyle(selected ? Color.canvas : Color.primary)
             .padding(.horizontal, 13)
             .frame(minHeight: 36)
             .background(selected ? Color.accentPrimary : Color.surfaceMid, in: Capsule())

--- a/ios/Mercury/Views/RootView.swift
+++ b/ios/Mercury/Views/RootView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// Top-level routing over the connection lifecycle.
 struct RootView: View {
     @Environment(AppModel.self) private var appModel: AppModel
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var splitSelection: HomeChatDestination?
 
     var body: some View {
         Group {
@@ -12,16 +14,50 @@ struct RootView: View {
             case .signInRequired:
                 SignInView()
             case .connected:
-                SessionListView()
+                home
             case .failed(let message):
                 if appModel.sessions.isEmpty {
                     ConnectView(errorMessage: message)
                 } else {
-                    SessionListView()
+                    home
                 }
             }
         }
         .amoledScreen()
+    }
+
+    /// Compact widths keep the single home stack. Regular widths (iPad, large
+    /// phones in landscape) use a native split view: the home list is the
+    /// sidebar and the selected chat is the detail column, the same
+    /// destinations Android's list/detail layout shows side by side.
+    @ViewBuilder
+    private var home: some View {
+        if horizontalSizeClass == .regular {
+            NavigationSplitView {
+                SessionListView(splitSelection: $splitSelection)
+            } detail: {
+                if let selection = splitSelection {
+                    NavigationStack {
+                        if selection.isNewSession {
+                            ChatView.newSession()
+                        } else {
+                            ChatView(sessionID: selection.sessionID, title: selection.title)
+                        }
+                    }
+                    .id(selection)
+                } else {
+                    ContentUnavailableView(
+                        "Select a session",
+                        systemImage: "bubble.left.and.bubble.right",
+                        description: Text("Pick a project or a recent session to open it here.")
+                    )
+                    .amoledScreen()
+                }
+            }
+            .navigationSplitViewStyle(.balanced)
+        } else {
+            SessionListView()
+        }
     }
 }
 

--- a/ios/Mercury/Views/RootView.swift
+++ b/ios/Mercury/Views/RootView.swift
@@ -30,3 +30,9 @@ struct RootView: View {
         .environment(AppModel())
         .preferredColorScheme(.dark)
 }
+
+#Preview("Light") {
+    RootView()
+        .environment(AppModel())
+        .preferredColorScheme(.light)
+}

--- a/ios/Mercury/Views/ServerListView.swift
+++ b/ios/Mercury/Views/ServerListView.swift
@@ -36,12 +36,10 @@ struct ServerListView: View {
                                 Text(entry.displayLabel)
                                     .font(.headline)
                                     .foregroundStyle(Color.primary)
-                                if !entry.label.isEmpty {
-                                    Text(entry.origin)
-                                        .font(.caption.monospaced())
-                                        .foregroundStyle(Color.secondary)
-                                        .lineLimit(1)
-                                }
+                                Text(entry.origin)
+                                    .font(.caption.monospaced())
+                                    .foregroundStyle(Color.secondary)
+                                    .lineLimit(1)
                             }
                             Spacer()
                         }

--- a/ios/Mercury/Views/SessionListView.swift
+++ b/ios/Mercury/Views/SessionListView.swift
@@ -7,8 +7,30 @@ import SwiftUI
 /// M3 additions: profile switcher menu, new-session button, swipe/context
 /// row actions (pin / archive / rename / delete), and infinite-scroll
 /// pagination driven by the AppModel's paged-session API.
+/// A chat the home list wants shown. On compact widths it is pushed onto the
+/// home navigation stack; on regular widths (iPad) it becomes the detail
+/// column of the split view (Android list/detail parity with native columns).
+struct HomeChatDestination: Hashable {
+    let sessionID: String
+    let title: String
+    var isNewSession = false
+}
+
 struct SessionListView: View {
     @Environment(AppModel.self) private var appModel: AppModel
+    /// Non-nil when hosted as the sidebar of a split view: chats route here
+    /// instead of pushing onto the sidebar column.
+    private let splitSelection: Binding<HomeChatDestination?>?
+
+    init(splitSelection: Binding<HomeChatDestination?>? = nil) {
+        self.splitSelection = splitSelection
+    }
+
+    private var usesSplit: Bool { splitSelection != nil }
+
+    private func routeToDetail(_ destination: HomeChatDestination) {
+        splitSelection?.wrappedValue = destination
+    }
 
     // Programmatic push of a brand-new chat session ("+" toolbar button).
     @State private var showNewSession = false
@@ -83,6 +105,15 @@ struct SessionListView: View {
         )
     }
 
+    /// Android Home "Running subagents" parity, from what this phone has
+    /// observed in opened sessions (not a host-wide delegation query).
+    private var observedRunningSubagents: [BackgroundTaskRow] {
+        appModel.backgroundTasksBySession.values
+            .flatMap(\.rows)
+            .filter { !$0.terminal }
+            .sorted { $0.observedAtMillis > $1.observedAtMillis }
+    }
+
     private var homeSessions: [SessionRow] {
         HomeInboxPolicy.recentSessionPreview(appModel.sessions)
     }
@@ -99,9 +130,7 @@ struct SessionListView: View {
                                 .foregroundStyle(Color.secondary)
                         } else {
                             ForEach(mergedSearchResults) { result in
-                                NavigationLink {
-                                    ChatView(sessionID: result.sessionID, title: result.title)
-                                } label: {
+                                homeChatLink(HomeChatDestination(sessionID: result.sessionID, title: result.title)) {
                                     VStack(alignment: .leading, spacing: 4) {
                                         Text(result.title)
                                             .font(.headline)
@@ -124,6 +153,29 @@ struct SessionListView: View {
                         Label(error, systemImage: "exclamationmark.triangle.fill")
                             .font(.footnote)
                             .foregroundStyle(Color.statusAlert)
+                    }
+                }
+
+                if !observedRunningSubagents.isEmpty {
+                    Section {
+                        ForEach(observedRunningSubagents) { row in
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(row.goal)
+                                    .font(.subheadline.weight(.semibold))
+                                    .lineLimit(2)
+                                Text(row.action ?? "running")
+                                    .font(.caption)
+                                    .foregroundStyle(Color.secondary)
+                                    .lineLimit(1)
+                            }
+                            .listRowBackground(Color.accentContainer.opacity(0.3))
+                            .accessibilityElement(children: .combine)
+                            .accessibilityLabel("Running subagent: \(row.goal), \(row.action ?? "running")")
+                        }
+                    } header: {
+                        Text("Running subagents")
+                    } footer: {
+                        Text("Observed from sessions opened on this phone.")
                     }
                 }
 
@@ -168,11 +220,7 @@ struct SessionListView: View {
                             .listRowSeparator(.hidden)
                     }
                     ForEach(homeSessions) { session in
-                        NavigationLink {
-                            ChatView(sessionID: session.id, title: session.title)
-                                .onAppear { projectController.setVisibleSession(session.id) }
-                                .onDisappear { projectController.setVisibleSession(nil) }
-                        } label: {
+                        homeChatLink(HomeChatDestination(sessionID: session.id, title: session.title)) {
                             sessionRow(session)
                         }
                         .buttonStyle(.plain)
@@ -246,7 +294,13 @@ struct SessionListView: View {
             .overlay(alignment: .bottomTrailing) {
                 // Android SessionListScreen floatingActionButton parity: the
                 // amber 48pt rounded-square "New task" FAB, bottom-trailing.
-                NewTaskFloatingButton { showNewSession = true }
+                NewTaskFloatingButton {
+                    if usesSplit {
+                        routeToDetail(HomeChatDestination(sessionID: UUID().uuidString, title: "New chat", isNewSession: true))
+                    } else {
+                        showNewSession = true
+                    }
+                }
             }
             .navigationTitle("Mercury")
             .navigationBarTitleDisplayMode(.inline)
@@ -587,6 +641,26 @@ struct SessionListView: View {
         }
         Task {
             await appModel.updateSession(id: session.id, pinned: shouldPin)
+        }
+    }
+
+    /// Compact: push the chat onto this stack. Regular (split view): select it
+    /// as the detail column instead.
+    @ViewBuilder
+    private func homeChatLink<Label: View>(
+        _ destination: HomeChatDestination,
+        @ViewBuilder label: () -> Label
+    ) -> some View {
+        if usesSplit {
+            Button { routeToDetail(destination) } label: { label() }
+        } else {
+            NavigationLink {
+                ChatView(sessionID: destination.sessionID, title: destination.title)
+                    .onAppear { projectController.setVisibleSession(destination.sessionID) }
+                    .onDisappear { projectController.setVisibleSession(nil) }
+            } label: {
+                label()
+            }
         }
     }
 

--- a/ios/Mercury/Views/SessionListView.swift
+++ b/ios/Mercury/Views/SessionListView.swift
@@ -689,3 +689,9 @@ private struct AllSessionsView: View {
         .environment(AppModel())
         .preferredColorScheme(.dark)
 }
+
+#Preview("Light") {
+    SessionListView()
+        .environment(AppModel())
+        .preferredColorScheme(.light)
+}

--- a/ios/Mercury/Views/SessionStatusViews.swift
+++ b/ios/Mercury/Views/SessionStatusViews.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// Android SessionDetail parity: the context ring in the session toolbar and
+/// the run status pill. These explain observed activity only; whether the
+/// user may interrupt is decided by controller authority, never by these.
+struct ContextRingButton: View {
+    let percent: Double?
+    let artifactCount: Int
+    let action: () -> Void
+
+    private var fraction: Double? { percent.map { min(max($0 / 100, 0), 1) } }
+
+    private var ringColor: Color {
+        guard let fraction else { return Color.secondaryContent }
+        if fraction >= 0.9 { return Color.statusAlert }
+        if fraction >= 0.75 { return Color.statusActive }
+        return Color.accentPrimary
+    }
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Circle()
+                    .stroke(Color.surfaceHighest, lineWidth: 3)
+                Circle()
+                    .trim(from: 0, to: fraction ?? 0)
+                    .stroke(ringColor, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                Text(percent.map { String(Int(min(max($0, 0), 99))) } ?? "–")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundStyle(Color.primary)
+            }
+            .frame(width: 30, height: 30)
+        }
+        .accessibilityLabel("Open session details")
+        .accessibilityValue(
+            (percent.map { "Context \(Int($0)) percent used" } ?? "Context usage unknown")
+                + ", " + (artifactCount == 1 ? "1 artifact" : "\(artifactCount) artifacts")
+        )
+    }
+}
+
+struct RunStatusPill: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+                .tint(Color.onAccentContainer)
+            Text(text)
+                .font(.caption)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .foregroundStyle(Color.onAccentContainer)
+        .background(Color.accentContainer, in: Capsule())
+        .accessibilityLabel("Current status: \(text)")
+    }
+}

--- a/ios/Mercury/Views/SettingsView.swift
+++ b/ios/Mercury/Views/SettingsView.swift
@@ -63,7 +63,7 @@ struct SettingsView: View {
                     }
                 }
 
-                if let target = appModel.activeRelayTarget {
+                if let target = appModel.activeRelayTarget ?? appModel.selectedRelayTarget {
                     Section {
                         Button {
                             appModel.disconnect()

--- a/ios/Mercury/Views/SettingsView.swift
+++ b/ios/Mercury/Views/SettingsView.swift
@@ -9,6 +9,8 @@ import ActivityKit
 struct SettingsView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(\.dismiss) private var dismiss
+    @State private var relay = RelayAppModel()
+    @State private var confirmRemoveRelay = false
 
     var body: some View {
         NavigationStack {
@@ -61,18 +63,47 @@ struct SettingsView: View {
                     }
                 }
 
-                Section {
-                    Button(role: .destructive) {
-                        Task { await appModel.signOut() }
-                    } label: {
-                        Label("Sign out of this server", systemImage: "rectangle.portrait.and.arrow.right")
+                if let target = appModel.activeRelayTarget {
+                    Section {
+                        Button {
+                            appModel.disconnect()
+                            dismiss()
+                        } label: {
+                            Label("Disconnect from this relay", systemImage: "antenna.radiowaves.left.and.right.slash")
+                        }
+                        Button(role: .destructive) {
+                            confirmRemoveRelay = true
+                        } label: {
+                            Label("Remove this pairing from this phone", systemImage: "trash")
+                        }
+                    } header: {
+                        Text("Mercury Relay — \(target.displayLabel)")
+                    } footer: {
+                        Text("Disconnecting returns you to the connect screen and keeps the pairing. Removing deletes this phone's key for the host; the host still lists the device until you revoke it there.")
                     }
-                } header: {
-                    Text(
-                        appModel.serverOrigin
-                            ?? appModel.activeRelayTarget.map { "Mercury Relay — \($0.displayLabel)" }
-                            ?? "Not connected"
-                    )
+                    .confirmationDialog(
+                        "Remove the pairing with \(target.displayLabel)?",
+                        isPresented: $confirmRemoveRelay,
+                        titleVisibility: .visible
+                    ) {
+                        Button("Remove pairing", role: .destructive) {
+                            Task {
+                                appModel.disconnect()
+                                await relay.removeTarget(target)
+                                dismiss()
+                            }
+                        }
+                    }
+                } else {
+                    Section {
+                        Button(role: .destructive) {
+                            Task { await appModel.signOut() }
+                        } label: {
+                            Label("Sign out of this server", systemImage: "rectangle.portrait.and.arrow.right")
+                        }
+                    } header: {
+                        Text(appModel.serverOrigin ?? "Not connected")
+                    }
                 }
             }
             .scrollContentBackground(.hidden)

--- a/ios/Mercury/Views/SignInView.swift
+++ b/ios/Mercury/Views/SignInView.swift
@@ -171,3 +171,9 @@ struct SignInView: View {
         .environment(AppModel())
         .preferredColorScheme(.dark)
 }
+
+#Preview("Light") {
+    SignInView()
+        .environment(AppModel())
+        .preferredColorScheme(.light)
+}

--- a/ios/Mercury/Voice/DictationViews.swift
+++ b/ios/Mercury/Voice/DictationViews.swift
@@ -13,14 +13,14 @@ struct DictationButton: View {
                 case .requestingPermission:
                     ProgressView()
                         .controlSize(.small)
-                        .tint(Color.composerPrimary)
+                        .tint(Color.accentPrimary)
                 case .recording:
                     Image(systemName: "stop.fill")
-                        .foregroundStyle(Color.composerPrimary)
+                        .foregroundStyle(Color.accentPrimary)
                 case .idle, .failed:
                     Image(systemName: "mic.fill")
                         .foregroundStyle(
-                            enabled ? Color.composerSecondaryContent : Color.white.opacity(0.38)
+                            enabled ? Color.secondaryContent : Color.white.opacity(0.38)
                         )
                 }
             }

--- a/ios/Mercury/Voice/SpeechSynthesisClient.swift
+++ b/ios/Mercury/Voice/SpeechSynthesisClient.swift
@@ -142,7 +142,7 @@ struct RESTSpeechSynthesizer: SpeechSynthesizing {
         self.transport = transport
     }
 
-    init(origin: URL, accessToken: String, profile: String, session: URLSession = .shared) {
+    init(origin: URL, accessToken: String, profile: String, session: URLSession = HermesURLSession.noRedirects) {
         self.init(origin: origin, accessToken: accessToken, profile: profile) { request in
             do {
                 let (data, response) = try await session.data(for: request)

--- a/ios/MercuryTests/NetworkingTests.swift
+++ b/ios/MercuryTests/NetworkingTests.swift
@@ -31,6 +31,15 @@ final class MockURLProtocol: URLProtocol {
         }
         do {
             let (response, data) = try handler(request)
+            // Simulate a real redirect: hand the session the new request so
+            // its redirect policy (delegate) decides whether to follow.
+            if (300...399).contains(response.statusCode),
+               let location = response.value(forHTTPHeaderField: "Location"),
+               let target = URL(string: location, relativeTo: request.url) {
+                var redirected = request
+                redirected.url = target.absoluteURL
+                client?.urlProtocol(self, wasRedirectedTo: redirected, redirectResponse: response)
+            }
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             client?.urlProtocol(self, didLoad: data)
             // URLProtocol does not persist Set-Cookie into HTTPCookieStorage on
@@ -80,7 +89,7 @@ final class NetworkingTests: XCTestCase {
         config.protocolClasses = [MockURLProtocol.self]
         config.httpCookieStorage = HTTPCookieStorage.shared
         config.httpShouldSetCookies = true
-        return HermesHTTPClient(origin: origin, session: URLSession(configuration: config))
+        return HermesHTTPClient(origin: origin, session: HermesURLSession.make(config))
     }
 
     private func makeProbe(origin: String = "https://hermes.test") -> StatusProbe {
@@ -99,6 +108,44 @@ final class NetworkingTests: XCTestCase {
     }
 
     // MARK: - Tests
+
+    /// Redirects are never followed (Android `followRedirects = false`
+    /// parity): a bearer token scoped to the configured origin must not be
+    /// forwarded to another host. The 3xx surfaces to the caller as-is.
+    func testHermesSessionRefusesCrossOriginRedirect() async throws {
+        MockURLProtocol.handler = { request in
+            if request.url?.host == "hermes.test" {
+                return self.response(
+                    302, headers: ["Location": "https://evil.test/steal"], for: request
+                )
+            }
+            return self.response(200, for: request)
+        }
+        let client = makeClient()
+        client.bearerToken = "secret-token"
+        let (_, http) = try await client.get(path: "/api/status")
+        XCTAssertEqual(http.statusCode, 302)
+        XCTAssertEqual(MockURLProtocol.receivedRequests.map { $0.url?.host }, ["hermes.test"])
+    }
+
+    /// Control for the test above: the mock really does redirect when the
+    /// session has no refusing delegate, so the assertion is meaningful.
+    func testControlPlainSessionFollowsTheSameRedirect() async throws {
+        MockURLProtocol.handler = { request in
+            if request.url?.host == "hermes.test" {
+                return self.response(
+                    302, headers: ["Location": "https://evil.test/steal"], for: request
+                )
+            }
+            return self.response(200, for: request)
+        }
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let client = HermesHTTPClient(origin: "https://hermes.test", session: URLSession(configuration: config))
+        let (_, http) = try await client.get(path: "/api/status")
+        XCTAssertEqual(http.statusCode, 200)
+        XCTAssertEqual(MockURLProtocol.receivedRequests.map { $0.url?.host }, ["hermes.test", "evil.test"])
+    }
 
     func testBearerTokenIsSentWhenSet() async throws {
         MockURLProtocol.handler = { request in

--- a/ios/MercuryTests/RelayPairingTests.swift
+++ b/ios/MercuryTests/RelayPairingTests.swift
@@ -10,6 +10,8 @@ final class FakeRelaySocket: RelayBinarySocketing, @unchecked Sendable {
     private var inbound: AsyncStream<Data>.AsyncIterator
     private let outbound: AsyncStream<Data>.Continuation
     private(set) var closed = false
+    /// Simulates the router's close code (for example 4004 no-host).
+    var closeCodeOverride: Int?
 
     fileprivate init(
         inbound: AsyncStream<Data>.AsyncIterator,
@@ -32,7 +34,7 @@ final class FakeRelaySocket: RelayBinarySocketing, @unchecked Sendable {
         outbound.finish()
     }
 
-    func lastCloseCode() -> Int? { nil }
+    func lastCloseCode() -> Int? { closeCodeOverride }
     func lastErrorDetail() -> String? { nil }
 }
 

--- a/ios/MercuryTests/RelayProbeTeardownTests.swift
+++ b/ios/MercuryTests/RelayProbeTeardownTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import Mercury
+
+/// The router allows one device socket per installation, so an approval
+/// probe must have finished closing its socket before `probeApproval`
+/// returns, on every exit path. A caller that opens the chat right after a
+/// probe must not race a socket that is still being torn down.
+final class RelayProbeTeardownTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_756_400_000)
+
+    private func makeTarget() -> RelayPairedTarget {
+        RelayPairedTarget(
+            id: UUID(),
+            label: "study",
+            relayOrigin: "https://relay.example.com",
+            installationID: TestRelayHost.installationID,
+            hostPublicKey: TestRelayHost.hostStaticPublicKey,
+            deviceID: RelayBase64.urlSafeEncode(Data((0..<16).map { UInt8($0 &+ 3) })),
+            deviceStaticPrivateKey: Data(repeating: 0x51, count: 32),
+            fingerprint: String(repeating: "b", count: 16),
+            status: .pending,
+            createdAtEpochSeconds: 1,
+            lastUsedEpochSeconds: nil
+        )
+    }
+
+    private struct AdmittedHost {
+        let channel: RelaySecureChannel
+        let reassembler: RelayFrameReassembler
+        let channelID: Data
+    }
+
+    /// Host side of one admitted connection: full XK plus the admission
+    /// envelope, leaving a live channel for the probe exchange.
+    private func admit(socket: FakeRelaySocket) async throws -> AdmittedHost {
+        let channel = try TestRelayHost.responderChannel()
+        let firstRaw = try await socket.receive()
+        let first = try XCTUnwrap(firstRaw)
+        _ = try channel.readHandshake(first)
+        try await socket.send(channel.writeHandshake())
+        let thirdRaw = try await socket.receive()
+        let third = try XCTUnwrap(thirdRaw)
+        XCTAssertEqual(try channel.readHandshake(third), Data())
+        let envelopeRaw = try await socket.receive()
+        let envelope = try XCTUnwrap(envelopeRaw)
+        _ = try channel.decrypt(envelope)
+        let channelID = Data(try channel.channelBinding.prefix(RelayFraming.channelIDSize))
+        return AdmittedHost(
+            channel: channel,
+            reassembler: RelayFrameReassembler(channelID: channelID),
+            channelID: channelID
+        )
+    }
+
+    private func receiveText(_ host: AdmittedHost, socket: FakeRelaySocket) async throws -> String {
+        var received: Data?
+        while received == nil {
+            let ciphertextRaw = try await socket.receive()
+            let ciphertext = try XCTUnwrap(ciphertextRaw)
+            received = try host.reassembler.push(try host.channel.decrypt(ciphertext))
+        }
+        return String(decoding: try XCTUnwrap(received), as: UTF8.self)
+    }
+
+    private func sendText(_ text: String, _ host: AdmittedHost, socket: FakeRelaySocket) async throws {
+        for record in try RelayFraming.encodeMessage(
+            channelID: host.channelID,
+            messageID: Data(repeating: 0x21, count: 16),
+            payload: Data(text.utf8)
+        ) {
+            try await socket.send(host.channel.encrypt(record))
+        }
+    }
+
+    /// Runs one probe against a scripted host and asserts the device socket
+    /// is closed by the time `probeApproval` returns. Then proves the next
+    /// connection through the same factory succeeds.
+    private func runProbe(
+        expectApproved: Bool,
+        cancelWhileWaiting: Bool = false,
+        host script: @escaping (AdmittedHost, FakeRelaySocket) async throws -> Void
+    ) async throws {
+        let (device, host) = InMemoryRelayTransport.pair()
+        let (nextDevice, nextHost) = InMemoryRelayTransport.pair()
+        let factory = FakeRelaySocketFactory(sockets: [device, nextDevice])
+        let store = RelayTargetStore(persistence: InMemoryRelayTargetPersistence(), now: { self.now })
+        let target = makeTarget()
+        try await store.add(target)
+        let coordinator = RelayPairingCoordinator(socketFactory: factory, store: store, now: { self.now })
+
+        let hostTask = Task {
+            let admitted = try await self.admit(socket: host)
+            try await script(admitted, host)
+        }
+        let probe = Task { await coordinator.probeApproval(target: target, profile: "default") }
+        if cancelWhileWaiting {
+            // Let the handshake and ping land before cancelling the waiter.
+            try await hostTask.value
+            probe.cancel()
+        }
+        let approved = await probe.value
+        XCTAssertEqual(approved, expectApproved)
+        // The contract under test: close has completed before the return.
+        XCTAssertTrue(device.closed, "probe returned before its socket was closed")
+        if !cancelWhileWaiting { try await hostTask.value }
+
+        let loaded = try await store.load()
+        XCTAssertEqual(loaded.first?.status, expectApproved ? .approved : .pending)
+
+        // The next connection is not superseded by a late close.
+        async let nextAdmitted = admit(socket: nextHost)
+        let connected = try await RelayConnector.connect(
+            target: target, profile: "default", socketFactory: factory
+        )
+        _ = try await nextAdmitted
+        XCTAssertEqual(factory.requestedURLs.count, 2)
+        await RelayChatSocket(connected: connected).close()
+    }
+
+    func testApprovedProbeClosesSocketBeforeReturning() async throws {
+        try await runProbe(expectApproved: true) { admitted, socket in
+            let ping = try await self.receiveText(admitted, socket: socket)
+            XCTAssertTrue(ping.contains("\"gateway.ping\""))
+            try await self.sendText(
+                #"{"jsonrpc":"2.0","id":"pairing-probe","result":{"ok":true}}"#, admitted, socket: socket
+            )
+            // Host observes the device's close as end of stream.
+            let afterClose = try await socket.receive()
+            XCTAssertNil(afterClose)
+        }
+    }
+
+    func testRejectedProbeClosesSocketBeforeReturning() async throws {
+        try await runProbe(expectApproved: false) { admitted, socket in
+            _ = try await self.receiveText(admitted, socket: socket)
+            try await self.sendText(
+                #"{"jsonrpc":"2.0","id":"pairing-probe","error":{"code":-32000,"message":"denied"}}"#,
+                admitted, socket: socket
+            )
+            let afterClose = try await socket.receive()
+            XCTAssertNil(afterClose)
+        }
+    }
+
+    func testEarlyEOFClosesSocketBeforeReturning() async throws {
+        try await runProbe(expectApproved: false) { admitted, socket in
+            _ = try await self.receiveText(admitted, socket: socket)
+            await socket.close()
+        }
+    }
+
+    func testProtocolErrorClosesSocketBeforeReturning() async throws {
+        try await runProbe(expectApproved: false) { admitted, socket in
+            _ = try await self.receiveText(admitted, socket: socket)
+            // Garbage ciphertext: the secure channel fails closed.
+            try await socket.send(Data(repeating: 0xEE, count: 64))
+            let afterClose = try await socket.receive()
+            XCTAssertNil(afterClose)
+        }
+    }
+
+    func testCancellationClosesSocketBeforeReturning() async throws {
+        try await runProbe(expectApproved: false, cancelWhileWaiting: true) { admitted, socket in
+            // Read the ping, then never reply; the test cancels the waiter.
+            _ = try await self.receiveText(admitted, socket: socket)
+        }
+    }
+}

--- a/ios/MercuryTests/RelayTransportTests.swift
+++ b/ios/MercuryTests/RelayTransportTests.swift
@@ -50,7 +50,7 @@ final class RelayTransportTests: XCTestCase {
 
         async let hostSide = admit(socket: host)
         let connected = try await RelayConnector.connect(
-            target: target, profile: "default", resumeCursor: 7, socketFactory: factory
+            target: target, profile: "default", resumeCursor: 7, deviceName: nil, socketFactory: factory
         )
         let admitted = try await hostSide
         XCTAssertEqual(

--- a/ios/MercuryTests/RelayTransportTests.swift
+++ b/ios/MercuryTests/RelayTransportTests.swift
@@ -427,6 +427,56 @@ final class RelayTransportTests: XCTestCase {
         await hostSocket.close()
     }
 
+    /// One phone, several sessions: each named channel gets its own admitted
+    /// socket and lease, and closing one leaves the others untouched.
+    func testPoolHoldsOneConnectionPerLeaseChannel() async throws {
+        let (deviceA, hostA) = InMemoryRelayTransport.pair()
+        let (deviceB, hostB) = InMemoryRelayTransport.pair()
+        let factory = FakeRelaySocketFactory(sockets: [deviceA, deviceB])
+        let pool = RelayConnectionPool(socketFactory: factory)
+        let target = makeTarget()
+
+        func serve(_ socket: FakeRelaySocket, lease: String) -> Task<String?, Error> {
+            Task {
+                let admitted = try await admit(socket: socket)
+                let envelope = try XCTUnwrap(JSONSerialization.jsonObject(with: admitted.envelope) as? [String: Any])
+                try await sendFrame(["jsonrpc": "2.0", "method": "relay.lease.attached", "params": [
+                    "recovery_version": 1, "lease_id": lease, "last_seq": 0,
+                    "resume_cursor": 0, "replay_gap": false, "recovery_reset": false,
+                    "bindings": [], "task_snapshot": []
+                ]], socket: socket, channel: admitted.channel)
+                try await sendFrame(["jsonrpc": "2.0", "method": "relay.lease.replay_complete",
+                                     "params": ["lease_id": lease, "last_seq": 0]],
+                                    socket: socket, channel: admitted.channel)
+                return envelope["channel"] as? String
+            }
+        }
+        let hostASide = serve(hostA, lease: "lease-a")
+        let hostBSide = serve(hostB, lease: "lease-b")
+        let a = try await pool.acquire(target: target, profile: "default", channel: "s-session-a")
+        let b = try await pool.acquire(target: target, profile: "default", channel: "s-session-b")
+        XCTAssertFalse(a === b)
+        XCTAssertEqual(factory.requestedURLs.count, 2)
+        let channelA = try await hostASide.value
+        let channelB = try await hostBSide.value
+        XCTAssertEqual(channelA, "s-session-a")
+        XCTAssertEqual(channelB, "s-session-b")
+
+        // Re-acquiring a channel returns its live connection; no new socket.
+        let again = try await pool.acquire(target: target, profile: "default", channel: "s-session-a")
+        XCTAssertTrue(again === a)
+        XCTAssertEqual(factory.requestedURLs.count, 2)
+
+        // Losing one channel's peer does not touch the other channel.
+        let ended = Task { for await _ in a.start(replayBuffered: false) {} }
+        await hostA.close()
+        await ended.value
+        XCTAssertTrue(a.isClosed)
+        XCTAssertFalse(b.isClosed)
+        await b.close()
+        await hostB.close()
+    }
+
     func testStaleAuxiliaryScopeCannotOpenOrSupersedeSelectedProfile() async throws {
         let factory = FakeRelaySocketFactory(sockets: [])
         let pool = RelayConnectionPool(socketFactory: factory, selectionRequired: true)

--- a/ios/MercuryTests/RelayTransportTests.swift
+++ b/ios/MercuryTests/RelayTransportTests.swift
@@ -497,6 +497,58 @@ final class RelayTransportTests: XCTestCase {
         }
     }
 
+    /// The router's 4004 close means no host is attached, not a refused device.
+    func testRouterNoHostCloseIsDistinctFromHostRefusal() async throws {
+        let (device, host) = InMemoryRelayTransport.pair()
+        device.closeCodeOverride = relayCloseNoHost
+        let factory = FakeRelaySocketFactory(sockets: [device])
+        let hostTask = Task {
+            _ = try? await host.receive()
+            await host.close()
+        }
+        do {
+            _ = try await RelayConnector.connect(
+                target: makeTarget(), profile: "default", socketFactory: factory
+            )
+            XCTFail("expected noHost")
+        } catch {
+            XCTAssertEqual(error as? RelayConnectionError, .noHost)
+        }
+        await hostTask.value
+    }
+
+    /// A router token renewed in the attach preamble reaches the sink once.
+    func testRenewedRoutingTokenFromAttachPreambleReachesTheSink() async throws {
+        let (device, hostSocket) = InMemoryRelayTransport.pair()
+        let pool = RelayConnectionPool(socketFactory: FakeRelaySocketFactory(sockets: [device]))
+        let renewed = RenewedTokens()
+        await pool.setRoutingTokenSink { target, token in await renewed.record(target.id, token) }
+        let target = makeTarget()
+        let host = Task {
+            let admitted = try await admit(socket: hostSocket)
+            try await sendFrame(["jsonrpc": "2.0", "method": "relay.lease.attached", "params": [
+                "recovery_version": 1, "lease_id": "lease", "last_seq": 0, "resume_cursor": 0,
+                "replay_gap": false, "recovery_reset": false, "bindings": [], "task_snapshot": [],
+                "relay_token": "renewed-token-1"
+            ]], socket: hostSocket, channel: admitted.channel)
+            try await sendFrame(["jsonrpc": "2.0", "method": "relay.lease.replay_complete",
+                                 "params": ["lease_id": "lease", "last_seq": 0]],
+                                socket: hostSocket, channel: admitted.channel)
+        }
+        let connection = try await pool.acquire(target: target, profile: "default")
+        try await host.value
+        let seen = await renewed.entries
+        XCTAssertEqual(seen.map(\.0), [target.id])
+        XCTAssertEqual(seen.map(\.1), ["renewed-token-1"])
+        await connection.close()
+        await hostSocket.close()
+    }
+
+    private actor RenewedTokens {
+        var entries: [(UUID, String)] = []
+        func record(_ id: UUID, _ token: String) { entries.append((id, token)) }
+    }
+
     func testUnadmittedDeviceSeesNotAuthorizedOnHostClose() async throws {
         let (device, host) = InMemoryRelayTransport.pair()
         let factory = FakeRelaySocketFactory(sockets: [device])

--- a/ios/MercuryTests/ServerCatalogTests.swift
+++ b/ios/MercuryTests/ServerCatalogTests.swift
@@ -114,4 +114,17 @@ private struct PersistedServerCatalogFixture: Codable {
 
 private extension Array {
     var onlyElement: Element? { count == 1 ? first : nil }
+
+    /// Server rows show the hostname unless the user set a label (Android parity).
+    func testDisplayLabelIsHostnameUnlessLabelled() throws {
+        let plain = try ServerCatalogEntry(id: UUID(), origin: "https://hermes.example.com:8443")
+        XCTAssertEqual(plain.displayLabel, "hermes.example.com")
+        let labelled = try ServerCatalogEntry(id: UUID(), origin: "https://hermes.example.com", label: "Home box")
+        XCTAssertEqual(labelled.displayLabel, "Home box")
+        let agent = CloudAgent(id: "a", name: "Atlas", status: "active",
+                               dashboardURL: "https://atlas.hermes.cloud/dashboard", gatewayState: nil)
+        XCTAssertEqual(agent.displayLabel, "atlas.hermes.cloud")
+        let provisioning = CloudAgent(id: "b", name: "Beacon", status: "provisioning", dashboardURL: nil, gatewayState: nil)
+        XCTAssertEqual(provisioning.displayLabel, "Beacon")
+    }
 }

--- a/ios/MercuryTests/ServerOriginTests.swift
+++ b/ios/MercuryTests/ServerOriginTests.swift
@@ -114,6 +114,20 @@ final class ServerOriginTests: XCTestCase {
         XCTAssertFalse(ServerOrigin.isLoopbackOrPrivate("https://192.169.0.1"))
     }
 
+    // MARK: - validationFailure (shared reason surfaces on iOS)
+
+    func testPublicPlainHTTPIsRejectedWithTheSharedReason() {
+        XCTAssertNil(ServerOrigin.normalize("http://hermes.example.com"))
+        XCTAssertEqual(
+            ServerOrigin.validationFailure("http://hermes.example.com"),
+            "Plain HTTP is allowed only for local or private-network servers"
+        )
+        XCTAssertNil(ServerOrigin.normalize("hermes.example.com", useTls: false))
+        XCTAssertNotNil(ServerOrigin.validationFailure("hermes.example.com", useTls: false))
+        XCTAssertNil(ServerOrigin.validationFailure("192.168.1.20:8080", useTls: false))
+        XCTAssertNil(ServerOrigin.validationFailure("hermes.example.com"))
+    }
+
     // MARK: - allowsCleartextHTTP (cleartext allowed only for private hosts)
 
     func testCleartextAllowedOnlyForPrivateHosts() {

--- a/ios/MercuryTests/TranscriptReducerTests.swift
+++ b/ios/MercuryTests/TranscriptReducerTests.swift
@@ -307,20 +307,31 @@ final class TranscriptReducerTests: XCTestCase {
         XCTAssertEqual(state.pendingRequest, .clarify(clarify))
     }
 
-    /// Any expire clears whichever request is pending — expires are not
-    /// matched by request ID or kind (pre-extraction parity).
-    func testAnyExpireClearsAnyPendingRequest() {
+    /// An expire clears the pending request only on an exact kind and
+    /// request-ID match (Android RunEventModels parity). Stale or unrelated
+    /// expiries must never dismiss a prompt the agent is still blocked on.
+    func testExpireClearsOnlyMatchingKindAndRequestID() {
         var state = makeState()
-        state.apply(ChatEvent.clarifyRequest(
+        let clarify = ChatEvent.clarifyRequest(
             sessionID: "s1", requestID: "c1", question: "?", choices: [], multiSelect: false
-        ))
-        state.apply(ChatEvent.approvalExpire(sessionID: "s1", requestID: "unrelated-id"))
+        )
+        state.apply(clarify)
+        state.apply(ChatEvent.approvalExpire(sessionID: "s1", requestID: "c1"))
+        XCTAssertEqual(state.pendingRequest, .clarify(clarify))
+        state.apply(ChatEvent.clarifyExpire(sessionID: "s1", requestID: "c0"))
+        XCTAssertEqual(state.pendingRequest, .clarify(clarify))
+        state.apply(ChatEvent.clarifyExpire(sessionID: "s1", requestID: "c1"))
         XCTAssertNil(state.pendingRequest)
 
-        state.apply(ChatEvent.approvalRequest(
+        let approval = ChatEvent.approvalRequest(
             sessionID: "s1", requestID: "r2", command: nil, description: nil, choices: ["go"]
-        ))
-        state.apply(ChatEvent.clarifyExpire(sessionID: "s1", requestID: "also-unrelated"))
+        )
+        state.apply(approval)
+        state.apply(ChatEvent.clarifyExpire(sessionID: "s1", requestID: "r2"))
+        XCTAssertEqual(state.pendingRequest, .approval(approval))
+        state.apply(ChatEvent.approvalExpire(sessionID: "s1", requestID: "stale"))
+        XCTAssertEqual(state.pendingRequest, .approval(approval))
+        state.apply(ChatEvent.approvalExpire(sessionID: "s1", requestID: "r2"))
         XCTAssertNil(state.pendingRequest)
     }
 

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/origin/ServerOriginPolicy.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/origin/ServerOriginPolicy.kt
@@ -110,6 +110,14 @@ object ServerOriginPolicy {
         return hostIsLoopbackOrPrivate(host)
     }
 
+    /**
+     * The host to show for an origin or dashboard URL in lists: no scheme, no
+     * port, no path, IPv6 without brackets. Null when the value has no host.
+     * Both apps label server and cloud-agent rows with this so the two lists
+     * read the same; a user-set label always wins over it.
+     */
+    fun displayHost(originOrUrl: String): String? = hostOf(originOrUrl.trim())
+
     /** Cleartext HTTP is acceptable only for loopback, local, or RFC1918 hosts. */
     fun allowsCleartextHttp(origin: String): Boolean =
         origin.startsWith("http://") && isLoopbackOrPrivate(origin)

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/relay/RelayLeaseRecovery.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/relay/RelayLeaseRecovery.kt
@@ -12,6 +12,12 @@ data class RelayLeaseSnapshot(
     val bindings: List<RelayLeaseBinding>,
     val tasks: List<String>,
     val truncated: Boolean,
+    /**
+     * A renewed router admission token delivered inside the authenticated
+     * attach preamble. Clients persist it onto the paired target so the
+     * credential never ages out while the device keeps connecting.
+     */
+    val routingToken: String? = null,
 ) {
     /** Recorded bindings are evidence, not permission to take over another runtime. */
     fun hasLiveBinding(durableId: String, profile: String): Boolean =
@@ -76,8 +82,13 @@ class RelayLeaseRecoveryEngine(private val profile: String) {
             .filter { it.profile == profile }.distinctBy { it.runtimeId }
         val tasks = (p["task_snapshot"] as? JsonArray).orEmpty().take(64)
             .mapNotNull { (it as? JsonObject)?.toString() }
+        val routingToken = p.text("relay_token")?.takeIf { token ->
+            token.isNotEmpty() && token.length <= RelayProtocolPolicy.maxRoutingTokenCharacters &&
+                token.all { it.code in 0x21..0x7e }
+        }
         val attached = RelayLeaseSnapshot(id, last, p.flag("replay_gap") ?: fail(),
-            p.flag("recovery_reset") ?: false, bindings, tasks, p.flag("snapshot_truncated") ?: false)
+            p.flag("recovery_reset") ?: false, bindings, tasks, p.flag("snapshot_truncated") ?: false,
+            routingToken)
         snapshot = attached
         received = cursor
         return attached

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/relay/RelayProtocol.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/relay/RelayProtocol.kt
@@ -25,6 +25,7 @@ object RelayProtocolPolicy {
     const val maxOriginCharacters = 256
     const val maxEnvelopeBytes = 512
     const val maxProfileCharacters = 128
+    const val maxChannelCharacters = 64
     const val maxRoutingTokenCharacters = 1_024
     const val maxExpirySkewSeconds = 900L
     const val fingerprintHexCharacters = 16
@@ -258,6 +259,21 @@ object RelayAdmissionEnvelope {
         profile: String,
         resumeCursor: Long?,
         recoveryVersion: Int?,
+    ): ByteArray = controllerOpen(deviceId, profile, resumeCursor, recoveryVersion, channel = null)
+
+    /**
+     * Names the lease channel. The host keeps one lease per (device, channel),
+     * so a client that opens one channel per session can run several Hermes
+     * sessions at once; null is the legacy default channel and keeps the
+     * one-lease-per-device supersede rule and the exact legacy bytes.
+     */
+    @Throws(RelayProtocolException::class)
+    fun controllerOpen(
+        deviceId: String,
+        profile: String,
+        resumeCursor: Long?,
+        recoveryVersion: Int?,
+        channel: String?,
     ): ByteArray {
         if (recoveryVersion != null && recoveryVersion != 1) invalid()
         if (RelayBase64.urlSafeDecodeExact(deviceId, RelayProtocolPolicy.deviceIdBytes) == null) invalid()
@@ -267,7 +283,10 @@ object RelayAdmissionEnvelope {
             invalid()
         }
         if (resumeCursor != null && resumeCursor < 0) invalid()
-        var envelope = "{\"device_id\":\"$deviceId\",\"profile\":\"$profile\""
+        if (channel != null && !isValidChannel(channel)) invalid()
+        var envelope = "{"
+        if (channel != null) envelope += "\"channel\":\"$channel\","
+        envelope += "\"device_id\":\"$deviceId\",\"profile\":\"$profile\""
         if (resumeCursor != null) envelope += ",\"resume_cursor\":$resumeCursor"
         envelope += ",\"type\":\"controller.open\""
         if (recoveryVersion != null) envelope += ",\"recovery_version\":$recoveryVersion"
@@ -276,6 +295,23 @@ object RelayAdmissionEnvelope {
             if (it.size > RelayProtocolPolicy.maxEnvelopeBytes) invalid()
         }
     }
+
+    /**
+     * The lease channel for one client-side session key (a durable or draft
+     * session id). Deterministic on both platforms so a reconnect reattaches
+     * the same lease: unsupported characters map to "_" and the result is
+     * bounded to the plugin's limit.
+     */
+    fun channelForSession(sessionKey: String): String {
+        val body = sessionKey.map { if (it.isAsciiLetterOrDigit() || it == '-' || it == '_') it else '_' }
+            .joinToString("")
+        return ("s-" + body).take(RelayProtocolPolicy.maxChannelCharacters)
+    }
+
+    /** Channel names: 1..64 of [A-Za-z0-9_-]; the plugin rejects anything else. */
+    fun isValidChannel(channel: String): Boolean =
+        channel.isNotEmpty() && channel.length <= RelayProtocolPolicy.maxChannelCharacters &&
+            channel.all { it.isAsciiLetterOrDigit() || it == '-' || it == '_' }
 
     private fun Char.isAsciiLetterOrDigit(): Boolean =
         this in 'a'..'z' || this in 'A'..'Z' || this in '0'..'9'

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/relay/RelayProtocol.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/relay/RelayProtocol.kt
@@ -26,6 +26,7 @@ object RelayProtocolPolicy {
     const val maxEnvelopeBytes = 512
     const val maxProfileCharacters = 128
     const val maxChannelCharacters = 64
+    const val maxDeviceNameCharacters = 64
     const val maxRoutingTokenCharacters = 1_024
     const val maxExpirySkewSeconds = 900L
     const val fingerprintHexCharacters = 16
@@ -274,6 +275,21 @@ object RelayAdmissionEnvelope {
         resumeCursor: Long?,
         recoveryVersion: Int?,
         channel: String?,
+    ): ByteArray = controllerOpen(deviceId, profile, resumeCursor, recoveryVersion, channel, deviceName = null)
+
+    /**
+     * Also names the device. The host records it against this device's
+     * key (pending or authorized) so the dashboard shows the phone by name;
+     * an unusable name is simply omitted.
+     */
+    @Throws(RelayProtocolException::class)
+    fun controllerOpen(
+        deviceId: String,
+        profile: String,
+        resumeCursor: Long?,
+        recoveryVersion: Int?,
+        channel: String?,
+        deviceName: String?,
     ): ByteArray {
         if (recoveryVersion != null && recoveryVersion != 1) invalid()
         if (RelayBase64.urlSafeDecodeExact(deviceId, RelayProtocolPolicy.deviceIdBytes) == null) invalid()
@@ -284,9 +300,12 @@ object RelayAdmissionEnvelope {
         }
         if (resumeCursor != null && resumeCursor < 0) invalid()
         if (channel != null && !isValidChannel(channel)) invalid()
+        val cleanName = deviceName?.let(::cleanDeviceName)
         var envelope = "{"
         if (channel != null) envelope += "\"channel\":\"$channel\","
-        envelope += "\"device_id\":\"$deviceId\",\"profile\":\"$profile\""
+        envelope += "\"device_id\":\"$deviceId\""
+        if (cleanName != null) envelope += ",\"device_name\":" + Json.encodeToString(JsonPrimitive(cleanName))
+        envelope += ",\"profile\":\"$profile\""
         if (resumeCursor != null) envelope += ",\"resume_cursor\":$resumeCursor"
         envelope += ",\"type\":\"controller.open\""
         if (recoveryVersion != null) envelope += ",\"recovery_version\":$recoveryVersion"
@@ -306,6 +325,13 @@ object RelayAdmissionEnvelope {
         val body = sessionKey.map { if (it.isAsciiLetterOrDigit() || it == '-' || it == '_') it else '_' }
             .joinToString("")
         return ("s-" + body).take(RelayProtocolPolicy.maxChannelCharacters)
+    }
+
+    /** Collapses whitespace, strips control characters, bounds to 64 chars; null when nothing is left. */
+    fun cleanDeviceName(name: String): String? {
+        val collapsed = name.split(' ', '\t', '\n', '\r').filter { it.isNotEmpty() }.joinToString(" ")
+        if (collapsed.any { it.code < 0x20 || it.code == 0x7f }) return null
+        return collapsed.take(RelayProtocolPolicy.maxDeviceNameCharacters).trim().ifEmpty { null }
     }
 
     /** Channel names: 1..64 of [A-Za-z0-9_-]; the plugin rejects anything else. */

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/ChatEventDecoder.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/ChatEventDecoder.kt
@@ -16,6 +16,8 @@ object ChatEventDecoder {
     const val MAX_EVENT_ID_CHARS = 256
     const val MAX_EVENT_NAME_CHARS = 256
     const val MAX_EVENT_TEXT_CHARS = 4_096
+    /** Shown when a terminal `error` event carries a missing or blank message. */
+    const val ERROR_MESSAGE_FALLBACK = "Hermes reported an error"
     const val MAX_MESSAGE_TEXT_CHARS = 1024 * 1024
     const val MAX_EVENT_CONTEXT_CHARS = 4_096
     const val MAX_EVENT_CHOICE_CHARS = 256
@@ -85,8 +87,12 @@ object ChatEventDecoder {
                 title = payload.boundedOptional("title", MAX_EVENT_NAME_CHARS),
                 running = payload.booleanValue("running"),
             )
-            "error" -> payload.boundedOptional("message", MAX_EVENT_TEXT_CHARS)
-                ?.let { ChatEvent.Error(boundedSessionId, it) }
+            // A terminal error with no usable message still ends the turn on
+            // both platforms; a generic fallback keeps the UI from spinning.
+            "error" -> ChatEvent.Error(
+                boundedSessionId,
+                payload.boundedOptional("message", MAX_EVENT_TEXT_CHARS) ?: ERROR_MESSAGE_FALLBACK,
+            )
             "tool.start" -> {
                 val toolId = payload.boundedRequired("tool_id", MAX_EVENT_ID_CHARS)
                 val name = payload.boundedRequired("name", MAX_EVENT_NAME_CHARS)

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/TranscriptEngine.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/TranscriptEngine.kt
@@ -14,8 +14,10 @@ package com.unsupportedpastels.mercury.core.transcript
  * - MessageComplete with null text keeps the streamed buffer; only a non-null
  *   final text replaces it. The interrupt sentinel counts as null final text,
  *   and a sentinel completion that streamed nothing drops the row entirely.
- * - Any approval/clarify expire clears whichever request is pending; expires
- *   are not matched by request id or kind.
+ * - An approval/clarify expire clears the pending request only when both the
+ *   kind and the request id match (Android RunEventModels parity). A stale or
+ *   unrelated expire must never dismiss a newer prompt the agent is still
+ *   blocked on.
  * - Reasoning deltas land on the last incomplete assistant row (or open a
  *   fresh reasoning-only row); reasoning text survives completion.
  * - Interim commentary seals the current streaming segment as completed;
@@ -271,8 +273,19 @@ object TranscriptEngine {
         is ChatEvent.ClarifyRequest ->
             state.copy(pendingRequest = PendingTranscriptRequest.Clarify(event))
 
-        is ChatEvent.ApprovalExpire, is ChatEvent.ClarifyExpire ->
-            if (state.pendingRequest != null) state.copy(pendingRequest = null) else state
+        is ChatEvent.ApprovalExpire ->
+            when (val pending = state.pendingRequest) {
+                is PendingTranscriptRequest.Approval ->
+                    if (pending.event.requestId == event.requestId) state.copy(pendingRequest = null) else state
+                else -> state
+            }
+
+        is ChatEvent.ClarifyExpire ->
+            when (val pending = state.pendingRequest) {
+                is PendingTranscriptRequest.Clarify ->
+                    if (pending.event.requestId == event.requestId) state.copy(pendingRequest = null) else state
+                else -> state
+            }
 
         is ChatEvent.SessionTitle ->
             // New-chat flow only: adopt live title renames for our own session.

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/origin/ServerOriginPolicyTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/origin/ServerOriginPolicyTest.kt
@@ -140,4 +140,14 @@ class ServerOriginPolicyTest {
         assertFalse(ServerOriginPolicy.allowsCleartextHttp("http://example.com"))
         assertFalse(ServerOriginPolicy.allowsCleartextHttp("https://192.168.1.5"))
     }
+
+    @Test
+    fun displayHostDropsSchemePortAndPath() {
+        assertEquals("hermes.example.com", ServerOriginPolicy.displayHost("https://hermes.example.com"))
+        assertEquals("hermes.example.com", ServerOriginPolicy.displayHost("https://Hermes.Example.com:8443/dashboard/x"))
+        assertEquals("192.168.1.20", ServerOriginPolicy.displayHost("http://192.168.1.20:8080"))
+        assertEquals("::1", ServerOriginPolicy.displayHost("http://[::1]:9119"))
+        assertEquals(null, ServerOriginPolicy.displayHost("hermes.example.com"))
+        assertEquals(null, ServerOriginPolicy.displayHost(""))
+    }
 }

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/relay/RelayLeaseRecoveryTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/relay/RelayLeaseRecoveryTest.kt
@@ -108,4 +108,19 @@ class RelayLeaseRecoveryTest {
         assertEquals(0L, completed.rows.single().observedAtMillis)
         assertTrue(completed.rows.single().terminal)
     }
+
+    @Test
+    fun attachedPreambleCarriesARenewedRoutingTokenWhenValid() {
+        fun attached(token: String?): RelayLeaseSnapshot {
+            val field = token?.let { ",\"relay_token\":\"$it\"" } ?: ""
+            return RelayLeaseRecoveryEngine("default").initialize(
+                """{"method":"relay.lease.attached","params":{"recovery_version":1,"lease_id":"lease","last_seq":0,"resume_cursor":0,"replay_gap":false$field}}""",
+            )
+        }
+        assertEquals(null, attached(null).routingToken)
+        assertEquals("abc.DEF-123_", attached("abc.DEF-123_").routingToken)
+        assertEquals(null, attached("").routingToken)
+        assertEquals(null, attached("x".repeat(RelayProtocolPolicy.maxRoutingTokenCharacters + 1)).routingToken)
+        assertEquals(null, attached("has space").routingToken)
+    }
 }

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/relay/RelayProtocolTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/relay/RelayProtocolTest.kt
@@ -51,6 +51,23 @@ class RelayProtocolTest {
         assertFailsWith<RelayProtocolException> {
             RelayAdmissionEnvelope.controllerOpen(deviceId, "bad profile")
         }
+        // Channel-scoped leases: the field leads (sorted-key order) and the
+        // legacy bytes above are untouched when no channel is given.
+        assertEquals(
+            "{\"channel\":\"s_1-A\",\"device_id\":\"$deviceId\",\"profile\":\"default\"," +
+                "\"type\":\"controller.open\",\"recovery_version\":1}",
+            RelayAdmissionEnvelope.controllerOpen(deviceId, "default", null, 1, "s_1-A").decodeToString(),
+        )
+        assertEquals("s-20260906_034455_bfd2a6", RelayAdmissionEnvelope.channelForSession("20260906_034455_bfd2a6"))
+        assertEquals("s-draft-1", RelayAdmissionEnvelope.channelForSession("draft-1"))
+        assertEquals("s-a_b_c", RelayAdmissionEnvelope.channelForSession("a/b c"))
+        assertEquals(64, RelayAdmissionEnvelope.channelForSession("x".repeat(100)).length)
+        assertTrue(RelayAdmissionEnvelope.isValidChannel(RelayAdmissionEnvelope.channelForSession("\u00fc/?")))
+        for (bad in listOf("", "has space", "a/b", "x".repeat(65), "\u00fc")) {
+            assertFailsWith<RelayProtocolException> {
+                RelayAdmissionEnvelope.controllerOpen(deviceId, "default", null, null, bad)
+            }
+        }
         assertTrue(RelayApprovalProbe.isSuccessfulGatewayPing(
             "{\"jsonrpc\":\"2.0\",\"id\":\"pairing-probe\",\"result\":{\"ok\":true}}"
         ))

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/relay/RelayProtocolTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/relay/RelayProtocolTest.kt
@@ -58,6 +58,13 @@ class RelayProtocolTest {
                 "\"type\":\"controller.open\",\"recovery_version\":1}",
             RelayAdmissionEnvelope.controllerOpen(deviceId, "default", null, 1, "s_1-A").decodeToString(),
         )
+        assertEquals(
+            "{\"device_id\":\"$deviceId\",\"device_name\":\"Mark's Fold \\\"8\\\"\",\"profile\":\"default\",\"type\":\"controller.open\"}",
+            RelayAdmissionEnvelope.controllerOpen(deviceId, "default", null, null, null, "  Mark's  Fold \"8\" ").decodeToString(),
+        )
+        assertEquals(null, RelayAdmissionEnvelope.cleanDeviceName("  \t "))
+        assertEquals(null, RelayAdmissionEnvelope.cleanDeviceName("bad\u0001name"))
+        assertEquals(64, RelayAdmissionEnvelope.cleanDeviceName("x".repeat(90))!!.length)
         assertEquals("s-20260906_034455_bfd2a6", RelayAdmissionEnvelope.channelForSession("20260906_034455_bfd2a6"))
         assertEquals("s-draft-1", RelayAdmissionEnvelope.channelForSession("draft-1"))
         assertEquals("s-a_b_c", RelayAdmissionEnvelope.channelForSession("a/b c"))

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/ChatEventDecoderTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/ChatEventDecoderTest.kt
@@ -25,6 +25,19 @@ class ChatEventDecoderTest {
     }
 
     @Test
+    fun terminalErrorWithoutUsableMessageStillDecodesWithFallback() {
+        val fallback = ChatEvent.Error("runtime-1", ChatEventDecoder.ERROR_MESSAGE_FALLBACK)
+        assertEquals(fallback, ChatEventDecoder.decode("error", "runtime-1", "{}"))
+        assertEquals(fallback, ChatEventDecoder.decode("error", "runtime-1", "{\"message\":null}"))
+        assertEquals(fallback, ChatEventDecoder.decode("error", "runtime-1", "{\"message\":\"\"}"))
+        assertEquals(fallback, ChatEventDecoder.decode("error", "runtime-1", "{\"message\":\"   \"}"))
+        assertEquals(
+            ChatEvent.Error("runtime-1", "boom"),
+            ChatEventDecoder.decode("error", "runtime-1", "{\"message\":\"boom\"}"),
+        )
+    }
+
+    @Test
     fun unknownOrMalformedEventsAreIgnoredWithoutThrowing() {
         assertNull(ChatEventDecoder.decode("future.event", "runtime-1", "42"))
         assertNull(ChatEventDecoder.decode("message.delta", "runtime-1", "42"))

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/TranscriptEngineTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/TranscriptEngineTest.kt
@@ -234,16 +234,44 @@ class TranscriptEngineTest {
     // --- pending requests -----------------------------------------------------
 
     @Test
-    fun secondRequestReplacesPendingAndAnyExpireClears() {
+    fun secondRequestReplacesPending() {
         val approval = ChatEvent.ApprovalRequest(sid, "r1", "cmd", null, listOf("yes", "no"))
         val clarify = ChatEvent.ClarifyRequest(sid, "r2", "which?", listOf("a"), multiSelect = false)
         var state = reduce(approval)
         assertIs<PendingTranscriptRequest.Approval>(state.pendingRequest)
         state = reduce(clarify, from = state)
         assertIs<PendingTranscriptRequest.Clarify>(state.pendingRequest)
-        // Blanket expire: not matched by id or kind.
-        state = reduce(ChatEvent.ApprovalExpire(sid, "unrelated"), from = state)
+    }
+
+    @Test
+    fun expireClearsOnlyTheMatchingKindAndRequestId() {
+        val clarify = ChatEvent.ClarifyRequest(sid, "c1", "which?", listOf("a"), multiSelect = false)
+        var state = reduce(clarify)
+        // Wrong kind, even with the same id, leaves the prompt up.
+        state = reduce(ChatEvent.ApprovalExpire(sid, "c1"), from = state)
+        assertIs<PendingTranscriptRequest.Clarify>(state.pendingRequest)
+        // Right kind, stale id (an earlier request's expiry arriving late).
+        state = reduce(ChatEvent.ClarifyExpire(sid, "c0"), from = state)
+        assertIs<PendingTranscriptRequest.Clarify>(state.pendingRequest)
+        // Exact match clears.
+        state = reduce(ChatEvent.ClarifyExpire(sid, "c1"), from = state)
         assertNull(state.pendingRequest)
+
+        val approval = ChatEvent.ApprovalRequest(sid, "r1", "cmd", null, listOf("yes"))
+        state = reduce(approval, from = state)
+        state = reduce(ChatEvent.ClarifyExpire(sid, "r1"), from = state)
+        assertIs<PendingTranscriptRequest.Approval>(state.pendingRequest)
+        state = reduce(ChatEvent.ApprovalExpire(sid, "r0"), from = state)
+        assertIs<PendingTranscriptRequest.Approval>(state.pendingRequest)
+        state = reduce(ChatEvent.ApprovalExpire(sid, "r1"), from = state)
+        assertNull(state.pendingRequest)
+    }
+
+    @Test
+    fun approvalWithoutRequestIdIsNeverExpiredByWire() {
+        val approval = ChatEvent.ApprovalRequest(sid, null, "cmd", null, listOf("yes"))
+        val state = reduce(approval, ChatEvent.ApprovalExpire(sid, "anything"))
+        assertIs<PendingTranscriptRequest.Approval>(state.pendingRequest)
     }
 
     // --- title / status -------------------------------------------------------


### PR DESCRIPTION
## Summary
- Phase 0 correctness: decoder no longer drops blank terminal errors; expiries clear only an exact kind+request match; iOS relay session-list fails closed; probe teardown awaited; iOS refuses redirects on Hermes-origin sessions; shared origin reason surfaced on iOS.
- Relay carries several sessions per phone: lease channels in the shared admission envelope; Android and iOS open one relay connection per chat; the close-others guard is gone. Requires mercury-relay-plugin ≥ 0.2.0.
- Routing tokens renew on every attach and both apps persist them; router refusals (401 / 4004 / silent close) get distinct messages, shown as a banner over cached sessions on iOS.
- Phones report a device name in the admission envelope so the host's device list shows names.
- Phase 1–4: adaptive teal theme with system light/dark on iOS; Android work bursts from the shared engine; hostname labels via shared displayHost; iOS context ring, run status pill, running-subagents section, split view on regular widths; visible relay removal and disconnect on iOS.
- AGENTS.md cross-platform rule and iOS gate.

## Verification
- Android: 989 unit tests, lintDebug, assembleDebug green.
- Shared mercury-core: 152 tests green.
- iOS: MercuryTests green on iPhone 17 Pro simulator (Xcode 26.6); light/dark/iPad simulator screenshots checked.
- Installed and exercised on a Galaxy Fold and an iPhone 17 Pro against the live relay.