### PR TITLE
fix(relay): stop the pairing scanner from auto-zooming past the QR

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayCodeScanner.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/relay/RelayCodeScanner.kt
@@ -10,9 +10,13 @@ class RelayCodeScanner(
 ) {
     private val scanner = GmsBarcodeScanning.getClient(
         activity,
+        // No auto-zoom: the pairing QR is dense (version ~18, ~100 modules a
+        // side), and ML Kit's auto-zoom overshoots on it, pushing the finder
+        // patterns out of frame so the scan never completes. Without it the
+        // scanner reads at whatever distance the user holds the phone, which
+        // is how the iOS scanner already behaves.
         GmsBarcodeScannerOptions.Builder()
             .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
-            .enableAutoZoom()
             .build(),
     )
 


### PR DESCRIPTION
Users reported the camera zooming in and cutting off the relay pairing QR. The Android scanner enables ML Kit auto-zoom, which overshoots on the dense pairing code (about 100 modules a side) and pushes the finder patterns out of frame, so the scan never completes.

This removes `enableAutoZoom()` from the scanner options. The scanner then reads at whatever distance the user holds the phone, which is how the iOS scanner already behaves. `:app:compileDebugKotlin` passes locally.

Pairs with mercury-relay-plugin 0.2.10, which draws the QR larger with a click-to-enlarge view.