### PR TITLE
fix: preserve owning profile when loading session transcripts

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
@@ -500,6 +500,7 @@ interface HermesConnectionClient {
         serverOrigin: ServerOrigin,
         accessToken: String?,
         durableSessionId: DurableSessionId,
+        profile: String = "default",
     ): List<ChatMessage> = throw UnsupportedOperationException()
 
     suspend fun loadHostDirectories(
@@ -1510,6 +1511,7 @@ class HttpHermesConnectionClient(
         serverOrigin: ServerOrigin,
         accessToken: String?,
         durableSessionId: DurableSessionId,
+        profile: String,
     ): List<ChatMessage> = try {
         TRANSCRIPT_PAGE_LIMITS.forEachIndexed { index, pageLimit ->
             try {
@@ -1518,6 +1520,7 @@ class HttpHermesConnectionClient(
                     accessToken = accessToken,
                     durableSessionId = durableSessionId,
                     pageLimit = pageLimit,
+                    profile = profile,
                 )
             } catch (error: HermesResponseBodyTooLargeException) {
                 if (index == TRANSCRIPT_PAGE_LIMITS.lastIndex) throw error
@@ -1537,13 +1540,14 @@ class HttpHermesConnectionClient(
         accessToken: String?,
         durableSessionId: DurableSessionId,
         pageLimit: Int,
+        profile: String,
     ): List<ChatMessage> {
         val encodedId = durableSessionId.value.encodeURLPathPart()
         val response = client.get("${serverOrigin.value}/api/sessions/$encodedId/messages") {
             accessToken?.let { bearerAuth(it) }
             parameter("limit", pageLimit)
             parameter("order", "latest")
-            parameter("profile", "default")
+            parameter("profile", profile)
         }
         if (!response.status.isSuccess()) {
             response.readBodyTextBounded()

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -880,10 +880,11 @@ class HermesConnectionViewModel(
             durableSessions = cached.sessions.map(CachedSession::summary),
             sessionMetadataSource = CacheSource.Cached,
             chatSessions = cached.sessions.fold(mutableSnapshots.value.chatSessions) { chats, session ->
-                if (session.messages.isEmpty()) chats else chats + (
+                if (session.messages.isEmpty() || chats[session.summary.id]?.owningProfile != null) chats else chats + (
                     session.summary.id to ChatSessionSnapshot(
                         messages = session.messages,
                         transcriptSource = CacheSource.Cached,
+                        owningProfile = session.summary.profile,
                     )
                 )
             },
@@ -2861,7 +2862,7 @@ class HermesConnectionViewModel(
                     isLocalDraft = true,
                 ),
             ) + snapshot.durableSessions,
-            chatSessions = snapshot.chatSessions + (draftId to ChatSessionSnapshot()),
+            chatSessions = snapshot.chatSessions + (draftId to ChatSessionSnapshot(owningProfile = snapshot.selectedProfile)),
         )
         hydrateDraftDefaults(draftId)
         return draftId
@@ -2889,7 +2890,7 @@ class HermesConnectionViewModel(
         val existingChat = snapshot.chatSessions[draftId]
         val chatSessions = if (workspacePath == null && !isNoProjectBucket(projectId)) {
             snapshot.chatSessions + (
-                draftId to (existingChat ?: ChatSessionSnapshot()).copy(error = "No workspace")
+                draftId to (existingChat ?: ChatSessionSnapshot(owningProfile = draft.profile)).copy(error = "No workspace")
                 )
         } else {
             snapshot.chatSessions
@@ -2899,7 +2900,7 @@ class HermesConnectionViewModel(
             projectSessionStates = snapshot.projectSessionStates + (
                 projectId to ProjectSessionLoadState.Loaded(projectSessions)
                 ),
-            chatSessions = chatSessions + (draftId to (chatSessions[draftId] ?: ChatSessionSnapshot())),
+            chatSessions = chatSessions + (draftId to (chatSessions[draftId] ?: ChatSessionSnapshot(owningProfile = draft.profile))),
         )
         hydrateDraftDefaults(draftId)
         return draftId
@@ -3086,8 +3087,9 @@ class HermesConnectionViewModel(
         }
     }
 
-    private fun loadBackgroundViewedTranscript(durableSessionId: DurableSessionId): Job =
-        viewModelScope.launch {
+    private fun loadBackgroundViewedTranscript(durableSessionId: DurableSessionId): Job {
+        pinChatProfile(durableSessionId)
+        return viewModelScope.launch {
             val origin = activeOrigin ?: return@launch
             val originGeneration = generation
             val profile = owningProfile(durableSessionId)
@@ -3122,8 +3124,10 @@ class HermesConnectionViewModel(
                 }
             }
         }
+    }
 
     fun openSession(durableSessionId: DurableSessionId): Job {
+        pinChatProfile(durableSessionId)
         sessionControllerRegistry.chatJobs[durableSessionId]?.takeIf { it.isActive }?.let { return it }
         if (durableSessionId in pendingDraftSessions) {
             return openDraftSession(durableSessionId)
@@ -3274,6 +3278,7 @@ class HermesConnectionViewModel(
         rawText: String,
         interrupted: Boolean = false,
     ): Job {
+        pinChatProfile(durableSessionId)
         if (mutableSnapshots.value.chatSessions[durableSessionId]?.connectionPhase?.let {
                 it == ChatConnectionPhase.Connecting || it == ChatConnectionPhase.Submitting
             } == true) {
@@ -4528,7 +4533,15 @@ class HermesConnectionViewModel(
         serverDurableIds[localId] ?: localId
 
     private fun owningProfile(durableSessionId: DurableSessionId): String =
-        cachedSummary(durableSessionId)?.profile ?: mutableSnapshots.value.selectedProfile
+        mutableSnapshots.value.chatSessions[durableSessionId]?.owningProfile
+            ?: cachedSummary(durableSessionId)?.profile
+            ?: mutableSnapshots.value.selectedProfile
+
+    private fun pinChatProfile(durableSessionId: DurableSessionId) {
+        if (mutableSnapshots.value.chatSessions[durableSessionId]?.owningProfile != null) return
+        val profile = owningProfile(durableSessionId)
+        updateChat(durableSessionId) { it.copy(owningProfile = profile) }
+    }
 
     private fun cachedSummary(durableSessionId: DurableSessionId): SessionSummary? =
         mutableSnapshots.value.durableSessions.firstOrNull { it.id == durableSessionId }
@@ -4705,7 +4718,7 @@ class HermesConnectionViewModel(
             val resumed = if (creatingDraft) {
                 session.createSession(
                     durableSessionId = durableSessionId,
-                    profile = localDraftSession(durableSessionId)?.profile ?: "default",
+                    profile = owningProfile(durableSessionId),
                     workspacePath = localDraftSession(durableSessionId)
                         ?.workspacePath
                         ?.let(::validProjectWorkspacePath),
@@ -6016,6 +6029,7 @@ class HermesConnectionViewModel(
                     )) +
                     (result.durableSessionId to ChatSessionSnapshot(
                         messages = result.messages.mapNotNull(::chatMessageFromJson),
+                        owningProfile = owningProfile(operation.durableSessionId),
                     )),
                 lastBranchedSessionId = result.durableSessionId,
             )

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -3090,6 +3090,7 @@ class HermesConnectionViewModel(
         viewModelScope.launch {
             val origin = activeOrigin ?: return@launch
             val originGeneration = generation
+            val profile = owningProfile(durableSessionId)
             updateChat(durableSessionId) { it.copy(isLoading = true, error = null) }
             try {
                 val relayTarget = activeRelayTarget
@@ -3098,7 +3099,7 @@ class HermesConnectionViewModel(
                 } else {
                     val accessToken = accessTokenForRequest(origin, originGeneration)
                     if (!isCurrentOrigin(origin, originGeneration)) return@launch
-                    client.loadTranscript(origin, accessToken, serverDurableId(durableSessionId))
+                    client.loadTranscript(origin, accessToken, serverDurableId(durableSessionId), profile)
                 }
                 if (!isCurrentOrigin(origin, originGeneration)) return@launch
                 updateChat(durableSessionId) {
@@ -3136,7 +3137,8 @@ class HermesConnectionViewModel(
             val origin = activeOrigin ?: return@launch
             var originGeneration = generation
             val expectedProfileGeneration = profileGeneration
-            val profile = mutableSnapshots.value.selectedProfile
+            val selectedProfile = mutableSnapshots.value.selectedProfile
+            val profile = owningProfile(durableSessionId)
             if (!isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) return@launch
             val cached = cacheRepository?.read(
                 CacheScope(origin, profile),
@@ -3145,7 +3147,7 @@ class HermesConnectionViewModel(
             if (
                 activeOrigin != origin || generation != originGeneration ||
                 profileGeneration != expectedProfileGeneration ||
-                mutableSnapshots.value.selectedProfile != profile
+                mutableSnapshots.value.selectedProfile != selectedProfile
             ) return@launch
             val hasCachedMessages = cached?.messages?.isNotEmpty() == true
             if (cached != null) {
@@ -3176,11 +3178,12 @@ class HermesConnectionViewModel(
                             origin,
                             accessToken,
                             serverDurableId(durableSessionId),
+                            profile = profile,
                         )
                         if (
                             !isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration) ||
                             profileGeneration != expectedProfileGeneration ||
-                            mutableSnapshots.value.selectedProfile != profile
+                            mutableSnapshots.value.selectedProfile != selectedProfile
                         ) return@launch
                     } catch (unauthorized: HermesUnauthorizedException) {
                         if (retriedAfterUnauthorized) throw unauthorized
@@ -3748,6 +3751,7 @@ class HermesConnectionViewModel(
     fun undoSession(durableSessionId: DurableSessionId): Job {
         val operation = beginMaintenanceSession(durableSessionId)
             ?: return unavailableMaintenanceJob(durableSessionId)
+        val profile = owningProfile(durableSessionId)
         return viewModelScope.launch {
             try {
                 operation.session.undoSession(operation.runtimeSessionId)
@@ -3757,6 +3761,7 @@ class HermesConnectionViewModel(
                     operation.origin,
                     token,
                     serverDurableId(durableSessionId),
+                    profile = profile,
                 )
                 currentCoroutineContext().ensureActive()
                 publishUndoneSession(operation, messages)
@@ -4522,6 +4527,9 @@ class HermesConnectionViewModel(
     private fun serverDurableId(localId: DurableSessionId): DurableSessionId =
         serverDurableIds[localId] ?: localId
 
+    private fun owningProfile(durableSessionId: DurableSessionId): String =
+        cachedSummary(durableSessionId)?.profile ?: mutableSnapshots.value.selectedProfile
+
     private fun cachedSummary(durableSessionId: DurableSessionId): SessionSummary? =
         mutableSnapshots.value.durableSessions.firstOrNull { it.id == durableSessionId }
             ?: mutableSnapshots.value.projectSessions.values.asSequence()
@@ -4703,8 +4711,7 @@ class HermesConnectionViewModel(
                         ?.let(::validProjectWorkspacePath),
                 )
             } else {
-                session.resume(serverDurableId(durableSessionId), profile =
-                    if (relayTarget != null) mutableSnapshots.value.selectedProfile else "default")
+                session.resume(serverDurableId(durableSessionId), profile = owningProfile(durableSessionId))
             }
             if (!isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) {
                 throw CancellationException("Chat operation was replaced")
@@ -4861,6 +4868,7 @@ class HermesConnectionViewModel(
         originGeneration: Long,
         operationGeneration: Long,
     ) {
+        val profile = owningProfile(durableSessionId)
         viewModelScope.launch {
             val accessToken = try {
                 accessTokenForRequest(origin, originGeneration)
@@ -4879,7 +4887,7 @@ class HermesConnectionViewModel(
                 reconcileCanonicalSessionMetadata(durableSessionId, canonical)
             }
             val messages = try {
-                client.loadTranscript(origin, accessToken, canonicalId)
+                client.loadTranscript(origin, accessToken, canonicalId, profile)
             } catch (_: Exception) {
                 return@launch
             }
@@ -5174,6 +5182,7 @@ class HermesConnectionViewModel(
         val relayTarget = activeRelayTarget
         val connector = chatConnector
         if (relayTarget == null && connector == null) return
+        val profile = owningProfile(durableSessionId)
         val previous = sessionControllerRegistry.controller(durableSessionId)
         if (previous != null) {
             sessionControllerRegistry.replaceControllerForRecovery(durableSessionId, previous.session)
@@ -5216,7 +5225,6 @@ class HermesConnectionViewModel(
                 // An open socket is not proof that resume will ever answer. Keep
                 // each reconciliation attempt bounded; never replay prompt.submit.
                 val recoverySnapshot = candidate.relayLeaseSnapshot
-                val profile = if (relayTarget != null) mutableSnapshots.value.selectedProfile else "default"
                 if (recoverySnapshot != null && !recoverySnapshot.hasLiveBinding(
                         serverDurableId(durableSessionId).value, profile)) {
                     // Missing retained ownership is not permission to take over another
@@ -5295,7 +5303,7 @@ class HermesConnectionViewModel(
                             },
                         ))
                     } else {
-                        client.loadTranscript(origin, token, serverDurableId(durableSessionId))
+                        client.loadTranscript(origin, token, serverDurableId(durableSessionId), profile)
                     }
                     if (!isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) {
                         closeChatSessionNonCancellably(candidate)

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesGateway.kt
@@ -116,6 +116,8 @@ data class ChatSessionSnapshot(
     val maintenanceError: String? = null,
     val transcriptSource: CacheSource = CacheSource.Live,
     val transcriptPresentation: TranscriptPresentation? = null,
+    /** Bound for this chat's lifetime, independent of the visible profile catalog. */
+    val owningProfile: String? = null,
 ) {
     init {
         require(processRows.size <= MAX_PROCESS_ROWS) { "Process rows exceed the bounded limit" }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
@@ -114,6 +114,42 @@ class HermesChatIntegrationTest {
     }
 
     @Test
+    fun namedProfileOpenAndRecoveryKeepTheSessionOwner() = runTest(dispatcher) {
+        val client = ChatConnectionClient(owningProfile = "director")
+        val initial = StreamingChatSession(submitFailure = HermesChatTransportException("dropped"))
+        val recovered = StreamingChatSession()
+        val sessions = ArrayDeque(listOf(initial, recovered))
+        val viewModel = HermesConnectionViewModel(
+            settingsStates = MutableStateFlow(ServerSettingsState.Ready(origin)),
+            client = client,
+            tokenStore = MemoryTokenStore(tokens),
+            chatConnector = HermesChatConnector { _, _ -> sessions.removeFirst() },
+            nowEpochSeconds = { 1_900_000_000 },
+        )
+        advanceUntilIdle()
+        assertEquals(AuthenticationState.Authenticated, viewModel.snapshots.value.authenticationState)
+        // The owning row, not the current settings selection, is authoritative.
+        assertEquals("default", viewModel.snapshots.value.selectedProfile)
+        viewModel.openSession(durableId)
+        advanceUntilIdle()
+        assertEquals(listOf("director"), client.transcriptProfiles)
+        assertEquals("director", initial.resumedProfile)
+
+        // Opening an idle session closes it; reconnect for Send, then recover.
+        sessions.addFirst(initial)
+        viewModel.sendMessage(durableId, "Recover this turn")
+        advanceUntilIdle()
+        assertEquals("director", recovered.resumedProfile)
+        // Open, first-prompt refresh, and idle recovery all use the same store.
+        assertEquals(listOf("director", "director", "director"), client.transcriptProfiles)
+        val chat = viewModel.snapshots.value.chatSessions.getValue(durableId)
+        assertFalse(chat.isSending)
+        assertEquals(listOf("Earlier question", "Earlier answer"), chat.messages.map { it.text })
+        // A lost submit acknowledgement still needs the existing retry warning.
+        assertEquals("Submission was not confirmed. Check the transcript before retrying.", chat.error)
+    }
+
+    @Test
     fun rejectedPersistedAuthenticationClearsTokensAndRequiresSignIn() = runTest(dispatcher) {
         val tokenStore = MemoryTokenStore(tokens)
         val viewModel = HermesConnectionViewModel(
@@ -2534,8 +2570,9 @@ private class MemoryTokenStore(initial: NativeTokenSet?) : NativeTokenStore {
     override suspend fun clear(serverOrigin: ServerOrigin) { value = null }
 }
 
-private class ChatConnectionClient : HermesConnectionClient {
+private class ChatConnectionClient(private val owningProfile: String = "default") : HermesConnectionClient {
     private val durableId = DurableSessionId("durable-1")
+    val transcriptProfiles = mutableListOf<String>()
     var transcriptAccessToken: String? = null
     var transcriptLoads = 0
     var lastTranscriptDurableId: DurableSessionId? = null
@@ -2552,14 +2589,16 @@ private class ChatConnectionClient : HermesConnectionClient {
         accessToken: String,
     ) = AuthenticatedHermesConnection(
         userId = "user-1",
-        sessions = listOf(SessionSummary(durableId, "Test session")),
+        sessions = listOf(SessionSummary(durableId, "Test session", profile = owningProfile)),
     )
 
     override suspend fun loadTranscript(
         serverOrigin: ServerOrigin,
         accessToken: String?,
         durableSessionId: DurableSessionId,
+        profile: String,
     ): List<com.unsupportedpastels.hermesandroid.gateway.ChatMessage> {
+        transcriptProfiles += profile
         transcriptAccessToken = accessToken
         transcriptLoads += 1
         lastTranscriptDurableId = durableSessionId
@@ -2594,6 +2633,7 @@ private class UnauthorizedOnceTranscriptClient : HermesConnectionClient {
         serverOrigin: ServerOrigin,
         accessToken: String?,
         durableSessionId: DurableSessionId,
+        profile: String,
     ): List<com.unsupportedpastels.hermesandroid.gateway.ChatMessage> {
         transcriptLoads += 1
         if (transcriptLoads == 1) throw HermesUnauthorizedException()
@@ -2721,6 +2761,7 @@ private class NonCooperativeAuthenticationClient(
         serverOrigin: ServerOrigin,
         accessToken: String?,
         durableSessionId: DurableSessionId,
+        profile: String,
     ) = emptyList<com.unsupportedpastels.hermesandroid.gateway.ChatMessage>()
 }
 
@@ -2747,6 +2788,7 @@ private class BlockingTranscriptClient : HermesConnectionClient {
         serverOrigin: ServerOrigin,
         accessToken: String?,
         durableSessionId: DurableSessionId,
+        profile: String,
     ): List<com.unsupportedpastels.hermesandroid.gateway.ChatMessage> = try {
         transcript.await()
     } catch (cancelled: CancellationException) {
@@ -3023,6 +3065,7 @@ private class StreamingChatSession(
     private val mutableEvents = MutableSharedFlow<HermesChatEvent>(extraBufferCapacity = 8)
     override val events: Flow<HermesChatEvent> = mutableEvents
     var resumedDurableId: DurableSessionId? = null
+    var resumedProfile: String? = null
     var submittedText: String? = null
     var closed = false
     val fileAttachCalls = mutableListOf<Triple<String, String, String>>()
@@ -3039,6 +3082,7 @@ private class StreamingChatSession(
         profile: String?,
     ): ResumedChatSession {
         resumedDurableId = durableSessionId
+        resumedProfile = profile
         return ResumedChatSession(
             runtimeSessionId = RuntimeSessionId("runtime-1"),
             durableSessionId = durableSessionId,

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
@@ -23,6 +23,7 @@ import com.unsupportedpastels.hermesandroid.gateway.HermesChatProtocolException
 import com.unsupportedpastels.hermesandroid.gateway.HermesChatSession
 import com.unsupportedpastels.hermesandroid.gateway.HermesChatTransportException
 import com.unsupportedpastels.hermesandroid.gateway.InflightPrompt
+import com.unsupportedpastels.hermesandroid.gateway.ModelOptions
 import com.unsupportedpastels.hermesandroid.gateway.PromptSubmission
 import com.unsupportedpastels.hermesandroid.gateway.ResumedChatSession
 import com.unsupportedpastels.hermesandroid.gateway.RuntimeSessionId
@@ -147,6 +148,91 @@ class HermesChatIntegrationTest {
         assertEquals(listOf("Earlier question", "Earlier answer"), chat.messages.map { it.text })
         // A lost submit acknowledgement still needs the existing retry warning.
         assertEquals("Submission was not confirmed. Check the transcript before retrying.", chat.error)
+    }
+
+    @Test
+    fun defaultChatRecoversAfterManagementReplacesVisibleCatalog() = runTest(dispatcher) {
+        assertChatOwnerSurvivesCatalogReplacement("default", "director")
+    }
+
+    @Test
+    fun namedChatRecoversAfterManagementReplacesVisibleCatalog() = runTest(dispatcher) {
+        assertChatOwnerSurvivesCatalogReplacement("director", "default")
+    }
+
+    private suspend fun assertChatOwnerSurvivesCatalogReplacement(owner: String, selected: String) {
+        val client = ChatConnectionClient(owningProfile = owner)
+        val initial = StreamingChatSession(
+            submitFailure = HermesChatTransportException("dropped"),
+            runningOnResume = true,
+        )
+        val recovered = StreamingChatSession()
+        val sessions = ArrayDeque(listOf(initial, recovered))
+        val viewModel = HermesConnectionViewModel(
+            settingsStates = MutableStateFlow(ServerSettingsState.Ready(origin)),
+            client = client,
+            tokenStore = MemoryTokenStore(tokens),
+            chatConnector = HermesChatConnector { _, _ -> sessions.removeFirst() },
+            nowEpochSeconds = { 1_900_000_000 },
+        )
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(AuthenticationState.Authenticated, viewModel.snapshots.value.authenticationState)
+        viewModel.openSession(durableId).join()
+        assertEquals(owner, initial.resumedProfile)
+        assertFalse(initial.closed)
+
+        viewModel.loadManagementSettings(selected, refreshStatus = false).join()
+        assertNull(viewModel.snapshots.value.managementError)
+        assertEquals(selected, viewModel.snapshots.value.selectedProfile)
+        assertEquals(listOf(DurableSessionId("other-session")), viewModel.snapshots.value.durableSessions.map { it.id })
+        assertTrue(viewModel.snapshots.value.chatSessions.containsKey(durableId))
+        viewModel.openSession(durableId).join()
+        assertFalse(initial.closed)
+        assertEquals(listOf(owner), client.transcriptProfiles)
+
+        initial.completeTurn()
+        dispatcher.scheduler.runCurrent()
+        assertFalse(viewModel.snapshots.value.chatSessions.getValue(durableId).isSending)
+        viewModel.sendMessage(durableId, "Recover this turn").join()
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("Recover this turn", initial.submittedText)
+        assertEquals(owner, recovered.resumedProfile)
+        assertTrue(client.transcriptProfiles.size > 1)
+        assertEquals(List(client.transcriptProfiles.size) { owner }, client.transcriptProfiles)
+        assertFalse(viewModel.snapshots.value.chatSessions.getValue(durableId).isSending)
+        viewModel.logout()
+        assertTrue(viewModel.snapshots.value.chatSessions.isEmpty())
+    }
+
+    @Test
+    fun idleChatAndDraftPinOwnerBeforeOpenOrSendSuspends() = runTest(dispatcher) {
+        val client = ChatConnectionClient()
+        val states = MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin))
+        val viewModel = HermesConnectionViewModel(
+            settingsStates = states,
+            client = client,
+            tokenStore = MemoryTokenStore(tokens),
+            nowEpochSeconds = { 1_900_000_000 },
+        )
+        advanceUntilIdle()
+        val open = viewModel.openSession(durableId)
+        assertEquals("default", viewModel.snapshots.value.chatSessions.getValue(durableId).owningProfile)
+        open.join()
+        val draft = viewModel.createNewSession()
+        assertEquals("default", viewModel.snapshots.value.chatSessions.getValue(draft).owningProfile)
+        viewModel.loadManagementSettings("director", refreshStatus = false).join()
+        viewModel.openSession(durableId).join()
+        assertEquals(listOf("default", "default"), client.transcriptProfiles)
+        viewModel.sendMessage(draft, "Draft turn").join()
+        assertEquals("default", viewModel.snapshots.value.chatSessions.getValue(draft).owningProfile)
+
+        states.value = ServerSettingsState.Ready(ServerOrigin.parse("https://other.example"))
+        advanceUntilIdle()
+        assertTrue(viewModel.snapshots.value.chatSessions.isEmpty())
+        viewModel.loadManagementSettings("director", refreshStatus = false).join()
+        viewModel.openSession(durableId).join()
+        assertEquals("director", client.transcriptProfiles.last())
+        viewModel.logout()
     }
 
     @Test
@@ -753,6 +839,8 @@ class HermesChatIntegrationTest {
         advanceUntilIdle()
 
         assertEquals(canonicalId, client.lastTranscriptDurableId)
+        viewModel.loadManagementSettings("director", refreshStatus = false).join()
+        assertEquals("director", viewModel.snapshots.value.selectedProfile)
         first.closeEvents()
         advanceUntilIdle()
         viewModel.addAttachments(
@@ -771,6 +859,8 @@ class HermesChatIntegrationTest {
         advanceUntilIdle()
 
         assertEquals(canonicalId, second.resumedDurableId)
+        assertEquals("default", second.resumedProfile)
+        assertEquals("default", viewModel.snapshots.value.chatSessions.getValue(draftId).owningProfile)
         assertEquals("Second prompt", second.submittedText?.lineSequence()?.last())
         assertEquals(listOf("note.txt"), second.fileAttachCalls.map { it.first })
         assertTrue(viewModel.attachments.value[draftId].orEmpty().isEmpty())
@@ -2573,6 +2663,22 @@ private class MemoryTokenStore(initial: NativeTokenSet?) : NativeTokenStore {
 private class ChatConnectionClient(private val owningProfile: String = "default") : HermesConnectionClient {
     private val durableId = DurableSessionId("durable-1")
     val transcriptProfiles = mutableListOf<String>()
+    override suspend fun loadProfiles(serverOrigin: ServerOrigin, accessToken: String) =
+        listOf("default", "director")
+
+    override suspend fun loadDefaultModelOptions(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+    ) = ModelOptions(providers = emptyList(), current = null, profile = profile)
+
+    override suspend fun loadSessionsForProfile(
+        serverOrigin: ServerOrigin,
+        accessToken: String,
+        profile: String,
+        archivedOnly: Boolean,
+    ) = listOf(SessionSummary(DurableSessionId("other-session"), "Other session", profile = profile))
+
     var transcriptAccessToken: String? = null
     var transcriptLoads = 0
     var lastTranscriptDurableId: DurableSessionId? = null
@@ -3061,6 +3167,7 @@ private class CancellableCreateChatSession : HermesChatSession {
 
 private class StreamingChatSession(
     private val submitFailure: Exception? = null,
+    private val runningOnResume: Boolean = false,
 ) : HermesChatSession {
     private val mutableEvents = MutableSharedFlow<HermesChatEvent>(extraBufferCapacity = 8)
     override val events: Flow<HermesChatEvent> = mutableEvents
@@ -3070,6 +3177,10 @@ private class StreamingChatSession(
     var closed = false
     val fileAttachCalls = mutableListOf<Triple<String, String, String>>()
     val imageAttachCalls = mutableListOf<Pair<String, String>>()
+
+    suspend fun completeTurn() {
+        mutableEvents.emit(HermesChatEvent.MessageComplete(RuntimeSessionId("runtime-1"), "Finished", "done"))
+    }
 
     override suspend fun createSession(
         durableSessionId: DurableSessionId,
@@ -3088,7 +3199,7 @@ private class StreamingChatSession(
             durableSessionId = durableSessionId,
             resumed = true,
             messages = emptyList(),
-            running = false,
+            running = runningOnResume,
             inflight = null as InflightPrompt?,
         )
     }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
@@ -419,9 +419,32 @@ class HermesConnectionClientTest {
     }
 
     @Test
+    fun namedProfileTranscriptDoesNotReadDefaultStore() = runTest {
+        val engine = MockEngine { request ->
+            assertEquals("/api/sessions/director-session/messages", request.url.encodedPath)
+            if (request.url.parameters["profile"] != "director") {
+                respond("{}", HttpStatusCode.NotFound)
+            } else {
+                respond(
+                    """{"messages":[{"role":"assistant","content":"Named history"}]}""",
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        }
+        val messages = HttpHermesConnectionClient(HttpClient(engine)).loadTranscript(
+            ServerOrigin.parse("https://hermes.example"),
+            accessToken = null,
+            DurableSessionId("director-session"),
+            profile = "director",
+        )
+        assertEquals("Named history", messages.single().text)
+    }
+
+    @Test
     fun transcriptKeepsToolRowsUsingNameAndContextPreview() = runTest {
         val engine = MockEngine { request ->
             assertEquals("/api/sessions/durable-1/messages", request.url.encodedPath)
+            assertEquals("default", request.url.parameters["profile"])
             respond(
                 content = """
                     {"session_id":"durable-1","messages":[
@@ -459,6 +482,7 @@ class HermesConnectionClientTest {
         val requestedLimits = mutableListOf<String?>()
         val engine = MockEngine { request ->
             assertEquals("/api/sessions/durable-large/messages", request.url.encodedPath)
+            assertEquals("director", request.url.parameters["profile"])
             assertEquals("latest", request.url.parameters["order"])
             requestedLimits += request.url.parameters["limit"]
             if (request.url.parameters["limit"] == "100") {
@@ -478,6 +502,7 @@ class HermesConnectionClientTest {
             ServerOrigin.parse("https://hermes.example"),
             accessToken = null,
             DurableSessionId("durable-large"),
+            profile = "director",
         )
 
         assertEquals(listOf("100", "50"), requestedLimits)

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
@@ -3602,6 +3602,7 @@ private class AuthenticatingHermesConnectionClient : HermesConnectionClient {
         serverOrigin: ServerOrigin,
         accessToken: String?,
         durableSessionId: DurableSessionId,
+        profile: String,
     ): List<com.unsupportedpastels.hermesandroid.gateway.ChatMessage> = emptyList()
 
     override suspend fun triggerCronJob(

--- a/ios/MercuryTests/SessionsTests.swift
+++ b/ios/MercuryTests/SessionsTests.swift
@@ -192,6 +192,20 @@ final class SessionsTests: XCTestCase {
         )
     }
 
+    func testNamedProfileTranscriptAndOlderPageUseOwningStore() async throws {
+        SessionsMockURLProtocol.requestHandler = { request in
+            let query = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?.queryItems
+            XCTAssertEqual(query?.first(where: { $0.name == "profile" })?.value, "director")
+            return try self.okResponse(request, body: Self.transcriptDataKeyJSON)
+        }
+        let sessions = SessionsClient(client: makeClient(), profile: "director")
+        let latest = try await sessions.transcript(sessionID: "director-session")
+        let older = try await sessions.olderTranscript(sessionID: "director-session", offset: 100)
+        XCTAssertEqual(latest.count, 2)
+        XCTAssertEqual(older.count, 2)
+        XCTAssertEqual(SessionsMockURLProtocol.requests.count, 2)
+    }
+
     func testOlderTranscriptBuildsOffsetQueryForLoadEarlier() async throws {
         SessionsMockURLProtocol.requestHandler = { request in
             SessionsMockURLProtocol.lastRequest = request
@@ -238,7 +252,7 @@ final class SessionsTests: XCTestCase {
                 : (response, Data(Self.transcriptDataKeyJSON.utf8))
         }
 
-        let transcript = try await SessionsClient(client: makeClient())
+        let transcript = try await SessionsClient(client: makeClient(), profile: "director")
             .transcript(sessionID: "oversized-session")
 
         let limits = SessionsMockURLProtocol.requests.compactMap { request in
@@ -246,6 +260,10 @@ final class SessionsTests: XCTestCase {
                 .queryItems?.first(where: { $0.name == "limit" })?.value
         }
         XCTAssertEqual(limits, ["100", "50"])
+        XCTAssertTrue(SessionsMockURLProtocol.requests.allSatisfy { request in
+            URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "profile" })?.value == "director"
+        })
         XCTAssertEqual(transcript.count, 2)
     }
 


### PR DESCRIPTION
## Summary
Fix Android transcript loading for sessions owned by a named Hermes profile. The client previously listed these sessions but fetched their history with `profile=default`, producing HTTP 404.

## Credit
Thanks to @HotRod5k for the detailed reproduction and root-cause diagnosis in #46. This implementation follows that report; reporter credit is preserved here and in the commit message.

## Fix
- Carry the owning SessionSummary profile through all HTTP transcript call sites and page-size retries.
- Use the same owner for normal resume, reconnect/recovery, and opening transcript-cache reads/writes.
- Preserve selected-profile generation guards and default-profile compatibility.
- Retain the owning profile in chat state so changing the visible profile/catalog cannot retarget an existing chat during recovery; cover default and named owners plus draft canonical-ID recovery.
- iOS already forwards the configured profile; add tests for current/older history and oversized-page retries without changing working iOS production code.

No server changes, Relay contract additions, compound-ID redesign, or video-playback changes.

## Verification
- Observed failing Android HTTP and ViewModel regression tests before the fix, then passing results.
- `./gradlew testDebugUnitTest lintDebug assembleDebug validateDebugScreenshotTest :shared:mercury-core:check --rerun-tasks` passed: 991 Android tests, 152 shared-core tests, 28 screenshots. Screenshot references unchanged.
- Xcode 26.6 build/test on iPhone 17 Pro simulator (iOS 26.5): 716 MercuryTests passed; changed Swift test source hash verified against the Mac copy.
- Independent read-only review found no blockers; `git diff --check` passed.
- After the review follow-up, `./gradlew testDebugUnitTest lintDebug assembleDebug` passed with 994 Android tests and no failures; a fresh read-only review of the final diff found no blockers. Shared/iOS code and screenshot references are unchanged by this follow-up.
- Android tests used JVM/Robolectric; no Android emulator or physical-device end-to-end run was performed.

Fixes #46
