### PR TITLE
release: 0.2.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         // duplicates). Release CI passes VERSION_CODE=${{ github.run_number }};
         // local builds fall back to 1.
         versionCode = (System.getenv("VERSION_CODE") ?: "1").toInt()
-        versionName = "0.2.2"
+        versionName = "0.2.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Bumps `versionName` to 0.2.3 so the release workflow publishes a fresh GitHub release. The relay pairing scanner fix (#55) has so far only overwritten the APK asset on the existing v0.2.2 release, so nothing signals a new version to users. No other changes.