### PR TITLE
fix(ci): stabilize Robolectric downloads and artifact preview test

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,11 @@ android {
 
     testOptions {
         unitTests.isIncludeAndroidResources = true
+        unitTests.all {
+            // Robolectric downloads SDKs independently of Gradle repositories.
+            // Its default repo1 endpoint can return HTTP 403 on hosted CI runners.
+            it.systemProperty("robolectric.dependency.repo.url", "https://repo.maven.apache.org/maven2")
+        }
     }
 
     lint {

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.hasTestTag
@@ -285,6 +286,7 @@ class HermesAppTest {
     }
 
     @Test
+    @org.robolectric.annotation.GraphicsMode(org.robolectric.annotation.GraphicsMode.Mode.NATIVE)
     fun sessionDetailsSummarizeArtifactsAndOpenArtifactBrowser() {
         val session = sessions.first()
         val previewBytes = ByteArrayOutputStream().use { output ->
@@ -331,7 +333,14 @@ class HermesAppTest {
         composeRule.onNodeWithText("voice.mp3").assertIsDisplayed()
         composeRule.onNodeWithText("Play").assertIsDisplayed()
         composeRule.onNodeWithContentDescription("Filter artifacts: Image").performClick()
-        composeRule.onNodeWithContentDescription("Zoom image preview.png").performClick()
+        // IO-thread decoding is not covered by Compose idleness. Wait until the
+        // loading placeholder has been replaced so it cannot disappear mid-click.
+        val loadedPreview = hasContentDescription("Zoom image preview.png") and
+            SemanticsMatcher.expectValue(SemanticsProperties.Role, androidx.compose.ui.semantics.Role.Image)
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodes(loadedPreview).fetchSemanticsNodes().size == 1
+        }
+        composeRule.onNode(loadedPreview).performScrollTo().performClick()
         composeRule.waitForIdle()
         composeRule.onNodeWithText("Close").assertExists()
     }


### PR DESCRIPTION
## Summary
- Configure Robolectric test JVMs to download Android runtimes from repo.maven.apache.org; the default repo1 endpoint returned HTTP 403 in main CI before 30 test classes could run.
- Stabilize the artifact browser image interaction test with native graphics, a loaded-image semantics wait, and scroll-before-click.
- Android test/build configuration only; no production behavior, shared-core contract, or iOS changes.

## Verification
- Verified a cold Robolectric SDK download into an empty temporary Maven cache.
- Full CI Gradle command with --rerun-tasks passed: 989 Android tests, 152 shared-core tests, 28 screenshots, lintDebug, assembleDebug, and shared-core check. All 84 tasks executed; screenshot references unchanged.
- Vendored relay-vector checks and both fake-Hermes unit tests passed.
- git diff --check passed.

GitHub CI must pass before merge.