### PR TITLE
feat: managed-video playback plus live working-presence indicators

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "17"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "17"
@@ -84,7 +84,7 @@ jobs:
         run: echo "name=$(grep -oP 'versionName\s*=\s*\"\K[^\"]+' app/build.gradle.kts)" >> "$GITHUB_OUTPUT"
 
       - name: Publish GitHub release (side-load APK)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: v${{ steps.ver.outputs.name }}
           prerelease: false

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,5 @@
 # Contributors
 
 - [@snowzlmbot](https://github.com/snowzlmbot) — originated the device voice-input idea carried forward from [PR #26](https://github.com/unsupportedpastels/Hermes-Agent-Mobile-HAM/pull/26).
+- [@forcewake](https://github.com/forcewake) — authored the original Android managed-video playback, download/cache implementation, and tests in [PR #48](https://github.com/unsupportedpastels/mercury/pull/48), adapted into the shared-core and native mobile video support.
+- [@HotRod5k](https://github.com/HotRod5k) — reported and diagnosed the named-profile transcript loading bug in [issue #46](https://github.com/unsupportedpastels/mercury/issues/46), fixed in [PR #54](https://github.com/unsupportedpastels/mercury/pull/54).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -153,4 +153,8 @@ dependencies {
   implementation(libs.androidx.navigation3.ui)
   implementation(libs.androidx.navigation3.runtime)
   implementation(libs.androidx.lifecycle.viewmodel.navigation3)
+
+  // Media playback (managed video artifacts)
+  implementation(libs.androidx.media3.exoplayer)
+  implementation(libs.androidx.media3.ui)
 }

--- a/app/src/androidTest/java/com/unsupportedpastels/hermesandroid/connection/ManagedVideoEndToEndTest.kt
+++ b/app/src/androidTest/java/com/unsupportedpastels/hermesandroid/connection/ManagedVideoEndToEndTest.kt
@@ -1,0 +1,160 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import android.graphics.Bitmap
+import android.util.Log
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.media3.common.Player
+import androidx.media3.ui.PlayerView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.unsupportedpastels.hermesandroid.MainActivity
+import org.junit.Assert.*
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/** Opt-in real decoder test. Run only on a disposable emulator with fake-hermes --video fixture.
+ * Build APKs, install explicitly with adb -s SERIAL, then am instrument -e class this class.
+ * No fake player, downloader, credentials store, or production dependency injection.
+ */
+@RunWith(AndroidJUnit4::class)
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+class ManagedVideoEndToEndTest {
+    companion object {
+        @JvmStatic @BeforeClass fun permissions() {
+            val i = InstrumentationRegistry.getInstrumentation()
+            if (android.os.Build.VERSION.SDK_INT >= 33) i.uiAutomation.grantRuntimePermission(
+                i.targetContext.packageName, android.Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+    @get:Rule val rule = createAndroidComposeRule<MainActivity>()
+    private val instrumentation get() = InstrumentationRegistry.getInstrumentation()
+    private fun text(value: String) = rule.onAllNodesWithText(value, substring = true)
+    private fun waitText(value: String) = rule.waitUntil(30_000) {
+        text(value).fetchSemanticsNodes().isNotEmpty()
+    }
+    private fun waitPlay() {
+        try {
+            rule.waitUntil(30_000) {
+                rule.onAllNodesWithContentDescription("Play video").fetchSemanticsNodes().isNotEmpty()
+            }
+        } catch (failure: Throwable) {
+            throw AssertionError(rule.onRoot().printToString(maxDepth = 16), failure)
+        }
+    }
+    private fun openVideoSurface() {
+        if (InstrumentationRegistry.getArguments().getString("entry") == "artifact") {
+            rule.onNodeWithContentDescription("Open session details").performClick()
+            waitText("View all artifacts")
+            rule.onNodeWithText("View all artifacts").performScrollTo().performClick()
+        }
+        waitPlay()
+    }
+    private fun player(): Player {
+        var result: Player? = null
+        onView(isAssignableFrom(PlayerView::class.java)).inRoot(object : org.hamcrest.TypeSafeMatcher<androidx.test.espresso.Root>() {
+            override fun describeTo(description: org.hamcrest.Description) { description.appendText("focused window") }
+            override fun matchesSafely(root: androidx.test.espresso.Root) = root.decorView.hasWindowFocus()
+        }).check { view, error ->
+            if (error != null) throw error
+            result = (view as PlayerView).player
+        }
+        return requireNotNull(result)
+    }
+    private fun state(player: Player): Pair<Long, Boolean> {
+        var value = 0L to false
+        instrumentation.runOnMainSync { value = player.currentPosition to player.isPlaying }
+        return value
+    }
+    private fun advances(player: Player, label: String) {
+        val deadline = System.currentTimeMillis() + 20_000
+        while (!state(player).second && System.currentTimeMillis() < deadline) Thread.sleep(100)
+        val start = state(player)
+        assertTrue("$label must be playing: $start", start.second)
+        Thread.sleep(2_300)
+        val end = state(player)
+        Log.i("ManagedVideoQA", "$label position=${start.first}->${end.first} isPlaying=${end.second}")
+        assertTrue("$label clock did not advance >=2s: $start -> $end", end.first - start.first >= 2_000)
+        assertTrue("$label stopped unexpectedly", end.second)
+    }
+    private fun screenshot(label: String) {
+        val metric = InstrumentationRegistry.getArguments().getString("metric") ?: "compact"
+        val file = File(instrumentation.targetContext.getExternalFilesDir(null), "video-$metric-$label.png")
+        file.outputStream().use { instrumentation.uiAutomation.takeScreenshot().compress(Bitmap.CompressFormat.PNG, 100, it) }
+        Log.i("ManagedVideoQA", "screenshot=${file.name}")
+    }
+    @Test fun managedVideoRealPlaybackFullscreenPauseAndCachedReplay() {
+        rule.waitUntil(30_000) {
+            text("Connect to Hermes").fetchSemanticsNodes().isNotEmpty() ||
+                text("E2E Session").fetchSemanticsNodes().isNotEmpty()
+        }
+        if (text("Connect to Hermes").fetchSemanticsNodes().isNotEmpty()) {
+            rule.onNodeWithText("Self-hosted").performClick()
+            rule.onNodeWithContentDescription("Server origin input").performTextInput("10.0.2.2:8787")
+            rule.onNodeWithContentDescription("Use HTTPS checkbox").performClick()
+            rule.onNodeWithText("Continue").performClick()
+            waitText("Sign in with username and password")
+            rule.onNodeWithText("Sign in with username and password").performClick()
+            rule.onNodeWithText("Password").performTextInput("e2epass")
+            rule.onNodeWithText("Sign in").performClick()
+        }
+        waitText("E2E Session")
+        // Let startup authentication/catalog refresh finish before opening cached rows.
+        Thread.sleep(5_000)
+        text("E2E Session")[0].performClick()
+        openVideoSurface()
+        rule.onNodeWithContentDescription("Play video").performClick()
+        try {
+            rule.waitUntil(30_000) {
+                rule.onAllNodesWithContentDescription("Open fullscreen video").fetchSemanticsNodes().isNotEmpty()
+            }
+        } catch (failure: Throwable) {
+            screenshot("failure")
+            throw AssertionError(rule.onAllNodes(isRoot()).printToString(maxDepth = 18), failure)
+        }
+        val inline = player()
+        advances(inline, "inline")
+        screenshot("playing")
+        rule.onNodeWithContentDescription("Open fullscreen video").performClick()
+        rule.onNodeWithContentDescription("Close fullscreen video").assertExists()
+        advances(inline, "fullscreen")
+        screenshot("fullscreen")
+        rule.onNodeWithContentDescription("Close fullscreen video").performClick()
+        assertSame("fullscreen should return same player", inline, player())
+        rule.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        Thread.sleep(500)
+        val stopped = state(inline)
+        Thread.sleep(1_000)
+        val later = state(inline)
+        Log.i("ManagedVideoQA", "background position=${stopped.first}->${later.first} isPlaying=${later.second}")
+        assertFalse(later.second)
+        assertTrue("background clock advanced", later.first - stopped.first < 100)
+        rule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        rule.activityRule.scenario.recreate()
+        openVideoSurface()
+        screenshot("cached-poster")
+        val cache = File(instrumentation.targetContext.cacheDir, "managed-video")
+        val before = cache.walkTopDown().filter { it.isFile }.associate { it.absolutePath to (it.length() to it.lastModified()) }
+        Log.i("ManagedVideoQA", "cache files=${before.size}")
+        rule.onNodeWithContentDescription("Play video").performClick()
+        try {
+            rule.waitUntil(30_000) {
+                rule.onAllNodesWithContentDescription("Open fullscreen video").fetchSemanticsNodes().isNotEmpty()
+            }
+        } catch (failure: Throwable) {
+            screenshot("failure")
+            throw AssertionError(rule.onAllNodes(isRoot()).printToString(maxDepth = 18), failure)
+        }
+        advances(player(), "cached-replay")
+        screenshot("cached-replay")
+        val after = cache.walkTopDown().filter { it.isFile }.associate { it.absolutePath to (it.length() to it.lastModified()) }
+        assertTrue("expected persisted cache", before.isNotEmpty())
+        assertEquals("cached replay must not rewrite download", before, after)
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
@@ -535,6 +535,7 @@ internal fun HermesAppHost(
         },
         isHomeRefreshing = homeRefreshing,
         onRefreshHome = { connectionViewModel?.refreshHomeData() },
+        onRefreshWorkingPresence = { connectionViewModel?.refreshActiveWorkingSessions() },
         onLoadRecentSessions = { connectionViewModel?.loadRecentSessions() },
         onLoadMoreRecentSessions = { connectionViewModel?.loadMoreRecentSessions() },
         onRenameSession = { sessionId, title ->
@@ -629,6 +630,16 @@ internal fun HermesAppHost(
             connectionViewModel?.let { viewModel ->
                 resultPreservingCancellation { viewModel.downloadManagedImage(path) }
             } ?: Result.failure(IllegalStateException("Managed images unavailable"))
+        },
+        onLoadManagedVideo = { path ->
+            connectionViewModel?.let { viewModel ->
+                resultPreservingCancellation { viewModel.downloadManagedVideo(path) }
+            } ?: Result.failure(IllegalStateException("Managed videos unavailable"))
+        },
+        onPeekManagedVideo = { path ->
+            connectionViewModel?.let { viewModel ->
+                resultPreservingCancellation { viewModel.peekManagedVideo(path) }.getOrNull()
+            }
         },
         modelPickerState = modelPickerState,
         onOpenModelPicker = { sessionId -> connectionViewModel?.openModelPicker(sessionId) },

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
@@ -1,5 +1,7 @@
 package com.unsupportedpastels.hermesandroid.connection
 
+import com.unsupportedpastels.mercury.core.artifacts.ManagedVideoPolicy
+
 import com.unsupportedpastels.hermesandroid.app.DurableSessionId
 import com.unsupportedpastels.hermesandroid.app.SessionSummary
 import com.unsupportedpastels.hermesandroid.app.validHostFolderName
@@ -26,6 +28,7 @@ import com.unsupportedpastels.hermesandroid.gateway.parseOperationalStatus
 import com.unsupportedpastels.hermesandroid.files.HostFileContent
 import com.unsupportedpastels.hermesandroid.files.HostFileEntry
 import com.unsupportedpastels.hermesandroid.files.HostFileListing
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
 import com.unsupportedpastels.hermesandroid.files.MAX_HOST_FILE_BYTES
 import com.unsupportedpastels.hermesandroid.files.MAX_HOST_FILE_ENTRIES
 import com.unsupportedpastels.hermesandroid.files.validCanonicalHostFilePath
@@ -47,6 +50,7 @@ import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
+import io.ktor.client.request.prepareGet
 import io.ktor.client.request.parameter
 import io.ktor.client.request.patch
 import io.ktor.client.request.post
@@ -59,9 +63,12 @@ import io.ktor.http.contentType
 import io.ktor.http.encodeURLPathPart
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.readRemaining
+import io.ktor.utils.io.readAvailable
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -79,6 +86,8 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
+import java.io.File
+import java.io.FileOutputStream
 import java.util.Base64
 
 @Serializable
@@ -335,6 +344,8 @@ private const val MAX_SESSION_PAGE_SIZE = 500
 private const val MAX_HOST_DIRECTORY_ENTRIES = 500
 internal const val MAX_CRON_RUNS = 20
 private const val MAX_MANAGED_IMAGE_BYTES = 10 * 1024 * 1024
+private const val MAX_MANAGED_VIDEO_BYTES = 256L * 1024 * 1024
+private const val DEFAULT_VIDEO_STREAM_BUFFER_BYTES = 64 * 1024
 internal const val MAX_EFFECTIVE_CONTEXT_LENGTH = 100_000_000
 private const val MAX_HOST_FILE_LISTING_BODY_BYTES = 512 * 1024
 private const val MAX_HOST_FILE_READ_BODY_BYTES = 1024 * 1024
@@ -545,6 +556,20 @@ interface HermesConnectionClient {
         accessToken: String?,
         path: String,
     ): ByteArray = throw UnsupportedOperationException()
+
+    /**
+     * Stream the managed video at [path] into [destination] (which must live in a
+     * per-origin cache directory). Requires a video response content type,
+     * streams to disk without buffering the body in memory, and lands the file
+     * atomically via a `.part` rename so [destination] only ever denotes a
+     * complete download.
+     */
+    suspend fun streamManagedVideoToFile(
+        serverOrigin: ServerOrigin,
+        accessToken: String?,
+        path: String,
+        destination: File,
+    ): ManagedVideoMedia = throw UnsupportedOperationException()
 
     suspend fun updateSession(
         serverOrigin: ServerOrigin,
@@ -1864,6 +1889,106 @@ class HttpHermesConnectionClient(
         throw error
     } catch (error: Exception) {
         throw HermesConnectionException("Could not download Hermes managed image", error)
+    }
+
+    override suspend fun streamManagedVideoToFile(
+        serverOrigin: ServerOrigin,
+        accessToken: String?,
+        path: String,
+        destination: File,
+    ): ManagedVideoMedia = streamManagedVideoToFile(
+        serverOrigin = serverOrigin,
+        accessToken = accessToken,
+        path = path,
+        destination = destination,
+        maxBytes = MAX_MANAGED_VIDEO_BYTES,
+    )
+
+    internal suspend fun streamManagedVideoToFile(
+        serverOrigin: ServerOrigin,
+        accessToken: String?,
+        path: String,
+        destination: File,
+        maxBytes: Long,
+    ): ManagedVideoMedia = try {
+        val canonicalPath = validCanonicalHostFilePath(path)
+            ?: throw HermesConnectionException("Host file path is invalid")
+        if (!ManagedVideoPolicy.isManagedVideoPath(canonicalPath)) {
+            throw HermesConnectionException("Host video path is invalid")
+        }
+        require(maxBytes in 1..ManagedVideoPolicy.MAX_DOWNLOAD_BYTES)
+        // The streamed body is written through FileOutputStream in chunks; keep
+        // that disk loop off the caller's (often Main) dispatcher.
+        withContext(Dispatchers.IO) {
+            client.prepareGet("${serverOrigin.value}/api/files/download") {
+                accessToken?.let { bearerAuth(it) }
+                parameter("path", canonicalPath)
+            }.execute { response ->
+                if (!response.status.isSuccess()) {
+                    response.bodyAsChannel().cancel(null)
+                    throw HermesConnectionException(
+                        "Hermes managed video returned HTTP ${response.status.value}",
+                    )
+                }
+                val mimeType = response.headers[io.ktor.http.HttpHeaders.ContentType]
+                    ?.substringBefore(';')
+                    ?.trim()
+                    ?.lowercase()
+                if (mimeType == null || !ManagedVideoPolicy.isVideoMimeType(mimeType)) {
+                    response.bodyAsChannel().cancel(null)
+                    throw HermesConnectionException("Hermes managed file was not a video")
+                }
+                val declaredLength = response.headers[io.ktor.http.HttpHeaders.ContentLength]?.toLongOrNull()
+                if (declaredLength != null && declaredLength > maxBytes) {
+                    response.bodyAsChannel().cancel(null)
+                    throw HermesConnectionException("Hermes managed video was too large")
+                }
+                response.writeVideoBodyBounded(destination, maxBytes)
+                ManagedVideoMedia(destination, mimeType)
+            }
+        }
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (error: HermesConnectionException) {
+        throw error
+    } catch (error: Exception) {
+        throw HermesConnectionException("Could not download Hermes managed video", error)
+    }
+
+    /**
+     * Streams the response body into [destination] through a `.part` file so a
+     * failed or oversized download never leaves a half-written video behind.
+     */
+    private suspend fun HttpResponse.writeVideoBodyBounded(destination: File, maxBytes: Long) {
+        val channel = bodyAsChannel()
+        val part = File(destination.parentFile, destination.name + ".part")
+        try {
+            FileOutputStream(part).use { out ->
+                val buffer = ByteArray(DEFAULT_VIDEO_STREAM_BUFFER_BYTES)
+                var total = 0L
+                while (true) {
+                    // Read at most the remaining allowance plus one byte; do not
+                    // wait for a whole chunk (or EOF) to reject an oversized body.
+                    val limit = minOf(buffer.size.toLong(), maxBytes - total + 1).toInt()
+                    val read = channel.readAvailable(buffer, 0, limit)
+                    if (read == -1) break
+                    total += read
+                    if (total > maxBytes) {
+                        throw HermesConnectionException("Hermes managed video was too large")
+                    }
+                    out.write(buffer, 0, read)
+                }
+                out.flush()
+            }
+            if (!part.renameTo(destination)) {
+                throw HermesConnectionException("Could not publish Hermes managed video")
+            }
+        } catch (error: Throwable) {
+            part.delete()
+            throw error
+        } finally {
+            channel.cancel(null)
+        }
     }
 
     private suspend fun loadSessionsPage(

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -36,6 +36,10 @@ import com.unsupportedpastels.hermesandroid.cache.CacheScope
 import com.unsupportedpastels.hermesandroid.cache.CachedSession
 import com.unsupportedpastels.hermesandroid.cache.EncryptedOfflineCacheRepository
 import com.unsupportedpastels.hermesandroid.cache.OfflineCacheRepository
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoCache
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import com.unsupportedpastels.hermesandroid.files.HostFileContent
 import com.unsupportedpastels.hermesandroid.files.HostFileListing
 import com.unsupportedpastels.hermesandroid.gateway.AuthenticationState
@@ -336,7 +340,12 @@ class HermesConnectionViewModel(
     private val notifications: TurnNotificationController = NoOpTurnNotificationController,
     private val sessionFilterRepository: SessionFilterRepository? = null,
     private val speechStreamConnector: SpeechStreamConnector? = null,
+    private val videoCache: ManagedVideoCache? = null,
 ) : ViewModel() {
+    // Serializes downloads targeting the same origin/path cache entry, so two
+    // concurrent players of the same path never race on the shared `.part` file.
+    private val videoDownloadLocks = ConcurrentHashMap<String, Mutex>()
+
     private val mutableSnapshots = MutableStateFlow(HermesGatewaySnapshot())
     val snapshots: StateFlow<HermesGatewaySnapshot> = mutableSnapshots.asStateFlow()
 
@@ -1931,6 +1940,80 @@ class HermesConnectionViewModel(
         return job
     }
 
+    /**
+     * Silent one-shot refresh of working-state presence: reads the read-only
+     * `session.active_list` snapshot and publishes the set of durable session
+     * IDs currently running a turn. The Home screen calls this on a short
+     * timer while visible — never a full-screen reload. Fails closed: an
+     * unsupported or failed RPC leaves the previous value untouched rather
+     * than showing stale spinners, and an empty snapshot clears them.
+     */
+    fun refreshActiveWorkingSessions(): Job {
+        activeRelayTarget?.let { target ->
+            val expectedGeneration = generation
+            return viewModelScope.launch {
+                try {
+                    withRelayReader(target, mutableSnapshots.value.selectedProfile) { session ->
+                        session.loadActiveSessionPresence()
+                    }.let { working ->
+                        if (generation == expectedGeneration && activeRelayTarget?.id == target.id) {
+                            mutableSnapshots.value = mutableSnapshots.value.copy(
+                                activeWorkingSessionIds = working,
+                            )
+                        }
+                    }
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
+                } catch (_: Exception) {
+                    // Fail closed to an empty working set rather than
+                    // preserving stale spinners.
+                    if (generation == expectedGeneration && activeRelayTarget?.id == target.id) {
+                        mutableSnapshots.value = mutableSnapshots.value.copy(
+                            activeWorkingSessionIds = emptySet(),
+                        )
+                    }
+                }
+            }
+        }
+        val serverOrigin = activeOrigin
+        val originGeneration = generation
+        if (serverOrigin == null || !isCurrentProjectLoad(serverOrigin, originGeneration)) {
+            return viewModelScope.launch { }
+        }
+        return viewModelScope.launch {
+            try {
+                val working = withProjectMetadataSession(
+                    serverOrigin = serverOrigin,
+                    originGeneration = originGeneration,
+                    accessToken = accessTokenForRequest(serverOrigin, originGeneration)
+                        ?: return@launch,
+                ) { session -> session.loadActiveSessionPresence() }
+                if (isCurrentProjectLoad(serverOrigin, originGeneration)) {
+                    mutableSnapshots.value = mutableSnapshots.value.copy(
+                        activeWorkingSessionIds = working,
+                    )
+                }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (_: HermesChatMethodNotFoundException) {
+                // Older server without the snapshot: fail closed to empty.
+                if (isCurrentProjectLoad(serverOrigin, originGeneration)) {
+                    mutableSnapshots.value = mutableSnapshots.value.copy(
+                        activeWorkingSessionIds = emptySet(),
+                    )
+                }
+            } catch (_: Exception) {
+                // Fail closed to an empty working set rather than
+                // preserving stale spinners.
+                if (isCurrentProjectLoad(serverOrigin, originGeneration)) {
+                    mutableSnapshots.value = mutableSnapshots.value.copy(
+                        activeWorkingSessionIds = emptySet(),
+                    )
+                }
+            }
+        }
+    }
+
     fun loadManagementSettings(
         profile: String = mutableSnapshots.value.selectedProfile,
         refreshStatus: Boolean = true,
@@ -2821,6 +2904,69 @@ class HermesConnectionViewModel(
             mutableSnapshots.value.selectedProfile != profile
         ) throw CancellationException("Image connection changed")
         bytes
+    }
+
+    /**
+     * Previously downloaded managed video for [path], if present in the
+     * origin-scoped cache. Never touches the network; powers poster previews.
+     */
+    suspend fun peekManagedVideo(path: String): ManagedVideoMedia? {
+        val cache = videoCache ?: return null
+        val scope = operationGuard.currentScope() ?: return null
+        if (scope.relayTargetId != null || !com.unsupportedpastels.mercury.core.artifacts.ManagedVideoPolicy.isManagedVideoPath(path)) return null
+        var acquired: ManagedVideoMedia? = null
+        try {
+            return operationGuard.run(scope) {
+                withContext(Dispatchers.IO) { cache.acquire(scope.origin, path).also { acquired = it } }
+            }
+        } catch (failure: Throwable) {
+            acquired?.close()
+            throw failure
+        }
+    }
+
+    /**
+     * Download the managed video at [path] into the origin-scoped disk cache and
+     * return the local file for playback. Previously completed downloads are
+     * reused without hitting the network, and concurrent callers targeting the
+     * same entry are serialized behind a shared cache check.
+     */
+    suspend fun downloadManagedVideo(path: String): ManagedVideoMedia {
+        if (!com.unsupportedpastels.mercury.core.artifacts.ManagedVideoPolicy.isManagedVideoPath(path)) {
+            throw HermesConnectionException("Host video path is invalid")
+        }
+        val cache = videoCache ?: throw HermesConnectionException("Managed videos are unavailable")
+        var acquired: ManagedVideoMedia? = null
+        try {
+            return withHermesRestOperation { serverOrigin, accessToken ->
+                val lock = videoDownloadLocks.computeIfAbsent(
+                    "${serverOrigin.value}\u0000$path",
+                ) { Mutex() }
+                lock.withLock {
+                    withContext(Dispatchers.IO) {
+                        cache.acquire(serverOrigin, path)?.also { acquired = it } ?: run {
+                            val reservation = cache.reserve(serverOrigin, path)
+                            acquired = reservation
+                            try {
+                                val downloaded = client.streamManagedVideoToFile(
+                                    serverOrigin, accessToken, path, reservation.file,
+                                )
+                                val media = ManagedVideoMedia(downloaded.file, downloaded.mimeType) { reservation.close() }
+                                acquired = media
+                                cache.prune(serverOrigin, keep = media.file)
+                                media
+                            } catch (failure: Throwable) {
+                                reservation.close()
+                                throw failure
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (failure: Throwable) {
+            acquired?.close()
+            throw failure
+        }
     }
 
     suspend fun createProject(
@@ -6755,6 +6901,7 @@ class HermesConnectionViewModel(
                     ticketClient = KtorWsTicketClient(httpClient),
                     socketFactory = KtorSpeechWebSocketFactory(httpClient),
                 ),
+                videoCache = ManagedVideoCache(File(context.cacheDir, "managed-video")),
             ) as T
         }
     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/files/HostFileModels.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/files/HostFileModels.kt
@@ -1,6 +1,7 @@
 package com.unsupportedpastels.hermesandroid.files
 
 import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import java.io.File
 
 const val MAX_HOST_FILE_ENTRIES = 500
 const val MAX_HOST_FILE_PATH_LENGTH = 1_024
@@ -40,6 +41,21 @@ data class HostFileContent(
         name == other.name && path == other.path && mimeType == other.mimeType && bytes.contentEquals(other.bytes)
 
     override fun hashCode(): Int = 31 * (31 * (31 * name.hashCode() + path.hashCode()) + mimeType.hashCode()) + bytes.contentHashCode()
+}
+
+/** A fully downloaded managed video cached on disk for local playback. */
+class ManagedVideoMedia(
+    val file: File,
+    val mimeType: String,
+    private val release: () -> Unit = {},
+) : AutoCloseable {
+    private val closed = java.util.concurrent.atomic.AtomicBoolean(false)
+    override fun close() {
+        if (closed.compareAndSet(false, true)) release()
+    }
+    override fun equals(other: Any?): Boolean =
+        other is ManagedVideoMedia && file == other.file && mimeType == other.mimeType
+    override fun hashCode(): Int = 31 * file.hashCode() + mimeType.hashCode()
 }
 
 data class HostFileScope(val origin: ServerOrigin, val profile: String) {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/files/ManagedVideoCache.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/files/ManagedVideoCache.kt
@@ -1,0 +1,118 @@
+package com.unsupportedpastels.hermesandroid.files
+
+import com.unsupportedpastels.mercury.core.artifacts.ManagedVideoPolicy
+
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import java.io.File
+import java.security.MessageDigest
+
+/** Per-file download bound for managed videos; videos stream to disk, never RAM. */
+const val MAX_MANAGED_VIDEO_BYTES = ManagedVideoPolicy.MAX_DOWNLOAD_BYTES
+
+/** Total disk budget for cached managed videos per server origin. */
+const val MAX_MANAGED_VIDEO_CACHE_BYTES = ManagedVideoPolicy.MAX_CACHE_BYTES
+
+private val MANAGED_VIDEO_CACHE_EXTENSION = Regex("^[a-z0-9]{1,5}$")
+
+/**
+ * Origin-scoped disk cache for downloaded managed videos.
+ *
+ * Entries are keyed by a SHA-256 of the server path inside a directory derived
+ * from the normalized server origin, so different servers never share cache
+ * entries and a server path can never escape or collide across directories.
+ * Downloads land through a `.part` file renamed into place, so an existing
+ * destination always denotes a complete download.
+ */
+class ManagedVideoCache(private val root: File?) {
+    private val lock = Any()
+    private val pins = mutableMapOf<File, Int>()
+
+    /** Acquire before handing a cache hit to a player or poster decoder. */
+    fun acquire(origin: ServerOrigin, path: String): ManagedVideoMedia? = synchronized(lock) {
+        val media = cached(origin, path) ?: return@synchronized null
+        pin(media.file, media.mimeType)
+    }
+
+    /** Reserve before the downloader can publish a new final file. */
+    fun reserve(origin: ServerOrigin, path: String): ManagedVideoMedia = synchronized(lock) {
+        val file = destinationFor(origin, path)
+        pin(file, mimeTypeFor(file))
+    }
+
+    private fun pin(file: File, mimeType: String): ManagedVideoMedia {
+        pins[file] = (pins[file] ?: 0) + 1
+        return ManagedVideoMedia(file, mimeType) {
+            synchronized(lock) {
+                val remaining = (pins[file] ?: 1) - 1
+                if (remaining == 0) pins.remove(file) else pins[file] = remaining
+            }
+        }
+    }
+
+    fun directoryFor(origin: ServerOrigin): File? {
+        root ?: return null
+        return File(root, sha256Hex(origin.value))
+    }
+
+    /** Returns the previously downloaded media for [path], if still present. */
+    fun cached(origin: ServerOrigin, path: String): ManagedVideoMedia? {
+        directoryFor(origin) ?: return null
+        val file = destinationFor(origin, path)
+        if (!file.isFile || file.length() <= 0L) return null
+        return ManagedVideoMedia(file, mimeTypeFor(file))
+    }
+
+    fun destinationFor(origin: ServerOrigin, path: String): File {
+        val directory = requireNotNull(directoryFor(origin)) {
+            "Managed video cache root is unavailable"
+        }
+        directory.mkdirs()
+        val extension = path.substringAfterLast('.', "").lowercase()
+        val suffix = if (extension.matches(MANAGED_VIDEO_CACHE_EXTENSION)) ".$extension" else ""
+        return File(directory, sha256Hex(path) + suffix)
+    }
+
+    /**
+     * Keeps the origin directory within [budgetBytes]: stale `.part` leftovers are
+     * removed first, then the oldest completed entries are deleted (never [keep]).
+     * Fresh partial downloads and leased final files are not eviction candidates.
+     * They still count toward usage, so the directory may temporarily exceed the
+     * budget while downloads or players retain their files.
+     */
+    fun prune(origin: ServerOrigin, keep: File? = null, budgetBytes: Long = MAX_MANAGED_VIDEO_CACHE_BYTES) = synchronized(lock) {
+        val directory = directoryFor(origin) ?: return@synchronized
+        val staleCutoff = System.currentTimeMillis() - STALE_PART_MILLIS
+        directory.listFiles().orEmpty()
+            .filter { it.isFile && it.name.endsWith(PART_SUFFIX) && it.lastModified() < staleCutoff }
+            .forEach(File::delete)
+
+        var total = directory.listFiles().orEmpty().filter(File::isFile).sumOf(File::length)
+        if (total <= budgetBytes) return@synchronized
+        directory.listFiles().orEmpty()
+            .filter { it.isFile && it != keep && it !in pins && !it.name.endsWith(PART_SUFFIX) }
+            .sortedBy(File::lastModified)
+            .forEach { file ->
+                if (total <= budgetBytes) return@synchronized
+                val size = file.length()
+                if (file.delete()) total -= size
+            }
+    }
+
+    private fun mimeTypeFor(file: File): String = when (file.extension) {
+        "webm" -> "video/webm"
+        "mov" -> "video/quicktime"
+        "m4v" -> "video/x-m4v"
+        "mkv" -> "video/x-matroska"
+        else -> "video/mp4"
+    }
+
+    companion object {
+        const val PART_SUFFIX = ".part"
+        private const val STALE_PART_MILLIS = 24 * 60 * 60 * 1000L
+
+        internal fun sha256Hex(value: String): String = MessageDigest
+            .getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
@@ -15,6 +15,7 @@ import com.unsupportedpastels.hermesandroid.app.SessionSummary
 import com.unsupportedpastels.hermesandroid.app.validProjectWorkspacePath
 import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
 import com.unsupportedpastels.hermesandroid.connection.readBodyTextBounded
+import com.unsupportedpastels.mercury.core.sessions.SessionPresencePolicy
 import com.unsupportedpastels.mercury.core.transcript.ChatEventDecoder
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.webSocketSession
@@ -38,6 +39,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
@@ -483,6 +485,15 @@ interface HermesChatSession {
     suspend fun loadDelegationStatus(): DelegationStatus =
         throw HermesChatMethodNotFoundException("delegation.status")
 
+    /**
+     * Read-only observer presence from the official `session.active_list`
+     * snapshot: durable session IDs currently running a turn in the connected
+     * gateway process. Enumerates without transport rebinding; the result
+     * never implies runtime ownership and must not gate resume affordances.
+     */
+    suspend fun loadActiveSessionPresence(): Set<DurableSessionId> =
+        throw HermesChatMethodNotFoundException("session.active_list")
+
     /** Session-scoped background processes owned by this exact runtime. */
     suspend fun loadProcessList(runtimeSessionId: RuntimeSessionId): List<ProcessRow> =
         throw HermesChatMethodNotFoundException("process.list")
@@ -768,6 +779,27 @@ class HermesChatConnection internal constructor(
             maxSpawnDepth = result.longValue("max_spawn_depth")?.coerceIn(0, 32)?.toInt(),
             maxConcurrentChildren = result.longValue("max_concurrent_children")?.coerceIn(0, 128)?.toInt(),
         )
+    }
+
+    override suspend fun loadActiveSessionPresence(): Set<DurableSessionId> {
+        val result = request(
+            "session.active_list",
+            buildJsonObject { put("current_session_id", "") },
+        )
+        // The shared policy consumes plain decoded shapes so both platforms run
+        // the same decision over their own JSON model; adapt JsonObject here.
+        fun JsonElement.asPlain(): Any? = when (this) {
+            is JsonObject -> entries.associate { it.key to it.value.asPlain() }
+            is JsonArray -> map { it.asPlain() }
+            is JsonPrimitive -> content
+        }
+        return SessionPresencePolicy
+            .parseRows(result.asPlain() as? Map<*, *>)
+            .let(SessionPresencePolicy::workingSessionIds)
+            .map { durableSessionId ->
+                DurableSessionId(durableSessionId)
+            }
+            .toSet()
     }
 
     override suspend fun loadProcessList(runtimeSessionId: RuntimeSessionId): List<ProcessRow> {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesGateway.kt
@@ -143,6 +143,13 @@ data class HermesGatewaySnapshot(
     val projectSessions: Map<ProjectId, List<SessionSummary>> = emptyMap(),
     val projectSessionStates: Map<ProjectId, ProjectSessionLoadState> = emptyMap(),
     val activeRuntimes: List<ActiveRuntimeSession> = emptyList(),
+    /**
+     * Durable session IDs currently running a turn in the connected gateway
+     * process, from the read-only `session.active_list` snapshot. Observer
+     * presence for the working indicator only — never runtime ownership and
+     * never a resume/activate affordance. Fails closed to empty on RPC error.
+     */
+    val activeWorkingSessionIds: Set<DurableSessionId> = emptySet(),
     val chatSessions: Map<DurableSessionId, ChatSessionSnapshot> = emptyMap(),
     val delegationStatus: DelegationStatus = DelegationStatus(),
     val delegationStatusAvailable: Boolean = false,

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
@@ -101,6 +101,7 @@ import com.unsupportedpastels.hermesandroid.gateway.UnsupportedBlockingKind
 import com.unsupportedpastels.hermesandroid.relay.RelayUiState
 import com.unsupportedpastels.mercury.core.relay.RelayPairedTarget
 import com.unsupportedpastels.mercury.core.relay.RelayTargetStatus
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
 import com.unsupportedpastels.hermesandroid.files.HostFileContent
 import com.unsupportedpastels.hermesandroid.files.HostFileListing
 import com.unsupportedpastels.hermesandroid.navigation.HomeRoute
@@ -218,6 +219,7 @@ fun HermesApp(
     onToggleCronJobRuns: (String) -> Unit = {},
     isHomeRefreshing: Boolean = false,
     onRefreshHome: () -> Unit = {},
+    onRefreshWorkingPresence: () -> Unit = {},
     onLoadRecentSessions: () -> Unit = {},
     onLoadMoreRecentSessions: () -> Unit = {},
     onRenameSession: suspend (DurableSessionId, String) -> Result<Unit> = { _, _ -> Result.success(Unit) },
@@ -261,6 +263,10 @@ fun HermesApp(
     onLoadManagedImage: suspend (String) -> Result<ByteArray> = {
         Result.failure(UnsupportedOperationException("Managed images are unavailable"))
     },
+    onLoadManagedVideo: suspend (String) -> Result<ManagedVideoMedia> = {
+        Result.failure(UnsupportedOperationException("Managed videos are unavailable"))
+    },
+    onPeekManagedVideo: suspend (String) -> ManagedVideoMedia? = { null },
     modelPickerState: ModelPickerState = ModelPickerState.Closed,
     onOpenModelPicker: (DurableSessionId) -> Unit = {},
     onDismissModelPicker: () -> Unit = {},
@@ -721,6 +727,7 @@ fun HermesApp(
                     showDockOwnedActions = !supportsNavigationRail,
                     isRefreshing = isHomeRefreshing,
                     onRefresh = onRefreshHome,
+                    onRefreshWorkingPresence = onRefreshWorkingPresence,
                     onLoadManagementSettings = onLoadManagementSettings,
                     onRefreshDurableSessions = onRefreshDurableSessions,
                     onConfigureServer = openServerSettings,
@@ -755,6 +762,7 @@ fun HermesApp(
                     onBack = navigateBack,
                     onLoad = onLoadRecentSessions,
                     onLoadMore = onLoadMoreRecentSessions,
+                    onRefreshWorkingPresence = onRefreshWorkingPresence,
                     onSessionSelected = navigateToSession,
                 )
             }
@@ -921,6 +929,8 @@ fun HermesApp(
                         showBack = !supportsListDetail,
                         onBack = navigateBack,
                         onLoadManagedImage = onLoadManagedImage,
+                        onLoadManagedVideo = onLoadManagedVideo.takeIf { snapshot.relayTargetId == null },
+                        onPeekManagedVideo = onPeekManagedVideo.takeIf { snapshot.relayTargetId == null },
                         onLoadHostFiles = onLoadHostFiles,
                         onLoadManagedFile = onLoadManagedFile,
                         onAttachHostReference = { reference ->

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/Home.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/Home.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.items
@@ -115,10 +117,14 @@ import com.unsupportedpastels.hermesandroid.gateway.RuntimeAccess
 import com.unsupportedpastels.hermesandroid.session.SavedSessionFilter
 import com.unsupportedpastels.hermesandroid.session.SessionListFilter
 import com.unsupportedpastels.hermesandroid.theme.LocalHermesSemanticColors
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 
 private const val HOME_RECENT_SESSION_PREVIEW_LIMIT = 10
+
+/** Silent working-presence poll cadence for the Home session list. */
+internal const val WORKING_PRESENCE_POLL_MILLIS = 3_000L
 
 private fun mergeSessionCollections(
     durableSessions: List<SessionSummary>,
@@ -224,6 +230,7 @@ internal fun SessionListScreen(
     showDockOwnedActions: Boolean = true,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
+    onRefreshWorkingPresence: () -> Unit = {},
     onLoadManagementSettings: (String) -> Unit = {},
     onRefreshDurableSessions: (Boolean) -> Unit = {},
     onConfigureServer: () -> Unit,
@@ -333,6 +340,25 @@ internal fun SessionListScreen(
         .filter { it.access == RuntimeAccess.Controller }
         .mapNotNull { it.durableSessionId }
         .toSet()
+    val activeWorkingSessionIds = snapshot.activeWorkingSessionIds
+    // Silent working-presence poll: authoritative session.active_list state
+    // (joined by durable session_key) every 3s while the Home screen is
+    // visible; the loop stops automatically when the composable leaves.
+    LaunchedEffect(snapshot.connectionState, snapshot.authenticationState) {
+        if (snapshot.connectionState != ConnectionState.Connected ||
+            snapshot.authenticationState !in setOf(
+                AuthenticationState.Authenticated,
+                AuthenticationState.NotRequired,
+            )
+        ) {
+            return@LaunchedEffect
+        }
+        onRefreshWorkingPresence()
+        while (true) {
+            delay(WORKING_PRESENCE_POLL_MILLIS)
+            onRefreshWorkingPresence()
+        }
+    }
     var observedFilterScopeKey by remember { mutableStateOf<String?>(null) }
     LaunchedEffect(serverOrigin, snapshot.authenticationState) {
         if (
@@ -798,6 +824,7 @@ internal fun SessionListScreen(
                                 projectLabel = session.projectId
                                     ?.let { projectId -> projects.firstOrNull { it.id == projectId }?.label },
                                 current = isCurrent,
+                                isWorking = session.id in activeWorkingSessionIds,
                                 onClick = dropUnlessResumed {
                                     onSessionSelected(session.id)
                                 },
@@ -1178,6 +1205,7 @@ private fun RecentSessionHomeRow(
     session: SessionSummary,
     projectLabel: String? = null,
     current: Boolean,
+    isWorking: Boolean = false,
     onClick: () -> Unit,
     onRename: () -> Unit,
     onPin: () -> Unit,
@@ -1214,12 +1242,19 @@ private fun RecentSessionHomeRow(
                     if (current) "Controller active" else null,
                     projectLabel,
                 ).joinToString(" · ")
-                Text(
-                    session.title,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    style = MaterialTheme.typography.titleSmall,
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        session.title,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        style = MaterialTheme.typography.titleSmall,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
+                    if (isWorking) {
+                        Spacer(Modifier.width(8.dp))
+                        WorkingIndicator()
+                    }
+                }
                 if (supportingLabel.isNotEmpty()) {
                     Text(
                         supportingLabel,
@@ -1246,6 +1281,7 @@ internal fun RecentSessionsScreen(
     onBack: () -> Unit,
     onLoad: () -> Unit,
     onLoadMore: () -> Unit,
+    onRefreshWorkingPresence: () -> Unit = {},
     onSessionSelected: (DurableSessionId) -> Unit,
 ) {
     val state = snapshot.recentSessions
@@ -1272,6 +1308,24 @@ internal fun RecentSessionsScreen(
         .filter { it.access == RuntimeAccess.Controller }
         .mapNotNull { it.durableSessionId }
         .toSet()
+    val activeWorkingSessionIds = snapshot.activeWorkingSessionIds
+
+    // Same silent presence poll as Home so the full list stays live.
+    LaunchedEffect(snapshot.connectionState, snapshot.authenticationState) {
+        if (snapshot.connectionState != ConnectionState.Connected ||
+            snapshot.authenticationState !in setOf(
+                AuthenticationState.Authenticated,
+                AuthenticationState.NotRequired,
+            )
+        ) {
+            return@LaunchedEffect
+        }
+        onRefreshWorkingPresence()
+        while (true) {
+            delay(WORKING_PRESENCE_POLL_MILLIS)
+            onRefreshWorkingPresence()
+        }
+    }
 
     LaunchedEffect(snapshot.selectedProfile, snapshot.authenticationState) {
         if (snapshot.authenticationState in setOf(
@@ -1364,6 +1418,7 @@ internal fun RecentSessionsScreen(
                         session = session,
                         projectLabel = projectLabel,
                         current = session.id in activeControllerSessionIds,
+                        isWorking = session.id in activeWorkingSessionIds,
                         onClick = dropUnlessResumed { onSessionSelected(session.id) },
                     )
                 }
@@ -1396,6 +1451,7 @@ private fun RecentSessionFullRow(
     session: SessionSummary,
     projectLabel: String,
     current: Boolean,
+    isWorking: Boolean = false,
     onClick: () -> Unit,
 ) {
     Surface(
@@ -1417,12 +1473,19 @@ private fun RecentSessionFullRow(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(3.dp),
         ) {
-            Text(
-                session.title,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.titleMedium,
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    session.title,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                if (isWorking) {
+                    Spacer(Modifier.width(8.dp))
+                    WorkingIndicator()
+                }
+            }
             Text(
                 projectLabel,
                 maxLines = 1,
@@ -1464,4 +1527,20 @@ private fun connectionContext(
     ConnectionState.Recovering -> "Reconnecting"
     ConnectionState.Disconnected ->
         if (snapshot.relayTargetId == null && serverOrigin == null) "Not configured" else "Offline"
+}
+
+/**
+ * Compact indeterminate "Agent is working" marker for a session row, driven by
+ * the authoritative `session.active_list` working set (observer presence).
+ * Accessibility announces the state explicitly; animation alone is never the
+ * only signal.
+ */
+@Composable
+internal fun WorkingIndicator(modifier: Modifier = Modifier) {
+    CircularProgressIndicator(
+        modifier = modifier
+            .size(14.dp)
+            .semantics { contentDescription = "Agent is working" },
+        strokeWidth = 2.dp,
+    )
 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoPlayer.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoPlayer.kt
@@ -1,0 +1,445 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Fullscreen
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private const val DEFAULT_VIDEO_ASPECT = 16f / 9f
+private const val MIN_VIDEO_ASPECT = 0.4f
+private const val MAX_VIDEO_ASPECT = 2.5f
+private const val MAX_POSTER_DIMENSION = 720
+private const val MAX_POSTER_CACHE_ENTRIES = 8
+
+/** Small in-memory LRU of poster frames keyed by the MEDIA source. */
+private object ManagedVideoPosterRuntime {
+    private val cache = object : LinkedHashMap<String, ImageBitmap>(
+        MAX_POSTER_CACHE_ENTRIES,
+        0.75f,
+        true,
+    ) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, ImageBitmap>?): Boolean =
+            size > MAX_POSTER_CACHE_ENTRIES
+    }
+
+    @Synchronized
+    fun get(source: String): ImageBitmap? = cache[source]
+
+    @Synchronized
+    fun put(source: String, bitmap: ImageBitmap) {
+        cache[source] = bitmap
+    }
+}
+
+private fun posterFileFor(media: ManagedVideoMedia): File =
+    File(media.file.parentFile, media.file.nameWithoutExtension + ".jpg")
+
+private fun decodePosterFile(file: File): ImageBitmap? =
+    BitmapFactory.decodeFile(file.absolutePath)?.asImageBitmap()
+
+/**
+ * Extracts a downscaled first frame from the downloaded video and, when
+ * [destination] is given, persists it as a JPEG poster next to the video.
+ */
+private suspend fun extractPosterFrame(file: File, destination: File?): ImageBitmap? =
+    withContext(Dispatchers.IO) {
+        runCatching {
+            MediaMetadataRetriever().use { retriever ->
+                retriever.setDataSource(file.absolutePath)
+                val frame = retriever.getFrameAtTime(
+                    0L,
+                    MediaMetadataRetriever.OPTION_CLOSEST_SYNC,
+                ) ?: return@runCatching null
+                val scale = minOf(
+                    1f,
+                    MAX_POSTER_DIMENSION.toFloat() / maxOf(frame.width, frame.height),
+                )
+                val bitmap = if (scale < 1f) {
+                    Bitmap.createScaledBitmap(
+                        frame,
+                        (frame.width * scale).toInt().coerceAtLeast(1),
+                        (frame.height * scale).toInt().coerceAtLeast(1),
+                        true,
+                    )
+                } else {
+                    frame
+                }
+                destination?.let { poster ->
+                    runCatching {
+                        FileOutputStream(poster).use { out ->
+                            bitmap.compress(Bitmap.CompressFormat.JPEG, 80, out)
+                        }
+                    }
+                }
+                bitmap.asImageBitmap()
+            }
+        }.getOrNull()
+    }
+
+/**
+ * Inline managed-video player for chat MEDIA blocks and the artifact browser.
+ *
+ * Playback is always fed from a fully downloaded, origin-scoped cache file: the
+ * bearer token never reaches the player and no streaming URL is embedded in the
+ * view hierarchy. Downloaded videos start playing immediately; a poster frame
+ * extracted from the file is shown while idle once the video is in cache.
+ */
+// PlayerView.switchTargetView (fullscreen hand-off) is UnstableApi in media3.
+@androidx.annotation.OptIn(UnstableApi::class)
+@Composable
+internal fun ManagedVideoBlock(
+    source: String,
+    modifier: Modifier = Modifier,
+    onLoadManagedVideo: (suspend (String) -> Result<ManagedVideoMedia>)? = null,
+    onPeekManagedVideo: (suspend (String) -> ManagedVideoMedia?)? = null,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var media by remember(source) { mutableStateOf<ManagedVideoMedia?>(null) }
+    val mediaOwner = remember(source) { ManagedVideoPresentationLease() }
+    DisposableEffect(mediaOwner) { onDispose { mediaOwner.close() } }
+    var loading by remember(source) { mutableStateOf(false) }
+    var error by remember(source) { mutableStateOf<String?>(null) }
+    var playbackError by remember(media) { mutableStateOf<String?>(null) }
+    var fullscreen by remember(media) { mutableStateOf(false) }
+    var poster by remember(source) { mutableStateOf<ImageBitmap?>(null) }
+
+    // Poster cache entries are keyed by the origin-scoped cache file, never by
+    // the raw source path: different servers may reference the same path, and
+    // the frame must always come from the file this server's cache owns.
+    fun posterKey(media: ManagedVideoMedia): String = media.file.absolutePath
+
+    LaunchedEffect(source, onPeekManagedVideo) {
+        val peek = onPeekManagedVideo ?: return@LaunchedEffect
+        val cached = runCatching { peek(source) }.getOrNull() ?: return@LaunchedEffect
+        try {
+            val key = posterKey(cached)
+            val existing = ManagedVideoPosterRuntime.get(key)
+            if (existing != null) {
+                poster = existing
+                return@LaunchedEffect
+            }
+            val posterFile = posterFileFor(cached)
+            val frame = if (posterFile.isFile) {
+                decodePosterFile(posterFile)
+            } else {
+                extractPosterFrame(cached.file, posterFile)
+            }
+            if (frame != null) {
+                ManagedVideoPosterRuntime.put(key, frame)
+                poster = frame
+            }
+        } finally {
+            cached.close()
+        }
+    }
+
+    val player = remember(media) {
+        media?.let { loaded ->
+            ExoPlayer.Builder(context).build().apply {
+                setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(C.USAGE_MEDIA)
+                        .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+                        .build(),
+                    /* handleAudioFocus = */ true,
+                )
+                setMediaItem(MediaItem.fromUri(Uri.fromFile(loaded.file)))
+                addListener(
+                    object : Player.Listener {
+                        override fun onPlayerError(failure: PlaybackException) {
+                            playbackError = "Playback failed"
+                        }
+                    },
+                )
+                prepare()
+                // One tap starts the whole flow: download, then playback.
+                playWhenReady = true
+            }
+        }
+    }
+    val lifecycle = androidx.lifecycle.compose.LocalLifecycleOwner.current.lifecycle
+    DisposableEffect(player, lifecycle) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_STOP) player?.pause()
+        }
+        lifecycle.addObserver(observer)
+        if (!lifecycle.currentState.isAtLeast(androidx.lifecycle.Lifecycle.State.STARTED)) player?.pause()
+        onDispose {
+            lifecycle.removeObserver(observer)
+            player?.release()
+        }
+    }
+
+    fun startLoading() {
+        val loader = onLoadManagedVideo
+        if (loader == null) {
+            error = "Video playback is unavailable"
+            return
+        }
+        scope.launch {
+            loading = true
+            error = null
+            loader(source).fold(
+                onSuccess = { loaded ->
+                    if (!mediaOwner.adopt(loaded)) return@fold
+                    media = loaded
+                    val key = posterKey(loaded)
+                    if (ManagedVideoPosterRuntime.get(key) == null) {
+                        val frame = extractPosterFrame(loaded.file, posterFileFor(loaded))
+                        if (frame != null) {
+                            ManagedVideoPosterRuntime.put(key, frame)
+                            poster = frame
+                        }
+                    }
+                },
+                onFailure = { failure ->
+                    if (failure is kotlinx.coroutines.CancellationException) throw failure
+                    error = "Could not load video"
+                },
+            )
+            loading = false
+        }
+    }
+
+    val aspect = poster?.let { bitmap ->
+        (bitmap.width.toFloat() / bitmap.height.coerceAtLeast(1))
+            .coerceIn(MIN_VIDEO_ASPECT, MAX_VIDEO_ASPECT)
+    } ?: DEFAULT_VIDEO_ASPECT
+    val surfaceModifier = modifier
+        .fillMaxWidth()
+        .aspectRatio(aspect)
+        .clip(RoundedCornerShape(8.dp))
+    if (media == null) {
+        Box(
+            modifier = surfaceModifier.background(
+                MaterialTheme.colorScheme.surfaceVariant,
+                RoundedCornerShape(8.dp),
+            ),
+            contentAlignment = Alignment.Center,
+        ) {
+            poster?.let { frame ->
+                Image(
+                    bitmap = frame,
+                    contentDescription = null,
+                    modifier = Modifier.matchParentSize(),
+                    contentScale = ContentScale.Crop,
+                )
+            }
+            when {
+                onLoadManagedVideo == null -> Text("Video playback is unavailable")
+                loading -> Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(Color.Black.copy(alpha = 0.35f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        CircularProgressIndicator(color = Color.White)
+                        Text("Loading video…", color = Color.White)
+                    }
+                }
+                error != null -> Column(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        error.orEmpty(),
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    TextButton(onClick = { startLoading() }) { Text("Retry") }
+                }
+                else -> PlayOverlayButton(
+                    description = "Play video",
+                    onClick = { startLoading() },
+                )
+            }
+        }
+    } else {
+        val inlineView = remember { mutableStateOf<PlayerView?>(null) }
+        Box(modifier = surfaceModifier) {
+            AndroidView(
+                factory = { holder -> PlayerView(holder).apply { useController = true } },
+                update = { view ->
+                    inlineView.value = view
+                    if (!fullscreen && view.player !== player) {
+                        view.player = player
+                    }
+                },
+                modifier = Modifier.fillMaxSize(),
+            )
+            IconButton(
+                onClick = { fullscreen = true },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .size(40.dp)
+                    .semantics { contentDescription = "Open fullscreen video" },
+            ) {
+                Icon(
+                    Icons.Rounded.Fullscreen,
+                    contentDescription = null,
+                    tint = Color.White,
+                )
+            }
+        }
+
+        if (fullscreen && player != null) {
+            var dialogView by remember { mutableStateOf<PlayerView?>(null) }
+            fun closeFullscreen() {
+                val dialog = dialogView
+                val inline = inlineView.value
+                if (dialog != null && inline != null) {
+                    PlayerView.switchTargetView(player, dialog, inline)
+                }
+                fullscreen = false
+            }
+            Dialog(
+                onDismissRequest = { closeFullscreen() },
+                properties = DialogProperties(
+                    usePlatformDefaultWidth = false,
+                    decorFitsSystemWindows = false,
+                ),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black)
+                        .safeDrawingPadding(),
+                ) {
+                    AndroidView(
+                        factory = { holder ->
+                            PlayerView(holder).apply {
+                                useController = true
+                                val previous = inlineView.value
+                                if (previous != null) {
+                                    PlayerView.switchTargetView(player, previous, this)
+                                } else {
+                                    this.player = player
+                                }
+                            }
+                        },
+                        update = { view -> dialogView = view },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    IconButton(
+                        onClick = { closeFullscreen() },
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .size(48.dp),
+                    ) {
+                        Icon(
+                            Icons.Rounded.Close,
+                            contentDescription = "Close fullscreen video",
+                            tint = Color.White,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    playbackError?.let { message ->
+        Text(
+            text = message,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 4.dp),
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+@Composable
+private fun BoxScope.PlayOverlayButton(
+    description: String,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        shape = CircleShape,
+        color = Color.Black.copy(alpha = 0.55f),
+        modifier = Modifier
+            .align(Alignment.Center)
+            .size(56.dp)
+            .semantics { contentDescription = description },
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                Icons.Rounded.PlayArrow,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(36.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoPresentationLease.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoPresentationLease.kt
@@ -1,0 +1,25 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
+
+/** Main-thread presentation owner, including results arriving after disposal. */
+internal class ManagedVideoPresentationLease : AutoCloseable {
+    private var current: ManagedVideoMedia? = null
+    private var disposed = false
+
+    fun adopt(media: ManagedVideoMedia): Boolean {
+        if (disposed) {
+            media.close()
+            return false
+        }
+        if (current !== media) current?.close()
+        current = media
+        return true
+    }
+
+    override fun close() {
+        disposed = true
+        current?.close()
+        current = null
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
 
 internal sealed interface MarkdownBlock
 
@@ -84,6 +85,10 @@ internal data class MarkdownImageBlock(
     val url: String,
 ) : MarkdownBlock
 
+internal data class MarkdownVideoBlock(
+    val url: String,
+) : MarkdownBlock
+
 internal enum class MarkdownTableAlignment {
     Start,
     Center,
@@ -105,7 +110,7 @@ internal data class MarkdownTableBlock(
 private val unorderedListPattern = Regex("^(\\s*)[-+*]\\s+(.+)$")
 private val orderedListPattern = Regex("^(\\s*)(\\d+[.)])\\s+(.+)$")
 private val headingPattern = Regex("^(#{1,6})\\s+(.+)$")
-private val mediaDirectivePattern = Regex("^MEDIA:(\\S+)$")
+
 private val imageAttachmentMarkerPattern = Regex(
     pattern = """^\[Image attached at: [^\]\r\n]+]\r?\n(?=data:image/)""",
     option = RegexOption.MULTILINE,
@@ -303,12 +308,18 @@ internal fun parseMessageMarkdown(source: String): List<MarkdownBlock> {
     while (index < lines.size) {
         val line = lines[index]
         val trimmedStart = line.trimStart()
-        val media = mediaDirectivePattern.matchEntire(trimmedStart)
-        if (media != null) {
-            val source = media.groupValues[1]
+        val mediaSource = com.unsupportedpastels.mercury.core.artifacts.ArtifactExtractor.standaloneMediaSource(line)
+        if (mediaSource != null) {
+            val source = mediaSource
             if (validateRemoteMediaUrl(source) || validateGatewayMediaPath(source)) {
                 flushParagraph()
                 blocks += MarkdownImageBlock(source)
+                index += 1
+                continue
+            }
+            if (validateGatewayVideoPath(source)) {
+                flushParagraph()
+                blocks += MarkdownVideoBlock(source)
                 index += 1
                 continue
             }
@@ -547,6 +558,8 @@ internal fun MarkdownMessage(
     text: String,
     modifier: Modifier = Modifier,
     loadManagedImage: (suspend (String) -> ByteArray)? = null,
+    loadManagedVideo: (suspend (String) -> Result<ManagedVideoMedia>)? = null,
+    peekManagedVideo: (suspend (String) -> ManagedVideoMedia?)? = null,
 ) {
     val displayText = remember(text) { compactEmbeddedPayloads(text) }
     var requestedCharacters by rememberSaveable(displayText) {
@@ -574,6 +587,11 @@ internal fun MarkdownMessage(
                         is MarkdownImageBlock -> RemoteMediaImage(
                             source = block.url,
                             loadManagedImage = loadManagedImage,
+                        )
+                        is MarkdownVideoBlock -> ManagedVideoBlock(
+                            source = block.url,
+                            onLoadManagedVideo = loadManagedVideo,
+                            onPeekManagedVideo = peekManagedVideo,
                         )
                         is MarkdownTableBlock -> MarkdownTable(block)
                     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImage.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImage.kt
@@ -112,6 +112,9 @@ internal fun hostResolvesToPublicNetwork(
 internal fun resolveHostToAddresses(host: String): List<InetAddress> =
     runCatching { InetAddress.getAllByName(host).toList() }.getOrElse { emptyList() }
 
+internal fun validateGatewayVideoPath(value: String): Boolean =
+    com.unsupportedpastels.mercury.core.artifacts.ManagedVideoPolicy.isManagedVideoPath(value)
+
 internal fun validateGatewayMediaPath(value: String): Boolean =
     value.startsWith('/') &&
         '\u0000' !in value &&

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetail.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetail.kt
@@ -174,6 +174,7 @@ import com.unsupportedpastels.hermesandroid.gateway.ModelSelection
 import com.unsupportedpastels.hermesandroid.gateway.UnsupportedBlockingKind
 import com.unsupportedpastels.hermesandroid.gateway.SlashCompletionItem
 import com.unsupportedpastels.hermesandroid.gateway.ValidReasoningEfforts
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
 import com.unsupportedpastels.hermesandroid.files.HostFileContent
 import com.unsupportedpastels.hermesandroid.files.HostFileListing
 import com.unsupportedpastels.hermesandroid.theme.LocalHermesSemanticColors
@@ -456,6 +457,8 @@ internal fun SessionDetailScreen(
     showBack: Boolean,
     onBack: () -> Unit,
     onLoadManagedImage: suspend (String) -> Result<ByteArray>,
+    onLoadManagedVideo: (suspend (String) -> Result<ManagedVideoMedia>)? = null,
+    onPeekManagedVideo: (suspend (String) -> ManagedVideoMedia?)? = null,
     onLoadHostFiles: suspend (String?) -> Result<HostFileListing>,
     onLoadManagedFile: suspend (String) -> Result<HostFileContent>,
     onAttachHostReference: (String) -> Unit,
@@ -715,6 +718,8 @@ internal fun SessionDetailScreen(
                                     loadManagedImage = { path ->
                                         onLoadManagedImage(path).getOrThrow()
                                     },
+                                    loadManagedVideo = onLoadManagedVideo,
+                                    peekManagedVideo = onPeekManagedVideo,
                                 )
                                 return@items
                             }
@@ -734,6 +739,8 @@ internal fun SessionDetailScreen(
                                     loadManagedImage = { path ->
                                         onLoadManagedImage(path).getOrThrow()
                                     },
+                                    loadManagedVideo = onLoadManagedVideo,
+                                    peekManagedVideo = onPeekManagedVideo,
                                 )
                                 return@items
                             }
@@ -773,6 +780,8 @@ internal fun SessionDetailScreen(
                                             loadManagedImage = { path ->
                                                 onLoadManagedImage(path).getOrThrow()
                                             },
+                                            loadManagedVideo = onLoadManagedVideo,
+                                            peekManagedVideo = onPeekManagedVideo,
                                         )
                                     }
                                     message.role == ChatMessageRole.User -> {
@@ -802,6 +811,8 @@ internal fun SessionDetailScreen(
                                                     loadManagedImage = { path ->
                                                         onLoadManagedImage(path).getOrThrow()
                                                     },
+                                                    loadManagedVideo = onLoadManagedVideo,
+                                                    peekManagedVideo = onPeekManagedVideo,
                                                 )
                                             }
                                         }
@@ -821,6 +832,8 @@ internal fun SessionDetailScreen(
                                                 loadManagedImage = { path ->
                                                     onLoadManagedImage(path).getOrThrow()
                                                 },
+                                                loadManagedVideo = onLoadManagedVideo,
+                                                peekManagedVideo = onPeekManagedVideo,
                                             )
                                         }
                                         val streamingTail = renderedText.substring(stableLength)
@@ -838,6 +851,8 @@ internal fun SessionDetailScreen(
                                             loadManagedImage = { path ->
                                                 onLoadManagedImage(path).getOrThrow()
                                             },
+                                            loadManagedVideo = onLoadManagedVideo,
+                                            peekManagedVideo = onPeekManagedVideo,
                                         )
                                     }
                                 }
@@ -1435,6 +1450,8 @@ internal fun SessionDetailScreen(
             artifacts = sessionArtifacts,
             onDismiss = { showArtifacts = false },
             onLoadManagedImage = onLoadManagedImage,
+            onLoadManagedVideo = onLoadManagedVideo,
+            onPeekManagedVideo = onPeekManagedVideo,
             onLoadManagedFile = onLoadManagedFile,
         )
     }
@@ -1556,6 +1573,8 @@ private fun ArtifactBrowserSheet(
     artifacts: List<Artifact>,
     onDismiss: () -> Unit,
     onLoadManagedImage: suspend (String) -> Result<ByteArray>,
+    onLoadManagedVideo: (suspend (String) -> Result<ManagedVideoMedia>)? = null,
+    onPeekManagedVideo: (suspend (String) -> ManagedVideoMedia?)? = null,
     onLoadManagedFile: suspend (String) -> Result<HostFileContent>,
 ) {
     val context = LocalContext.current
@@ -1743,6 +1762,16 @@ private fun ArtifactBrowserSheet(
                                 artifact.origin == ArtifactOrigin.ManagedPath
                             ) {
                                 ManagedAudioPlayer(artifact, onLoadManagedFile)
+                            }
+                            if (
+                                artifact.type == ArtifactType.Video &&
+                                artifact.origin == ArtifactOrigin.ManagedPath
+                            ) {
+                                ManagedVideoBlock(
+                                    source = artifact.source,
+                                    onLoadManagedVideo = onLoadManagedVideo,
+                                    onPeekManagedVideo = onPeekManagedVideo,
+                                )
                             }
                             HorizontalDivider()
                         }
@@ -2587,6 +2616,8 @@ private fun ToolMessageBlock(
     expanded: Boolean,
     onToggle: () -> Unit,
     loadManagedImage: (suspend (String) -> ByteArray)? = null,
+    loadManagedVideo: (suspend (String) -> Result<ManagedVideoMedia>)? = null,
+    peekManagedVideo: (suspend (String) -> ManagedVideoMedia?)? = null,
 ) {
     val preview = remember(text) {
         text.replace('\n', ' ').trim().take(80)
@@ -2642,6 +2673,8 @@ private fun ToolMessageBlock(
                 MarkdownMessage(
                     text,
                     loadManagedImage = loadManagedImage,
+                    loadManagedVideo = loadManagedVideo,
+                    peekManagedVideo = peekManagedVideo,
                 )
             }
         }
@@ -2661,6 +2694,8 @@ private fun TranscriptToolRunGroup(
     onToggle: () -> Unit,
     sessionKey: String,
     loadManagedImage: (suspend (String) -> ByteArray)? = null,
+    loadManagedVideo: (suspend (String) -> Result<ManagedVideoMedia>)? = null,
+    peekManagedVideo: (suspend (String) -> ManagedVideoMedia?)? = null,
 ) {
     val semanticColors = LocalHermesSemanticColors.current
     val noun = if (tools.size == 1) "action" else "actions"
@@ -2720,6 +2755,8 @@ private fun TranscriptToolRunGroup(
                             expanded = showToolMessage,
                             onToggle = { showToolMessage = !showToolMessage },
                             loadManagedImage = loadManagedImage,
+                            loadManagedVideo = loadManagedVideo,
+                            peekManagedVideo = peekManagedVideo,
                         )
                     }
                 }
@@ -2741,6 +2778,8 @@ private fun WorkBurstGroup(
     onToggle: () -> Unit,
     sessionKey: String,
     loadManagedImage: (suspend (String) -> ByteArray)? = null,
+    loadManagedVideo: (suspend (String) -> Result<ManagedVideoMedia>)? = null,
+    peekManagedVideo: (suspend (String) -> ManagedVideoMedia?)? = null,
 ) {
     val stepCount = reasoning.size + tools.size
     val noun = if (stepCount == 1) "step" else "steps"
@@ -2809,6 +2848,8 @@ private fun WorkBurstGroup(
                         onToggle = { toolsExpanded = !toolsExpanded },
                         sessionKey = sessionKey,
                         loadManagedImage = loadManagedImage,
+                        loadManagedVideo = loadManagedVideo,
+                        peekManagedVideo = peekManagedVideo,
                     )
                 }
             }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/artifacts/ArtifactExtractorTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/artifacts/ArtifactExtractorTest.kt
@@ -63,6 +63,28 @@ class ArtifactExtractorTest {
     }
 
     @Test
+    fun classifiesManagedAndRemoteVideoSources() {
+        val artifacts = ArtifactExtractor.extract(
+            """
+            MEDIA:/workspace/scene-00/preview.mp4
+            [Video: moving preview](https://cdn.example/previews/scene.webm?dl=1)
+            """.trimIndent(),
+        )
+
+        assertEquals(listOf(ArtifactType.Video, ArtifactType.Video), artifacts.map { it.type })
+        assertEquals(ArtifactOrigin.ManagedPath, artifacts[0].origin)
+        assertEquals(ArtifactOrigin.RemoteUrl, artifacts[1].origin)
+        assertEquals("preview.mp4", artifacts[0].displayName)
+    }
+
+    @Test
+    fun videoLabelPrefixClassifiesWithoutExtension() {
+        val artifacts = ArtifactExtractor.extract("[Video: demo](https://files.example/download)")
+
+        assertEquals(ArtifactType.Video, artifacts.single().type)
+    }
+
+    @Test
     fun rejectsUnsafeUrlsMalformedSourcesAndArbitraryProse() {
         val credentialedUrl = "https://user" + ":pass@example.com/secret.png"
         val artifacts = ArtifactExtractor.extract(

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
@@ -19,10 +19,14 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
 import com.unsupportedpastels.hermesandroid.app.DurableSessionId
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessage
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessageRole
@@ -392,6 +396,111 @@ class HermesConnectionClientTest {
         )
 
         assertTrue(downloaded.contentEquals(bytes))
+    }
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun managedVideoStreamsAuthenticatedBodyIntoDestinationFile() = runTest {
+        val bytes = byteArrayOf(9, 8, 7, 6, 5)
+        val engine = MockEngine { request ->
+            assertEquals("/api/files/download", request.url.encodedPath)
+            assertEquals("/workspace/scene-00/preview.mp4", request.url.parameters["path"])
+            assertEquals("Bearer opaque-access", request.headers[HttpHeaders.Authorization])
+            respond(
+                content = bytes,
+                headers = headersOf(HttpHeaders.ContentType, "video/mp4"),
+            )
+        }
+        val client = HttpHermesConnectionClient(HttpClient(engine))
+        val destination = File(tempFolder.root, "preview.mp4")
+
+        val media = client.streamManagedVideoToFile(
+            ServerOrigin.parse("https://hermes.example"),
+            "opaque-access",
+            "/workspace/scene-00/preview.mp4",
+            destination,
+        )
+
+        assertEquals("video/mp4", media.mimeType)
+        assertEquals(destination.absolutePath, media.file.absolutePath)
+        assertArrayEquals(bytes, destination.readBytes())
+        assertFalse(File(tempFolder.root, "preview.mp4.part").exists())
+    }
+
+    @Test
+    fun managedVideoRejectsNonVideoContentTypeWithoutWritingDestination() = runTest {
+        val engine = MockEngine {
+            respond(
+                content = ByteArray(4),
+                headers = headersOf(HttpHeaders.ContentType, "image/jpeg"),
+            )
+        }
+        val client = HttpHermesConnectionClient(HttpClient(engine))
+        val destination = File(tempFolder.root, "clip.mp4")
+
+        val failure = runCatching {
+            client.streamManagedVideoToFile(
+                ServerOrigin.parse("https://hermes.example"),
+                "opaque-access",
+                "/workspace/scene-00/clip.mp4",
+                destination,
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is HermesConnectionException)
+        assertFalse(destination.exists())
+    }
+
+    @Test
+    fun managedVideoRejectsRelativePathBeforeAnyRequest() = runTest {
+        var requests = 0
+        val engine = MockEngine {
+            requests += 1
+            respond(content = ByteArray(0), headers = headersOf(HttpHeaders.ContentType, "video/mp4"))
+        }
+        val client = HttpHermesConnectionClient(HttpClient(engine))
+
+        val failure = runCatching {
+            client.streamManagedVideoToFile(
+                ServerOrigin.parse("https://hermes.example"),
+                "opaque-access",
+                "relative/clip.mp4",
+                File(tempFolder.root, "clip.mp4"),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is HermesConnectionException)
+        assertEquals(0, requests)
+    }
+
+    @Test
+    fun managedVideoRejectsBodyLargerThanCapAndLeavesNoPartialFile() = runTest {
+        val engine = MockEngine {
+            respond(
+                content = ByteArray(64),
+                headers = headersOf(HttpHeaders.ContentType, "video/mp4"),
+            )
+        }
+        val client = HttpHermesConnectionClient(HttpClient(engine))
+        val destination = File(tempFolder.root, "clip.mp4")
+
+        val failure = runCatching {
+            client.streamManagedVideoToFile(
+                ServerOrigin.parse("https://hermes.example"),
+                "opaque-access",
+                "/workspace/scene-00/clip.mp4",
+                destination,
+                maxBytes = 16L,
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is HermesConnectionException)
+        assertFalse(destination.exists())
+        tempFolder.root.listFiles().orEmpty().forEach { file ->
+            assertFalse("leftover ${file.name}", file.name.endsWith(".part"))
+        }
     }
 
     @Test

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
@@ -4,6 +4,8 @@ import com.unsupportedpastels.hermesandroid.cache.CacheScope
 import com.unsupportedpastels.hermesandroid.cache.CachedSession
 import com.unsupportedpastels.hermesandroid.cache.OfflineCacheRepository
 import com.unsupportedpastels.hermesandroid.cache.OfflineCacheSnapshot
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoCache
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
 import com.unsupportedpastels.hermesandroid.gateway.CacheSource
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessage
 import com.unsupportedpastels.hermesandroid.gateway.AuthenticationState
@@ -61,9 +63,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.nio.file.Files
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -126,6 +132,149 @@ class HermesConnectionViewModelTest {
         assertTrue(snapshot.nativeOAuthSupported)
         assertEquals(listOf("nous"), snapshot.authProviders.map { it.name })
         assertEquals(listOf(origin), client.probedOrigins)
+    }
+
+    @Test
+    fun videoDownloadCannotReturnOldOriginMediaAfterSettingsChange() = runTest(dispatcher) {
+        val origin = ServerOrigin.parse("https://hermes.example")
+        val other = ServerOrigin.parse("https://other.example")
+        val settings = MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin))
+        val cacheRoot = Files.createTempDirectory("video-origin-race").toFile()
+        try {
+            val client = GatedVideoDownloadClient()
+            val cache = ManagedVideoCache(cacheRoot)
+            val viewModel = HermesConnectionViewModel(settings, client, videoCache = cache)
+            client.connection.complete(HermesConnectionInfo(
+                version = "0.20.0", authRequired = false, nativeOAuthSupported = false, providers = emptyList(),
+            ))
+            advanceUntilIdle()
+            assertEquals(AuthenticationState.NotRequired, viewModel.snapshots.value.authenticationState)
+            val pending = async { runCatching { viewModel.downloadManagedVideo("/a/clip.mp4") } }
+            client.firstDownloadStarted.await()
+            settings.value = ServerSettingsState.Ready(other)
+            advanceUntilIdle()
+            client.gate.complete(Unit)
+            val result = pending.await()
+            assertTrue(result.exceptionOrNull() is kotlinx.coroutines.CancellationException)
+            val staleMedia = cache.destinationFor(origin, "/a/clip.mp4")
+            cache.prune(origin, budgetBytes = 0L)
+            assertFalse(staleMedia.exists())
+            assertEquals(null, viewModel.peekManagedVideo("/a/clip.mp4"))
+        } finally {
+            cacheRoot.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun concurrentDownloadsOfTheSamePathSerializeBehindOneCacheEntry() = runTest(dispatcher) {
+        val origin = ServerOrigin.parse("https://hermes.example")
+        val settings = MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin))
+        val cacheRoot = Files.createTempDirectory("video-cache").toFile()
+        val client = GatedVideoDownloadClient()
+        val viewModel = HermesConnectionViewModel(
+            settings,
+            client,
+            videoCache = ManagedVideoCache(cacheRoot),
+        )
+
+        runCurrent()
+        client.connection.complete(
+            HermesConnectionInfo(
+                version = "0.20.0",
+                authRequired = false,
+                nativeOAuthSupported = false,
+                providers = emptyList(),
+            ),
+        )
+        advanceUntilIdle()
+
+        val first = async { viewModel.downloadManagedVideo("/a/clip.mp4") }
+        val second = async { viewModel.downloadManagedVideo("/a/clip.mp4") }
+        client.firstDownloadStarted.await()
+
+        // The second caller must wait behind the first instead of streaming into
+        // the same .part file concurrently.
+        assertEquals(1, client.started)
+        assertEquals(1, client.active)
+        client.gate.complete(Unit)
+        advanceUntilIdle()
+
+        val firstMedia = first.await()
+        val secondMedia = second.await()
+        assertEquals(1, client.started)
+        assertEquals(firstMedia.file.absolutePath, secondMedia.file.absolutePath)
+        assertTrue(secondMedia.file.isFile)
+
+        cacheRoot.deleteRecursively()
+    }
+
+    @Test
+    fun failedVideoDownloadReleasesItsCacheLease() = runTest(dispatcher) {
+        val origin = ServerOrigin.parse("https://hermes.example")
+        val settings = MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin))
+        val cacheRoot = Files.createTempDirectory("video-failed-download").toFile()
+        try {
+            val client = FailedVideoDownloadClient()
+            val cache = ManagedVideoCache(cacheRoot)
+            val viewModel = HermesConnectionViewModel(
+                settings,
+                client,
+                videoCache = cache,
+            )
+            runCurrent()
+            client.connection.complete(
+                HermesConnectionInfo(
+                    version = "0.20.0",
+                    authRequired = false,
+                    nativeOAuthSupported = false,
+                    providers = emptyList(),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertTrue(runCatching { viewModel.downloadManagedVideo("/a/clip.mp4") }.isFailure)
+            val destination = cache.destinationFor(origin, "/a/clip.mp4")
+            cache.prune(origin, budgetBytes = 0L)
+            assertFalse("a failed download must release its lease", destination.exists())
+        } finally {
+            cacheRoot.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun cancelledVideoDownloadReleasesItsCacheLease() = runTest(dispatcher) {
+        val origin = ServerOrigin.parse("https://hermes.example")
+        val settings = MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin))
+        val cacheRoot = Files.createTempDirectory("video-cancelled-download").toFile()
+        try {
+            val client = CancelledVideoDownloadClient()
+            val cache = ManagedVideoCache(cacheRoot)
+            val viewModel = HermesConnectionViewModel(
+                settings,
+                client,
+                videoCache = cache,
+            )
+            runCurrent()
+            client.connection.complete(
+                HermesConnectionInfo(
+                    version = "0.20.0",
+                    authRequired = false,
+                    nativeOAuthSupported = false,
+                    providers = emptyList(),
+                ),
+            )
+            advanceUntilIdle()
+
+            val pending = async { viewModel.downloadManagedVideo("/a/clip.mp4") }
+            client.started.await()
+            pending.cancelAndJoin()
+
+            val destination = cache.destinationFor(origin, "/a/clip.mp4")
+            cache.prune(origin, budgetBytes = 0L)
+            assertFalse("a cancelled download must release its lease", destination.exists())
+        } finally {
+            cacheRoot.deleteRecursively()
+        }
     }
 
     @Test
@@ -299,6 +448,44 @@ class HermesConnectionViewModelTest {
         advanceUntilIdle()
 
         assertEquals(listOf(CacheScope(origin, "default")), cache.clearedTranscriptScopes)
+    }
+
+    @Test
+    fun refreshActiveWorkingSessionsPublishesPresenceAndFailsClosed() = runTest(dispatcher) {
+        val origin = ServerOrigin.parse("https://hermes.example")
+        val client = AuthenticatingHermesConnectionClient()
+        val metadata = PresenceAwareMetadataSession(
+            ProjectTreeResult(emptyList()),
+            presence = setOf(DurableSessionId("dur-1")),
+        )
+        val viewModel = HermesConnectionViewModel(
+            settingsStates = MutableStateFlow(ServerSettingsState.Ready(origin)),
+            client = client,
+            tokenStore = FixedTokenStore(),
+            projectConnector = HermesChatConnector { _, _ -> metadata },
+        )
+        runCurrent()
+        client.probeResponse.complete(authRequiredInfo())
+        runCurrent()
+        client.authenticationResponse.complete(AuthenticatedHermesConnection("user", emptyList()))
+        advanceUntilIdle()
+
+        assertEquals(AuthenticationState.Authenticated, viewModel.snapshots.value.authenticationState)
+
+        viewModel.refreshActiveWorkingSessions().join()
+        assertEquals(
+            setOf(DurableSessionId("dur-1")),
+            viewModel.snapshots.value.activeWorkingSessionIds,
+        )
+
+        // Fail closed: a failing read-only poll clears the working set instead
+        // of preserving stale spinners.
+        metadata.failure = RuntimeException("transient")
+        viewModel.refreshActiveWorkingSessions().join()
+        assertEquals(
+            emptySet<DurableSessionId>(),
+            viewModel.snapshots.value.activeWorkingSessionIds,
+        )
     }
 
     @Test
@@ -3385,6 +3572,71 @@ private class FakeHermesConnectionClient : HermesConnectionClient {
     }
 }
 
+private class GatedVideoDownloadClient : HermesConnectionClient {
+    val connection = CompletableDeferred<HermesConnectionInfo>()
+    val gate = CompletableDeferred<Unit>()
+    val firstDownloadStarted = CompletableDeferred<Unit>()
+    var started = 0
+    var active = 0
+
+    override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo = connection.await()
+
+    override suspend fun streamManagedVideoToFile(
+        serverOrigin: ServerOrigin,
+        accessToken: String?,
+        path: String,
+        destination: File,
+    ): ManagedVideoMedia {
+        started += 1
+        active += 1
+        firstDownloadStarted.complete(Unit)
+        try {
+            gate.await()
+            destination.parentFile?.mkdirs()
+            destination.writeBytes(byteArrayOf(1, 2, 3))
+        } finally {
+            active -= 1
+        }
+        return ManagedVideoMedia(destination, "video/mp4")
+    }
+}
+
+private class FailedVideoDownloadClient : HermesConnectionClient {
+    val connection = CompletableDeferred<HermesConnectionInfo>()
+
+    override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo = connection.await()
+
+    override suspend fun streamManagedVideoToFile(
+        serverOrigin: ServerOrigin,
+        accessToken: String?,
+        path: String,
+        destination: File,
+    ): ManagedVideoMedia {
+        destination.parentFile?.mkdirs()
+        destination.writeBytes(byteArrayOf(1, 2, 3))
+        throw HermesConnectionException("download failed")
+    }
+}
+
+private class CancelledVideoDownloadClient : HermesConnectionClient {
+    val connection = CompletableDeferred<HermesConnectionInfo>()
+    val started = CompletableDeferred<Unit>()
+
+    override suspend fun probe(serverOrigin: ServerOrigin): HermesConnectionInfo = connection.await()
+
+    override suspend fun streamManagedVideoToFile(
+        serverOrigin: ServerOrigin,
+        accessToken: String?,
+        path: String,
+        destination: File,
+    ): ManagedVideoMedia {
+        destination.parentFile?.mkdirs()
+        destination.writeBytes(byteArrayOf(1, 2, 3))
+        started.complete(Unit)
+        awaitCancellation()
+    }
+}
+
 private class UnauthenticatedRecentSessionsClient : HermesConnectionClient {
     var recentSessionPageCalls = 0
     var sawNullAccessToken = false
@@ -3817,6 +4069,19 @@ private class MetadataOnlyProjectSession private constructor(
 
     override suspend fun close() {
         closed = true
+    }
+}
+
+/** Metadata session that also answers the read-only presence snapshot. */
+private class PresenceAwareMetadataSession(
+    tree: ProjectTreeResult,
+    private val presence: Set<DurableSessionId>,
+) : HermesChatSession by MetadataOnlyProjectSession(tree) {
+    var failure: Throwable? = null
+
+    override suspend fun loadActiveSessionPresence(): Set<DurableSessionId> {
+        failure?.let { throw it }
+        return presence
     }
 }
 

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/ManagedVideoDownloadSafetyTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/ManagedVideoDownloadSafetyTest.kt
@@ -1,0 +1,116 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ManagedVideoDownloadSafetyTest {
+    @get:Rule val temporaryFolder = TemporaryFolder()
+    private val origin = ServerOrigin.parse("https://hermes.example")
+
+    @Test fun rejectsErrorHeadersBeforeBodyEof() = assertEarlyRejection(
+        HttpStatusCode.InternalServerError, "video/mp4", null, 0, "HTTP 500",
+    )
+
+    @Test fun rejectsNonVideoHeadersBeforeBodyEof() = assertEarlyRejection(
+        HttpStatusCode.OK, "text/plain", null, 0, "not a video",
+    )
+
+    @Test fun rejectsDeclaredOversizeBeforeBodyEof() = assertEarlyRejection(
+        HttpStatusCode.OK, "video/mp4", "9", 0, "too large",
+    )
+
+    @Test fun rejectsUnknownLengthAtCapBeforeBodyEof() = assertEarlyRejection(
+        HttpStatusCode.OK, "video/mp4", null, 9, "too large",
+    )
+
+    private fun assertEarlyRejection(
+        status: HttpStatusCode,
+        mimeType: String,
+        length: String?,
+        prefixBytes: Int,
+        expectedMessage: String,
+    ) = runBlocking {
+        // The producer cannot send EOF until the test releases it. A buffering
+        // request or a chunk reader waiting beyond cap+1 times out instead.
+        val body = ByteChannel(autoFlush = true)
+        val headersReturned = CompletableDeferred<Unit>()
+        val releaseEof = CompletableDeferred<Unit>()
+        val producer = launch {
+            if (prefixBytes > 0) body.writeFully(ByteArray(prefixBytes))
+            releaseEof.await()
+            body.close()
+        }
+        val engine = MockEngine {
+            headersReturned.complete(Unit)
+            respond(body, status, headersOf(*buildList {
+                add(HttpHeaders.ContentType to listOf(mimeType))
+                length?.let { add(HttpHeaders.ContentLength to listOf(it)) }
+            }.toTypedArray()))
+        }
+        val http = HttpClient(engine)
+        val destination = File(temporaryFolder.root, "clip.mp4")
+        val download = async {
+            try {
+                HttpHermesConnectionClient(http).streamManagedVideoToFile(
+                    origin, null, "/clip.mp4", destination, maxBytes = 8,
+                )
+                null
+            } catch (error: HermesConnectionException) {
+                error
+            }
+        }
+        try {
+            withTimeout(5_000) { headersReturned.await() }
+            val failure = withTimeout(5_000) { download.await() }
+            assertTrue(failure?.message.orEmpty().contains(expectedMessage))
+            assertFalse(releaseEof.isCompleted)
+            assertTrue(body.isClosedForRead)
+            assertFalse(destination.exists())
+            assertFalse(File(destination.path + ".part").exists())
+        } finally {
+            download.cancelAndJoin()
+            releaseEof.complete(Unit)
+            producer.cancelAndJoin()
+            http.close()
+        }
+    }
+
+    @Test fun failedRenameDoesNotCopyOverDestination() = runBlocking {
+        val destination = temporaryFolder.newFolder("clip.mp4")
+        val http = HttpClient(MockEngine {
+            respond(byteArrayOf(1, 2, 3), headers = headersOf(HttpHeaders.ContentType, "video/mp4"))
+        })
+        try {
+            val failure = runCatching {
+                HttpHermesConnectionClient(http).streamManagedVideoToFile(
+                    origin, null, "/clip.mp4", destination, maxBytes = 8,
+                )
+            }.exceptionOrNull()
+            assertTrue("Publication must fail closed", failure is HermesConnectionException)
+            assertTrue("Existing destination must not be replaced by a copy", destination.isDirectory)
+            assertEquals(0, destination.listFiles()!!.size)
+            assertFalse(File(destination.path + ".part").exists())
+        } finally {
+            http.close()
+        }
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/files/ManagedVideoCacheTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/files/ManagedVideoCacheTest.kt
@@ -1,0 +1,151 @@
+package com.unsupportedpastels.hermesandroid.files
+
+import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ManagedVideoCacheTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private val origin = ServerOrigin.parse("https://hermes.example")
+    private val otherOrigin = ServerOrigin.parse("https://other.example")
+
+    @Test
+    fun destinationsAreDeterministicOriginScopedAndExtensionTyped() {
+        val cache = ManagedVideoCache(tempFolder.root)
+
+        val first = cache.destinationFor(origin, "/workspace/clip.mp4")
+        val again = cache.destinationFor(origin, "/workspace/clip.mp4")
+        val other = cache.destinationFor(otherOrigin, "/workspace/clip.mp4")
+
+        assertEquals(first.absolutePath, again.absolutePath)
+        assertNotEquals(first.parentFile.absolutePath, other.parentFile.absolutePath)
+        assertTrue(first.name.endsWith(".mp4"))
+        assertEquals(ManagedVideoCache.sha256Hex("/workspace/clip.mp4") + ".mp4", first.name)
+    }
+
+    @Test
+    fun sanitizesHostileCacheExtensions() {
+        val cache = ManagedVideoCache(tempFolder.root)
+
+        val destination = cache.destinationFor(origin, "/workspace/clip.ELABORATE")
+
+        assertFalse(destination.name.endsWith(".ELABORATE"))
+        assertEquals(ManagedVideoCache.sha256Hex("/workspace/clip.ELABORATE"), destination.name)
+    }
+
+    @Test
+    fun cachedReturnsExistingCompleteDownloadOnly() {
+        val cache = ManagedVideoCache(tempFolder.root)
+        val destination = cache.destinationFor(origin, "/workspace/clip.mp4")
+        assertNull(cache.cached(origin, "/workspace/clip.mp4"))
+
+        destination.writeBytes(byteArrayOf(1, 2, 3))
+
+        val media = cache.cached(origin, "/workspace/clip.mp4")
+        assertEquals("video/mp4", media?.mimeType)
+        assertEquals(destination.absolutePath, media?.file?.absolutePath)
+        assertNull(cache.cached(otherOrigin, "/workspace/clip.mp4"))
+    }
+
+    @Test
+    fun pruneKeepsMostRecentDownloadWithinBudget() {
+        val cache = ManagedVideoCache(tempFolder.root)
+        val old = cache.destinationFor(origin, "/a/old.mp4")
+        val keep = cache.destinationFor(origin, "/b/keep.mp4")
+        old.writeBytes(ByteArray(600))
+        keep.writeBytes(ByteArray(400))
+        old.setLastModified(1_000L)
+        keep.setLastModified(2_000L)
+
+        cache.prune(origin, keep = keep, budgetBytes = 500L)
+
+        assertFalse(old.exists())
+        assertTrue(keep.exists())
+    }
+
+    @Test
+    fun pruneRemovesStalePartialDownloads() {
+        val cache = ManagedVideoCache(tempFolder.root)
+        val part = File(cache.directoryFor(origin), "pending.mp4.part")
+        part.parentFile.mkdirs()
+        part.writeBytes(ByteArray(16))
+        part.setLastModified(1_000L)
+
+        cache.prune(origin, budgetBytes = Long.MAX_VALUE)
+
+        assertFalse(part.exists())
+    }
+
+    @Test
+    fun pruneDoesNotUnlinkAnotherPathsOpenPartialDownload() {
+        val cache = ManagedVideoCache(tempFolder.root)
+        val destination = cache.destinationFor(origin, "/active.mp4")
+        val part = File(destination.path + ManagedVideoCache.PART_SUFFIX)
+        val keep = cache.destinationFor(origin, "/completed.mp4")
+        val executor = java.util.concurrent.Executors.newSingleThreadExecutor()
+        try {
+            java.io.FileOutputStream(part).use { writer ->
+                writer.write(ByteArray(60))
+                keep.writeBytes(ByteArray(60))
+                assertTrue(part.setLastModified(System.currentTimeMillis() - 1_000))
+                executor.submit {
+                    cache.prune(origin, keep = keep, budgetBytes = 100)
+                }.get(5, java.util.concurrent.TimeUnit.SECONDS)
+                assertTrue("Prune must not unlink an open fresh partial", part.exists())
+                writer.write(7)
+            }
+            assertTrue(part.renameTo(destination))
+            assertEquals(61L, cache.cached(origin, "/active.mp4")?.file?.length())
+            assertTrue(keep.exists())
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun pruneKeepsPinnedFinalFileUntilItsLastLeaseCloses() {
+        val cache = ManagedVideoCache(tempFolder.root)
+        val active = cache.destinationFor(origin, "/active.mp4")
+        val other = cache.destinationFor(origin, "/other.mp4")
+        active.writeBytes(ByteArray(600))
+        other.writeBytes(ByteArray(400))
+        active.setLastModified(1_000L)
+        other.setLastModified(2_000L)
+
+        val firstLease = cache.acquire(origin, "/active.mp4")!!
+        val secondLease = cache.acquire(origin, "/active.mp4")!!
+        try {
+            cache.prune(origin, budgetBytes = 500L)
+            assertTrue("an active final file must stay pinned", active.exists())
+            assertFalse("unpinned files remain eviction candidates", other.exists())
+
+            firstLease.close()
+            firstLease.close()
+            cache.prune(origin, budgetBytes = 500L)
+            assertTrue("a duplicate close must not release another lease", active.exists())
+
+            secondLease.close()
+            cache.prune(origin, budgetBytes = 500L)
+            assertFalse("the final file is evictable after its last close", active.exists())
+        } finally {
+            firstLease.close()
+            secondLease.close()
+        }
+    }
+
+    @Test
+    fun cacheWithoutRootIsUnavailable() {
+        val cache = ManagedVideoCache(null)
+
+        assertNull(cache.directoryFor(origin))
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayProjectTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayProjectTest.kt
@@ -1,5 +1,6 @@
 package com.unsupportedpastels.hermesandroid.gateway
 
+import com.unsupportedpastels.hermesandroid.app.DurableSessionId
 import com.unsupportedpastels.hermesandroid.app.ProjectId
 import com.unsupportedpastels.hermesandroid.app.MAX_PROCESS_ROWS
 import com.unsupportedpastels.hermesandroid.app.RunTodoItem
@@ -174,6 +175,65 @@ class HermesChatGatewayProjectTest {
         assertFalse(result.paused)
         assertEquals(2, result.maxSpawnDepth)
         assertEquals(3, result.maxConcurrentChildren)
+        connection.close()
+    }
+
+    @Test
+    fun activeSessionPresenceJoinsBySessionKeyAndOnlyReportsWorking() = runTest {
+        val socket = MetadataSocket()
+        socket.onSend = { frame ->
+            val request = Json.parseToJsonElement(frame).jsonObject
+            assertEquals("session.active_list", request["method"]!!.jsonPrimitive.content)
+            assertEquals(
+                "",
+                request["params"]!!.jsonObject["current_session_id"]!!.jsonPrimitive.content,
+            )
+            socket.offer(
+                """{"jsonrpc":"2.0","id":${request["id"]!!.jsonPrimitive.content},"result":{"sessions":[{"id":"runtime-1","session_key":"dur-1","title":"Build","status":"working"},{"id":"runtime-2","session_key":"dur-2","status":"idle"},{"id":"runtime-3","session_key":"dur-3","status":"waiting"},{"id":"runtime-4","session_key":"dur-4","status":"starting"},{"id":"missing-key","status":"working"},{"id":"runtime-5","session_key":"dur-5","status":"future"}],"future":true}}""",
+            )
+        }
+        val connection = HermesChatGateway(
+            origin = ServerOrigin.parse("https://hermes.example"),
+            accessToken = "access-token",
+            ticketClient = object : WsTicketClient {
+                override suspend fun mintTicket(origin: ServerOrigin, accessToken: String) =
+                    WsTicket("ticket", 30)
+            },
+            socketFactory = object : ChatWebSocketFactory { override suspend fun connect(url: String) = socket },
+            parentScope = backgroundScope,
+        ).connect()
+
+        val presence = connection.loadActiveSessionPresence()
+
+        // Only `working` rows, joined by the durable session_key — never the
+        // runtime id — and malformed rows are dropped, not fatal.
+        assertEquals(setOf(DurableSessionId("dur-1")), presence)
+        connection.close()
+    }
+
+    @Test
+    fun activeSessionPresenceEmptySnapshotReportsNoWorkingSessions() = runTest {
+        val socket = MetadataSocket()
+        socket.onSend = { frame ->
+            val request = Json.parseToJsonElement(frame).jsonObject
+            assertEquals("session.active_list", request["method"]!!.jsonPrimitive.content)
+            socket.offer(
+                """{"jsonrpc":"2.0","id":${request["id"]!!.jsonPrimitive.content},"result":{"sessions":[]}}""",
+            )
+        }
+        val connection = HermesChatGateway(
+            origin = ServerOrigin.parse("https://hermes.example"),
+            accessToken = "access-token",
+            ticketClient = object : WsTicketClient {
+                override suspend fun mintTicket(origin: ServerOrigin, accessToken: String) =
+                    WsTicket("ticket", 30)
+            },
+            socketFactory = object : ChatWebSocketFactory { override suspend fun connect(url: String) = socket },
+            parentScope = backgroundScope,
+        ).connect()
+
+        val presence = connection.loadActiveSessionPresence()
+        assertEquals(emptySet<DurableSessionId>(), presence)
         connection.close()
     }
 

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoBlockTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoBlockTest.kt
@@ -1,0 +1,44 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.junit.Assert.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class ManagedVideoBlockTest {
+    @get:Rule val rule = createComposeRule()
+
+    @Test fun unavailableTransportDoesNotOfferPlayback() {
+        rule.setContent { MaterialTheme { ManagedVideoBlock("/a/clip.mp4") } }
+        rule.onAllNodesWithText("Video playback is unavailable").assertCountEquals(1)
+        rule.onAllNodesWithContentDescription("Play video").assertCountEquals(0)
+    }
+
+    @Test fun downloadIsExplicitAndErrorsAreSafe() {
+        var requested: String? = null
+        rule.setContent {
+            MaterialTheme {
+                MarkdownMessage("MEDIA:/a/clip.mp4", loadManagedVideo = { path ->
+                    requested = path
+                    Result.failure(IllegalStateException("private transport detail"))
+                })
+            }
+        }
+        rule.runOnIdle { assertEquals(null, requested) }
+        rule.onNodeWithContentDescription("Play video").performClick()
+        rule.runOnIdle { assertEquals("/a/clip.mp4", requested) }
+        rule.onAllNodesWithText("Could not load video").assertCountEquals(1)
+        rule.onAllNodesWithText("private transport detail").assertCountEquals(0)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoPresentationLeaseTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/ManagedVideoPresentationLeaseTest.kt
@@ -1,0 +1,33 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ManagedVideoPresentationLeaseTest {
+    @Test fun disposalClosesCurrentAndRejectsLateResults() {
+        val owner = ManagedVideoPresentationLease()
+        var closed = 0
+        assertTrue(owner.adopt(ManagedVideoMedia(File("first.mp4"), "video/mp4") { closed++ }))
+        owner.close()
+        owner.close()
+        assertEquals(1, closed)
+        assertFalse(owner.adopt(ManagedVideoMedia(File("late.mp4"), "video/mp4") { closed++ }))
+        assertEquals(2, closed)
+    }
+
+    @Test fun replacementClosesOnlyPreviousLease() {
+        val owner = ManagedVideoPresentationLease()
+        var firstClosed = 0
+        var secondClosed = 0
+        assertTrue(owner.adopt(ManagedVideoMedia(File("clip.mp4"), "video/mp4") { firstClosed++ }))
+        assertTrue(owner.adopt(ManagedVideoMedia(File("clip.mp4"), "video/mp4") { secondClosed++ }))
+        assertEquals(1, firstClosed)
+        assertEquals(0, secondClosed)
+        owner.close()
+        assertEquals(1, secondClosed)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
@@ -60,6 +60,54 @@ class MessageMarkdownTest {
     }
 
     @Test
+    fun parsesGatewayLocalVideoMediaDirectiveAsVideoBlockInsteadOfRawPath() {
+        val path = "/workspace/project/scene-00/preview.mp4"
+
+        val blocks = parseMessageMarkdown("Preview:\n\nMEDIA:$path\n\nDone")
+
+        val video = blocks.filterIsInstance<MarkdownVideoBlock>().single()
+        assertEquals(path, video.url)
+        assertTrue(blocks.filterIsInstance<MarkdownImageBlock>().isEmpty())
+        assertFalse(
+            blocks.filterIsInstance<MarkdownTextBlock>()
+                .any { it.plainText.contains("MEDIA:") },
+        )
+    }
+
+    @Test
+    fun videoMediaDirectiveCoversCaseInsensitivePreviewExtensions() {
+        for (path in listOf("/a/clip.MP4", "/a/clip.webm", "/a/clip.mov", "/a/clip.m4v", "/a/clip.mkv")) {
+            val blocks = parseMessageMarkdown("MEDIA:$path")
+            assertEquals(path, blocks.filterIsInstance<MarkdownVideoBlock>().single().url)
+        }
+    }
+
+    @Test
+    fun videoMediaDirectiveUsesSharedWhitespaceAndQuoteGrammar() {
+        for (directive in listOf(
+            "MEDIA: /tmp/preview.mp4",
+            "  MEDIA: /tmp/preview.mp4  ",
+            "MEDIA: \"/tmp/preview.mp4\"",
+            "`MEDIA:/tmp/preview.mp4`",
+        )) {
+            assertEquals(
+                "/tmp/preview.mp4",
+                parseMessageMarkdown(directive).filterIsInstance<MarkdownVideoBlock>().single().url,
+            )
+        }
+        assertTrue(parseMessageMarkdown("MEDIA: /tmp/../private.mp4").filterIsInstance<MarkdownVideoBlock>().isEmpty())
+    }
+
+    @Test
+    fun nonMediaManagedFileStaysPlainTextInsteadOfVideoBlock() {
+        val blocks = parseMessageMarkdown("MEDIA:/workspace/report.pdf")
+
+        assertTrue(blocks.filterIsInstance<MarkdownVideoBlock>().isEmpty())
+        assertTrue(blocks.filterIsInstance<MarkdownImageBlock>().isEmpty())
+        assertTrue(blocks.filterIsInstance<MarkdownTextBlock>().isNotEmpty())
+    }
+
+    @Test
     fun compactsEmbeddedImagePayloadAndHidesServerAttachmentPath() {
         val source = buildString {
             appendLine("before")

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImageTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImageTest.kt
@@ -99,6 +99,15 @@ class RemoteMediaImageTest {
     }
 
     @Test
+    fun acceptsVideoHostPathsButRejectsNonVideoAndMalformedPaths() {
+        assertTrue(validateGatewayVideoPath("/workspace/scene-00/preview.mp4"))
+        assertTrue(validateGatewayVideoPath("/workspace/scene-00/preview.WEBM"))
+        assertFalse(validateGatewayVideoPath("relative/preview.mp4"))
+        assertFalse(validateGatewayVideoPath("/workspace/scene-00/generated.jpg"))
+        assertFalse(validateGatewayVideoPath("/workspace/scene-00/no-extension"))
+    }
+
+    @Test
     fun oversizedImageBodyIsRejectedBeforeDecode() = runTest {
         val client = HttpClient(MockEngine {
             respond(

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -6,7 +6,7 @@
 |---|---|
 | JDK | 17 |
 | Android Gradle Plugin | 9.3.1 (required for current AndroidX artifacts compiled against API 37) |
-| Gradle wrapper | 9.5.0 with pinned SHA-256 (AGP 9.3.1 supported baseline) |
+| Gradle wrapper | 9.7.1 with pinned SHA-256 (verified with AGP 9.3.1) |
 | Kotlin / Compose compiler plugin | 2.4.10 |
 | AndroidX Core | 1.19.0 |
 | Lifecycle / ViewModel | 2.11.0 |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+media3 = "1.8.0"
 androidGradlePlugin = "9.3.1"
 androidxCore = "1.19.0"
 androidxLifecycle = "2.11.0"
@@ -73,6 +74,8 @@ screenshot-validation-api = { module = "com.android.tools.screenshot:screenshot-
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3Core" }
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNav3" }
+androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
+androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/ios/Mercury/MercuryKit/Chat/MediaDirectiveExtractor.swift
+++ b/ios/Mercury/MercuryKit/Chat/MediaDirectiveExtractor.swift
@@ -7,6 +7,7 @@ import MercuryCore
 enum ArtifactType: Sendable, Equatable {
     case image
     case audio
+    case video
     case file
 }
 
@@ -138,7 +139,8 @@ private extension Artifact {
             stableIdentity: core.stableIdentity,
             type: core.type == MercuryCore.ArtifactType.image
                 ? .image
-                : (core.type == MercuryCore.ArtifactType.audio ? .audio : .file),
+                : (core.type == MercuryCore.ArtifactType.video ? .video
+                    : (core.type == MercuryCore.ArtifactType.audio ? .audio : .file)),
             origin: core.origin == MercuryCore.ArtifactOrigin.managedpath ? .managedPath : .remoteURL,
             source: core.source,
             displayName: core.displayName

--- a/ios/Mercury/MercuryKit/Files/ManagedVideoDownload.swift
+++ b/ios/Mercury/MercuryKit/Files/ManagedVideoDownload.swift
@@ -1,0 +1,180 @@
+import Foundation
+import CryptoKit
+import MercuryCore
+
+struct ManagedVideoUnavailable: Error {}
+struct ManagedVideoHTTPFailure: Error { let statusCode: Int }
+
+/// A lease keeps the local file alive for the complete AVPlayer lifetime.
+final class ManagedVideoFile {
+    let url: URL
+    init(url: URL) { self.url = url; ManagedVideoCache.retain(url) }
+    deinit { ManagedVideoCache.release(url) }
+}
+
+enum ManagedVideoCache {
+    private static let lock = NSRecursiveLock()
+    private static var active: Set<URL> = []
+    static let root = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        .appendingPathComponent("ManagedVideos", isDirectory: true)
+
+    static func directory(origin: String, profile: String, root: URL = ManagedVideoCache.root) throws -> URL {
+        let key = SHA256.hash(data: Data((origin + "\n" + profile).utf8)).map { String(format: "%02x", $0) }.joined()
+        let directory = root.appendingPathComponent(key, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+    static func retain(_ url: URL) { lock.lock(); defer { lock.unlock() }; active.insert(url) }
+    static func publish(part: URL, destination: URL) throws -> ManagedVideoFile {
+        lock.lock(); defer { lock.unlock() }
+        try FileManager.default.moveItem(at: part, to: destination)
+        let file = ManagedVideoFile(url: destination)
+        active.remove(part)
+        return file
+    }
+    static func release(_ url: URL) { lock.lock(); defer { lock.unlock() }; active.remove(url); prune() }
+    private static func modified(_ url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+    }
+    static func prune(root: URL = ManagedVideoCache.root, limit: Int64 = ManagedVideoPolicy.shared.MAX_CACHE_BYTES) {
+        lock.lock(); defer { lock.unlock() }
+        let fm = FileManager.default
+        let files = (fm.enumerator(at: root, includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey, .contentModificationDateKey])?.allObjects as? [URL] ?? [])
+            .filter { (try? $0.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true }
+            .sorted { modified($0) < modified($1) }
+        // In-flight partials are registered as active. Any other partial was
+        // abandoned by a prior process and can never be a playable cache hit.
+        for file in files where file.pathExtension == "part" && !active.contains(file) {
+            try? fm.removeItem(at: file)
+        }
+        var total = files.reduce(Int64(0)) { $0 + Int64((try? $1.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0) }
+        for file in files where total > limit && !active.contains(file) {
+            let size = Int64((try? file.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
+            if (try? fm.removeItem(at: file)) != nil { total -= size }
+        }
+    }
+}
+
+/// Data-delegate streaming bounds bytes BEFORE disk writes, including chunked
+/// and decompressed responses. No response-sized Data, URL credentials or redirects.
+final class ManagedVideoDownload: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    private let lock = NSRecursiveLock()
+    private var session: URLSession?
+    private var task: URLSessionDataTask?
+    private var continuation: CheckedContinuation<ManagedVideoFile, Error>?
+    private var handle: FileHandle?
+    private var part: URL?
+    private var destination: URL?
+    private var received: Int64 = 0
+    private var accepted = false
+    private var cancelled = false
+    private let maximumBytes: Int64
+
+    init(maximumBytes: Int64 = ManagedVideoPolicy.shared.MAX_DOWNLOAD_BYTES) {
+        self.maximumBytes = min(maximumBytes, ManagedVideoPolicy.shared.MAX_DOWNLOAD_BYTES)
+    }
+
+    func download(request: URLRequest, directory: URL,
+                  configuration: URLSessionConfiguration = .ephemeral) async throws -> ManagedVideoFile {
+        try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            return try await withCheckedThrowingContinuation { continuation in
+                lock.lock(); defer { lock.unlock() }
+                guard !cancelled else { continuation.resume(throwing: CancellationError()); return }
+                self.continuation = continuation
+                do {
+                    let destination = directory.appendingPathComponent(UUID().uuidString + ".mp4")
+                    let part = destination.appendingPathExtension("part")
+                    self.destination = destination; self.part = part
+                    ManagedVideoCache.retain(part)
+                    guard FileManager.default.createFile(atPath: part.path, contents: nil) else { throw CocoaError(.fileWriteUnknown) }
+                    handle = try FileHandle(forWritingTo: part)
+                    configuration.urlCache = nil
+                    configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+                    configuration.timeoutIntervalForRequest = 30
+                    configuration.timeoutIntervalForResource = 300
+                    let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+                    self.session = session
+                    let task = session.dataTask(with: request)
+                    self.task = task
+                    task.resume()
+                } catch { finish(error) }
+            }
+        } onCancel: { self.cancel() }
+    }
+
+    func cancel() {
+        lock.lock(); defer { lock.unlock() }
+        cancelled = true
+        finish(CancellationError())
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest,
+                    completionHandler: @escaping (URLRequest?) -> Void) {
+        lock.lock(); defer { lock.unlock() }
+        completionHandler(nil)
+        finish(URLError(.redirectToNonExistentLocation))
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        lock.lock(); defer { lock.unlock() }
+        guard continuation != nil, !cancelled,
+              let http = response as? HTTPURLResponse else {
+            completionHandler(.cancel); finish(URLError(.cannotDecodeContentData)); return
+        }
+        guard http.statusCode == 200 else {
+            completionHandler(.cancel); finish(ManagedVideoHTTPFailure(statusCode: http.statusCode)); return
+        }
+        guard ManagedVideoPolicy.shared.isVideoMimeType(contentType: http.value(forHTTPHeaderField: "Content-Type") ?? ""),
+              response.expectedContentLength <= maximumBytes else {
+            completionHandler(.cancel); finish(URLError(.cannotDecodeContentData)); return
+        }
+        if let raw = http.value(forHTTPHeaderField: "Content-Length"),
+           Int64(raw).map({ $0 >= 0 && $0 <= maximumBytes }) != true {
+            completionHandler(.cancel); finish(ResponseTooLargeError()); return
+        }
+        accepted = true
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        lock.lock(); defer { lock.unlock() }
+        guard continuation != nil, accepted, !cancelled else { return }
+        guard Int64(data.count) <= maximumBytes - received else { finish(ResponseTooLargeError()); return }
+        do { try handle?.write(contentsOf: data); received += Int64(data.count) }
+        catch { finish(error) }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        lock.lock(); defer { lock.unlock() }
+        guard continuation != nil else { return }
+        if let error { finish(error); return }
+        guard accepted, received > 0, !cancelled, let part, let destination else {
+            finish(URLError(.zeroByteResource)); return
+        }
+        do {
+            try handle?.close(); handle = nil
+            let file = try ManagedVideoCache.publish(part: part, destination: destination)
+            self.part = nil
+            let completion = continuation; continuation = nil
+            session.finishTasksAndInvalidate(); self.session = nil; self.task = nil
+            ManagedVideoCache.prune()
+            completion?.resume(returning: file)
+        } catch { finish(error) }
+    }
+
+    private func finish(_ error: Error) {
+        task?.cancel(); task = nil
+        session?.invalidateAndCancel(); session = nil
+        try? handle?.close(); handle = nil
+        if let part {
+            try? FileManager.default.removeItem(at: part)
+            ManagedVideoCache.release(part)
+            self.part = nil
+        }
+        let completion = continuation; continuation = nil
+        completion?.resume(throwing: error)
+    }
+}

--- a/ios/Mercury/MercuryKit/Networking/HermesHTTPClient.swift
+++ b/ios/Mercury/MercuryKit/Networking/HermesHTTPClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MercuryCore
 
 /// Thrown when a response body exceeds the 64 KiB safety cap.
 struct ResponseTooLargeError: Error {}
@@ -136,6 +137,41 @@ final class HermesHTTPClient {
         request.httpMethod = "DELETE"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         return try await run(request)
+    }
+
+    /// Video uses the same origin-scoped credentials, but a bounded disk stream
+    /// rather than the JSON/Data transport. AVKit receives only the resulting file.
+    func downloadManagedVideo(path: String, profile: String) async throws -> ManagedVideoFile {
+        guard MercuryCore.ManagedVideoPolicy.shared.isManagedVideoPath(path: path),
+              ServerOrigin.normalize(origin) == origin else { throw URLError(.badURL) }
+        var components = try urlComponents(path: "/api/files/download")
+        components.queryItems = [URLQueryItem(name: "path", value: path)]
+        guard let url = components.url else { throw URLError(.badURL) }
+        let directory = try ManagedVideoCache.directory(origin: origin, profile: profile)
+        func request() -> URLRequest {
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.setValue("video/*", forHTTPHeaderField: "Accept")
+            if let bearerToken, !bearerToken.isEmpty {
+                request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+            }
+            if let cookies = session.configuration.httpCookieStorage?.cookies(for: url), !cookies.isEmpty {
+                request.setValue(HTTPCookie.requestHeaderFields(with: cookies)["Cookie"], forHTTPHeaderField: "Cookie")
+            }
+            return request
+        }
+        try Task.checkCancellation()
+        do {
+            return try await ManagedVideoDownload().download(request: request(), directory: directory,
+                                                             configuration: session.configuration)
+        } catch let failure as ManagedVideoHTTPFailure {
+            guard failure.statusCode == 401, refreshTokenProvider != nil,
+                  await refreshAndApplyToken() else { throw failure }
+            try Task.checkCancellation()
+            // Fresh bounded stream, once only; the rejected attempt cleaned its partial file.
+            return try await ManagedVideoDownload().download(request: request(), directory: directory,
+                                                             configuration: session.configuration)
+        }
     }
 
     // MARK: - Internals

--- a/ios/Mercury/ProjectMetadataController.swift
+++ b/ios/Mercury/ProjectMetadataController.swift
@@ -84,15 +84,14 @@ final class ProjectMetadataController {
             guard loadGeneration == generation, connection === owned else { return }
             tree = loaded
             isLoading = false
-            if case .relay = source {
-                // Relay metadata borrows the selected controller admission.
-                // Do not infer runtime ownership from process-global presence
-                // polling; child lifecycle uses the scoped recovery reducer.
-                activeListSupported = false
-            } else {
-                let shouldPoll = await refreshActiveSessions(connection: owned, generation: loadGeneration)
-                if shouldPoll { beginActivityPolling(connection: owned, generation: loadGeneration) }
-            }
+            // Working-presence polling is read-only observer state and is safe
+            // on BOTH transports: `session.active_list` enumerates live runtimes
+            // without resuming, activating, or rebinding any transport, and the
+            // tracker only feeds the inbox running/unread indicators. Relay
+            // previously skipped this poll, which left every home-screen row
+            // permanently idle even while a turn ran on the host.
+            let shouldPoll = await refreshActiveSessions(connection: owned, generation: loadGeneration)
+            if shouldPoll { beginActivityPolling(connection: owned, generation: loadGeneration) }
         } catch is ChatMethodNotFoundError {
             guard loadGeneration == generation else { return }
             isUnsupported = true

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -2041,10 +2041,25 @@ struct ChatView: View {
     @ViewBuilder
     private func managedImages(in text: String) -> some View {
         let artifacts = MediaDirectiveExtractor.extract(text)
-            .filter { $0.origin == .managedPath && $0.type == .image }
+            .filter { ($0.origin == .managedPath && $0.type == .image) || $0.type == .video }
         ForEach(artifacts, id: \.stableIdentity) { artifact in
-            RemoteManagedImage(path: artifact.source, scope: managedImageScope) { path in
-                try await loadManagedImage(path: path)
+            Group {
+                if artifact.type == .video, artifact.origin == .remoteURL {
+                    if let url = URL(string: artifact.source), url.scheme?.lowercased() == "https" {
+                        Link(destination: url) {
+                            Label("Open video: \(artifact.displayName)", systemImage: "arrow.up.right.video")
+                        }
+                    }
+                } else if artifact.type == .video {
+                    RemoteManagedVideo(path: artifact.source, scope: managedImageScope,
+                                       available: appModel.activeRelayTarget == nil) { path in
+                        try await loadManagedVideo(path: path)
+                    }
+                } else {
+                    RemoteManagedImage(path: artifact.source, scope: managedImageScope) { path in
+                        try await loadManagedImage(path: path)
+                    }
+                }
             }
             .id(managedImageScope + "|" + artifact.source)
         }
@@ -2057,6 +2072,21 @@ struct ChatView: View {
         let transport = appModel.activeRelayTarget.map { "relay:\($0.relayOrigin)|\($0.id)" }
             ?? "direct:\(appModel.serverOrigin ?? "unconfigured")"
         return "\(transport)|\(appModel.activeProfile)|\(connection.map { String(describing: ObjectIdentifier($0)) } ?? "disconnected")"
+    }
+
+    private func loadManagedVideo(path: String) async throws -> ManagedVideoFile {
+        // Relay's image_read base64 contract is not a bounded video file stream.
+        // No relay route is invented or used as a direct-mode dependency.
+        guard appModel.activeRelayTarget == nil else { throw ManagedVideoUnavailable() }
+        guard let origin = appModel.serverOrigin else { throw URLError(.userAuthenticationRequired) }
+        let scope = managedImageScope
+        let profile = appModel.activeProfile
+        try Task.checkCancellation()
+        let file = try await makeHTTPClient(origin: origin).downloadManagedVideo(path: path, profile: profile)
+        try Task.checkCancellation()
+        guard managedImageScope == scope, appModel.activeRelayTarget == nil,
+              appModel.serverOrigin == origin, appModel.activeProfile == profile else { throw CancellationError() }
+        return file
     }
 
     private func loadManagedImage(path: String) async throws -> Data {

--- a/ios/Mercury/Views/RemoteManagedVideo.swift
+++ b/ios/Mercury/Views/RemoteManagedVideo.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+import AVKit
+
+/// Tap-to-download, then native fullscreen playback of a leased local file.
+/// Remote HTTPS artifacts never enter this view or AVPlayer.
+struct RemoteManagedVideo: View {
+    let path: String
+    let scope: String
+    var available = true
+    var load: (String) async throws -> ManagedVideoFile
+
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var loading = false
+    @State private var failed = false
+    @State private var player: AVPlayer?
+    @State private var file: ManagedVideoFile?
+    @State private var showPlayer = false
+    @State private var work: Task<Void, Never>?
+    @State private var generation = UUID()
+    @State private var playbackFailed = false
+    @State private var itemObservation: NSKeyValueObservation?
+
+    var body: some View {
+        Button(action: open) {
+            VStack(spacing: 10) {
+                if loading { ProgressView("Downloading video…") }
+                else { Image(systemName: failed ? "exclamationmark.triangle" : "play.rectangle.fill").font(.largeTitle) }
+                Text(path.split(separator: "/").last.map(String.init) ?? "Video")
+                    .font(.callout).lineLimit(1)
+                Text(!available ? "Video unavailable over Relay" : failed ? "Video unavailable. Tap to retry" : "Tap to play video")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity).frame(height: 160)
+            .background(Color.surfaceLow).clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+        .disabled(loading || !available || scenePhase != .active)
+        .accessibilityIdentifier("managed-video-preview")
+        .fullScreenCover(isPresented: $showPlayer, onDismiss: closePlayer) {
+            if let player {
+                ZStack(alignment: .topTrailing) {
+                    NativeManagedVideoPlayer(player: player).ignoresSafeArea()
+                    if playbackFailed {
+                        VStack(spacing: 12) {
+                            Image(systemName: "exclamationmark.triangle").font(.largeTitle)
+                            Text("This video could not be played on this device.")
+                                .multilineTextAlignment(.center)
+                        }
+                        .foregroundStyle(.white).padding(24)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(.black)
+                        .accessibilityIdentifier("managed-video-playback-error")
+                    }
+                    VStack(alignment: .trailing) {
+                        Button("Close video") { showPlayer = false }
+                            .padding().background(.ultraThinMaterial).clipShape(Capsule()).padding()
+                            .accessibilityIdentifier("managed-video-close")
+                        #if DEBUG
+                        // Native simulator evidence reads the actual AVPlayer clock,
+                        // never a synthetic timer or a mocked playback state.
+                        if ProcessInfo.processInfo.arguments.contains("-uitest-video-clock") {
+                            TimelineView(.periodic(from: .now, by: 1)) { _ in
+                                let time = player.currentTime().seconds
+                                Text("Playback \(time.isFinite ? Int(max(0, min(time, 86400))) : 0) seconds")
+                                    .font(.caption).padding(8).background(.ultraThinMaterial)
+                                    .accessibilityIdentifier("managed-video-playback-time")
+                            }
+                        }
+                        #endif
+                    }
+                }
+                .onAppear { player.play() }
+            }
+        }
+        .onChange(of: scope) { _, _ in dispose() }
+        .onChange(of: path) { _, _ in dispose() }
+        .onChange(of: scenePhase) { _, phase in if phase != .active { dispose() } }
+        // A fullscreen cover can make its presenting row disappear. The
+        // cover owns playback until dismissal; don't cancel its own launch.
+        .onDisappear { if !showPlayer { dispose() } }
+    }
+
+    private func open() {
+        guard available, scenePhase == .active else { return }
+        // Reuse only this presentation owner's authenticated lease. A scope
+        // change, background or navigation releases it; no cross-login hit.
+        if let file {
+            preparePlayer(file: file)
+            showPlayer = true
+            return
+        }
+        dispose()
+        let owner = generation
+        loading = true; failed = false
+        work = Task { @MainActor in
+            do {
+                let downloaded = try await load(path)
+                try Task.checkCancellation()
+                guard generation == owner, scenePhase == .active else { return }
+                // The local-file guard is deliberately redundant at the UI boundary.
+                guard downloaded.url.isFileURL else { throw URLError(.badURL) }
+                file = downloaded
+                preparePlayer(file: downloaded)
+                loading = false; showPlayer = true
+            } catch {
+                guard generation == owner, !Task.isCancelled else { return }
+                loading = false; failed = true
+            }
+        }
+    }
+
+    private func dispose() {
+        generation = UUID()
+        work?.cancel(); work = nil
+        closePlayer()
+        file = nil
+    }
+
+    private func closePlayer() {
+        itemObservation?.invalidate(); itemObservation = nil
+        player?.pause(); player?.replaceCurrentItem(with: nil); player = nil
+        loading = false; showPlayer = false
+    }
+
+    private func preparePlayer(file: ManagedVideoFile) {
+        playbackFailed = false
+        let item = AVPlayerItem(url: file.url)
+        player = AVPlayer(playerItem: item)
+        let owner = generation
+        itemObservation = item.observe(\.status, options: [.initial, .new]) { item, _ in
+            guard item.status == .failed else { return }
+            DispatchQueue.main.async {
+                guard generation == owner, player?.currentItem === item else { return }
+                player?.pause()
+                playbackFailed = true
+            }
+        }
+    }
+}
+
+private struct NativeManagedVideoPlayer: UIViewControllerRepresentable {
+    let player: AVPlayer
+
+    func makeUIViewController(context: Context) -> AVPlayerViewController {
+        let controller = AVPlayerViewController()
+        controller.player = player
+        controller.allowsPictureInPicturePlayback = false
+        controller.showsPlaybackControls = true
+        return controller
+    }
+
+    func updateUIViewController(_ controller: AVPlayerViewController, context: Context) {
+        // Preserve the existing native binding across unrelated SwiftUI updates.
+        if controller.player !== player {
+            controller.player = player
+        }
+    }
+
+    static func dismantleUIViewController(_ controller: AVPlayerViewController, coordinator: ()) {
+        controller.player?.pause(); controller.player = nil
+    }
+}

--- a/ios/MercuryTests/ManagedVideoTests.swift
+++ b/ios/MercuryTests/ManagedVideoTests.swift
@@ -1,0 +1,250 @@
+import XCTest
+import MercuryCore
+@testable import Mercury
+
+final class ManagedVideoTests: XCTestCase {
+    private var root: URL!
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+    override func tearDownWithError() throws {
+        VideoProtocol.handler = nil
+        try? FileManager.default.removeItem(at: root)
+    }
+    private func configuration() -> URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [VideoProtocol.self]
+        config.httpCookieStorage = nil
+        return config
+    }
+    private func request() -> URLRequest {
+        URLRequest(url: URL(string: "https://video.example/api/files/download?path=%2Ftmp%2Fclip.mp4")!)
+    }
+    private func files() throws -> [URL] { try FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil) }
+
+    func testSharedVideoAdapterOnlyExplicitMediaPromotesManagedVideo() {
+        let artifacts = MediaDirectiveExtractor.extract("MEDIA:/tmp/clip.mp4\nMEDIA:https://example.com/clip.webm")
+        XCTAssertEqual(artifacts.map(\.type), [.video, .video])
+        XCTAssertEqual(artifacts.map(\.origin), [.managedPath, .remoteURL])
+        XCTAssertFalse(MediaDirectiveExtractor.extract("`/tmp/clip.mp4`").contains { $0.type == .video })
+        XCTAssertTrue(ManagedVideoPolicy.shared.isVideoMimeType(contentType: "video/mp4; codecs=avc1"))
+        XCTAssertFalse(ManagedVideoPolicy.shared.isVideoMimeType(contentType: "application/octet-stream"))
+    }
+
+    func testStreamsToAtomicLocalFileWithNoPartLeft() async throws {
+        VideoProtocol.handler = { p in
+            p.respond(headers: ["Content-Type": "video/mp4"])
+            p.client?.urlProtocol(p, didLoad: Data([1, 2]))
+            p.client?.urlProtocol(p, didLoad: Data([3, 4]))
+            p.client?.urlProtocolDidFinishLoading(p)
+        }
+        let file = try await ManagedVideoDownload(maximumBytes: 4).download(request: request(), directory: root, configuration: configuration())
+        XCTAssertTrue(file.url.isFileURL)
+        XCTAssertNil(file.url.query)
+        XCTAssertEqual(try Data(contentsOf: file.url), Data([1, 2, 3, 4]))
+        XCTAssertEqual(try files().count, 1)
+        XCTAssertFalse(try files().contains { $0.pathExtension == "part" })
+    }
+
+    func testRejectsOversizedHeaderBeforeAnyBodyOrPublication() async throws {
+        VideoProtocol.handler = { $0.respond(headers: ["Content-Type": "video/mp4", "Content-Length": "5"]) }
+        do {
+            _ = try await ManagedVideoDownload(maximumBytes: 4).download(request: request(), directory: root, configuration: configuration())
+            XCTFail("Oversize header accepted")
+        } catch { }
+        XCTAssertTrue(try files().isEmpty)
+    }
+
+    func testRejectsMissingAndNonVideoMimeWithoutBody() async throws {
+        for headers in [[:], ["Content-Type": "text/html"], ["Content-Type": "application/octet-stream"]] {
+            VideoProtocol.handler = { $0.respond(headers: headers) }
+            do {
+                _ = try await ManagedVideoDownload().download(request: request(), directory: root, configuration: configuration())
+                XCTFail("Unsafe MIME accepted")
+            } catch { }
+            XCTAssertTrue(try files().isEmpty)
+        }
+    }
+
+    func testUnknownLengthStreamCapCancelsAndRemovesPart() async throws {
+        VideoProtocol.handler = { p in
+            p.respond(headers: ["Content-Type": "video/mp4"])
+            p.client?.urlProtocol(p, didLoad: Data(repeating: 1, count: 3))
+            p.client?.urlProtocol(p, didLoad: Data(repeating: 1, count: 2))
+        }
+        do {
+            _ = try await ManagedVideoDownload(maximumBytes: 4).download(request: request(), directory: root, configuration: configuration())
+            XCTFail("Chunked overflow accepted")
+        } catch { XCTAssertTrue(error is ResponseTooLargeError) }
+        XCTAssertTrue(try files().isEmpty)
+    }
+
+    func testCancellationWhileWaitingForHeadersResumesAndCleansPart() async throws {
+        let started = expectation(description: "request started")
+        VideoProtocol.handler = { _ in started.fulfill() }
+        let downloader = ManagedVideoDownload()
+        let request = request(), directory = root!, config = configuration()
+        let work = Task { try await downloader.download(request: request, directory: directory, configuration: config) }
+        await fulfillment(of: [started], timeout: 2)
+        work.cancel()
+        do { _ = try await work.value; XCTFail("Cancelled download returned a file") }
+        catch { XCTAssertTrue(error is CancellationError) }
+        XCTAssertTrue(try files().isEmpty)
+    }
+
+    func testCancellationDuringBodyRemovesPartial() async throws {
+        let started = expectation(description: "body sent")
+        VideoProtocol.handler = { p in
+            p.respond(headers: ["Content-Type": "video/mp4"])
+            p.client?.urlProtocol(p, didLoad: Data([1, 2]))
+            started.fulfill()
+        }
+        let downloader = ManagedVideoDownload()
+        let request = request(), directory = root!, config = configuration()
+        let work = Task { try await downloader.download(request: request, directory: directory, configuration: config) }
+        await fulfillment(of: [started], timeout: 2)
+        work.cancel()
+        do { _ = try await work.value; XCTFail("Cancelled stream returned a file") }
+        catch { XCTAssertTrue(error is CancellationError) }
+        XCTAssertTrue(try files().isEmpty)
+    }
+
+    func testRedirectDuringDownloadResumesFailureAndRemovesPartial() async throws {
+        let started = expectation(description: "request started")
+        VideoProtocol.handler = { _ in started.fulfill() }
+        let downloader = ManagedVideoDownload()
+        let request = request(), directory = root!, config = configuration()
+        let work = Task { try await downloader.download(request: request, directory: directory, configuration: config) }
+        await fulfillment(of: [started], timeout: 2)
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.invalidateAndCancel() }
+        let response = HTTPURLResponse(url: request.url!, statusCode: 302, httpVersion: nil,
+                                       headerFields: ["Location": "https://other.example/clip.mp4"])!
+        downloader.urlSession(session, task: session.dataTask(with: request), willPerformHTTPRedirection: response, newRequest: request) {
+            XCTAssertNil($0)
+        }
+        do { _ = try await work.value; XCTFail("Redirect returned a file") }
+        catch { XCTAssertEqual((error as? URLError)?.code, .redirectToNonExistentLocation) }
+        XCTAssertTrue(try files().isEmpty)
+    }
+
+    func testCancellationBeforeStartDoesNotMakePart() async throws {
+        let downloader = ManagedVideoDownload()
+        downloader.cancel()
+        do { _ = try await downloader.download(request: request(), directory: root, configuration: configuration()); XCTFail() }
+        catch { XCTAssertTrue(error is CancellationError) }
+        XCTAssertTrue(try files().isEmpty)
+    }
+
+    func testRedirectDelegateRefusesEvenSameOriginAndNeverReturnsCredentials() {
+        let downloader = ManagedVideoDownload()
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.invalidateAndCancel() }
+        var request = request()
+        request.setValue("Bearer synthetic", forHTTPHeaderField: "Authorization")
+        let response = HTTPURLResponse(url: request.url!, statusCode: 302, httpVersion: nil, headerFields: ["Location": "https://other.example/clip.mp4"])!
+        downloader.urlSession(session, task: session.dataTask(with: request), willPerformHTTPRedirection: response, newRequest: request) {
+            XCTAssertNil($0)
+        }
+    }
+
+    func testCacheScopesOriginsProfilesAndProtectsLeasedFiles() throws {
+        let a = try ManagedVideoCache.directory(origin: "https://one.example", profile: "default", root: root)
+        let b = try ManagedVideoCache.directory(origin: "https://two.example", profile: "default", root: root)
+        let c = try ManagedVideoCache.directory(origin: "https://one.example", profile: "other", root: root)
+        XCTAssertNotEqual(a, b); XCTAssertNotEqual(a, c)
+        let active = a.appendingPathComponent("active.mp4"), stale = a.appendingPathComponent("stale.mp4")
+        try Data([1]).write(to: active); try Data([2]).write(to: stale)
+        var lease: ManagedVideoFile? = ManagedVideoFile(url: active)
+        ManagedVideoCache.prune(root: root, limit: 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lease!.url.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stale.path))
+        lease = nil
+        ManagedVideoCache.prune(root: root, limit: 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: active.path))
+    }
+
+    func testOfficialHTTPAdapterUsesBearerPathQueryAndLocalPlayerURL() async throws {
+        VideoProtocol.handler = { p in
+            XCTAssertEqual(p.request.url?.path, "/api/files/download")
+            let query = URLComponents(url: p.request.url!, resolvingAgainstBaseURL: false)?.queryItems
+            XCTAssertEqual(query, [URLQueryItem(name: "path", value: "/tmp/clip.mp4")])
+            XCTAssertEqual(p.request.value(forHTTPHeaderField: "Authorization"), "Bearer synthetic")
+            p.respond(headers: ["Content-Type": "video/mp4"])
+            p.client?.urlProtocol(p, didLoad: Data([1]))
+            p.client?.urlProtocolDidFinishLoading(p)
+        }
+        let session = URLSession(configuration: configuration())
+        defer { session.invalidateAndCancel() }
+        let client = HermesHTTPClient(origin: "https://video.example", session: session)
+        client.bearerToken = "synthetic"
+        let file = try await client.downloadManagedVideo(path: "/tmp/clip.mp4", profile: "video-test")
+        defer { try? FileManager.default.removeItem(at: file.url) }
+        XCTAssertTrue(file.url.isFileURL)
+        XCTAssertFalse(file.url.absoluteString.contains("synthetic"))
+    }
+
+    func testExpiredVideoBearerRefreshesOnceBeforeRetry() async throws {
+        var calls = 0
+        VideoProtocol.handler = { p in
+            calls += 1
+            if calls == 1 {
+                p.respond(headers: [:], status: 401)
+                p.client?.urlProtocolDidFinishLoading(p)
+                return
+            }
+            XCTAssertEqual(p.request.value(forHTTPHeaderField: "Authorization"), "Bearer refreshed")
+            p.respond(headers: ["Content-Type": "video/mp4"])
+            p.client?.urlProtocol(p, didLoad: Data([1]))
+            p.client?.urlProtocolDidFinishLoading(p)
+        }
+        let session = URLSession(configuration: configuration())
+        defer { session.invalidateAndCancel() }
+        let client = HermesHTTPClient(origin: "https://video.example", session: session)
+        client.bearerToken = "expired"
+        var refreshes = 0
+        client.refreshTokenProvider = {
+            refreshes += 1
+            return NativeTokenSet(accessToken: "refreshed", refreshToken: "r2", expiresAt: 9_000_000_000, provider: "nous", userID: "u")
+        }
+        let file = try await client.downloadManagedVideo(path: "/tmp/clip.mp4", profile: "video-test")
+        defer { try? FileManager.default.removeItem(at: file.url) }
+        XCTAssertEqual(calls, 2)
+        XCTAssertEqual(refreshes, 1)
+    }
+
+    func testVideoAuthRetryStopsAfterSecond401() async throws {
+        var calls = 0
+        VideoProtocol.handler = { p in
+            calls += 1
+            p.respond(headers: [:], status: 401)
+            p.client?.urlProtocolDidFinishLoading(p)
+        }
+        let session = URLSession(configuration: configuration())
+        defer { session.invalidateAndCancel() }
+        let client = HermesHTTPClient(origin: "https://video.example", session: session)
+        var refreshes = 0
+        client.refreshTokenProvider = {
+            refreshes += 1
+            return NativeTokenSet(accessToken: "refreshed", refreshToken: "r2", expiresAt: 9_000_000_000, provider: "nous", userID: "u")
+        }
+        do {
+            _ = try await client.downloadManagedVideo(path: "/tmp/clip.mp4", profile: "video-test")
+            XCTFail("Repeated auth rejection must fail")
+        } catch { }
+        XCTAssertEqual(calls, 2)
+        XCTAssertEqual(refreshes, 1)
+    }
+}
+
+private final class VideoProtocol: URLProtocol {
+    static var handler: ((VideoProtocol) -> Void)?
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() { Self.handler?(self) }
+    override func stopLoading() { }
+    func respond(headers: [String: String], status: Int = 200) {
+        client?.urlProtocol(self, didReceive: HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headers)!, cacheStoragePolicy: .notAllowed)
+    }
+}

--- a/ios/MercuryTests/MediaDirectiveExtractorTests.swift
+++ b/ios/MercuryTests/MediaDirectiveExtractorTests.swift
@@ -223,9 +223,9 @@ final class MediaDirectiveExtractorTests: XCTestCase {
         XCTAssertEqual(artifacts.count, 3)
         // Extension beats label prefix.
         XCTAssertEqual(artifacts[0].type, .image)
-        // Label prefix only promotes image/audio; video falls back to file,
-        // and the prefix is stripped from the display name.
-        XCTAssertEqual(artifacts[1].type, .file)
+        // Shared video extensions/labels promote video; the prefix is
+        // stripped from the display name. Remote video remains external-only.
+        XCTAssertEqual(artifacts[1].type, .video)
         XCTAssertEqual(artifacts[1].displayName, "clip.mkv")
         XCTAssertEqual(artifacts[2].type, .file)
         XCTAssertEqual(artifacts[2].displayName, "plain")

--- a/ios/MercuryUITests/ManagedVideoUITests.swift
+++ b/ios/MercuryUITests/ManagedVideoUITests.swift
@@ -1,0 +1,49 @@
+import XCTest
+
+/// Uses the unchanged official fake-Hermes file route with a real H264 MP4
+/// fixture supplied by MERCURY_E2E_VIDEO_FILE on the backend. No test-only
+/// playback bypass: authentication, extraction, disk download and AVKit run.
+final class ManagedVideoUITests: XCTestCase {
+    func testManagedVideoPlaysLocallyAndDisposesOnBackground() throws {
+        guard ProcessInfo.processInfo.environment["FAKE_HERMES_VIDEO"] == "1",
+              let origin = ProcessInfo.processInfo.environment["FAKE_HERMES_ORIGIN"], !origin.isEmpty else {
+            throw XCTSkip("Set FAKE_HERMES_VIDEO=1 and FAKE_HERMES_ORIGIN with a video-enabled fake backend")
+        }
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitest-reset-local-state", "-uitest-video-clock", "-uitest-probe", origin]
+        app.launch()
+        let login = app.buttons["Sign in with username and password"]
+        XCTAssertTrue(login.waitForExistence(timeout: 30))
+        login.tap()
+        let username = app.textFields["Username"]
+        XCTAssertTrue(username.waitForExistence(timeout: 10))
+        XCTAssertEqual(username.value as? String, "admin")
+        let password = app.secureTextFields["Password"]
+        XCTAssertTrue(password.waitForExistence(timeout: 10))
+        password.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        password.typeText("e2epass")
+        app.buttons["Sign in"].tap()
+        let row = app.staticTexts["E2E Session"]
+        XCTAssertTrue(row.waitForExistence(timeout: 30)); row.tap()
+        let preview = app.buttons["managed-video-preview"].firstMatch
+        XCTAssertTrue(preview.waitForExistence(timeout: 30), app.debugDescription)
+        preview.tap()
+        let close = app.buttons["managed-video-close"]
+        XCTAssertTrue(close.waitForExistence(timeout: 30), app.debugDescription)
+        let progress = app.staticTexts["managed-video-playback-time"]
+        let advanced = NSPredicate(format: "label MATCHES %@", "Playback ([2-9]|[1-9][0-9]+) seconds")
+        expectation(for: advanced, evaluatedWith: progress)
+        waitForExpectations(timeout: 20)
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "Managed video native playback"; screenshot.lifetime = .keepAlways
+        add(screenshot)
+        close.tap()
+        XCTAssertTrue(preview.waitForExistence(timeout: 10))
+        preview.tap()
+        XCTAssertTrue(close.waitForExistence(timeout: 30))
+        XCUIDevice.shared.press(.home)
+        app.activate()
+        XCTAssertTrue(preview.waitForExistence(timeout: 10))
+        XCTAssertFalse(close.exists, "Background must dispose fullscreen playback")
+    }
+}

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactExtractor.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactExtractor.kt
@@ -114,7 +114,8 @@ object ArtifactExtractor {
         val forcedType: ArtifactType?,
     )
 
-    private fun standaloneMediaSource(line: String): String? {
+    /** Parses only the standalone directive grammar; callers must validate the returned source before fetching it. */
+    fun standaloneMediaSource(line: String): String? {
         var body = line.trim(' ', '\t')
         if (body.isEmpty()) return null
 
@@ -300,6 +301,8 @@ object ArtifactExtractor {
         return when {
             extension in imageExtensions -> ArtifactType.Image
             extension in audioExtensions -> ArtifactType.Audio
+            extension in ManagedVideoPolicy.extensions -> ArtifactType.Video
+            typePrefixPattern.find(labelHint.orEmpty())?.groupValues?.get(1)?.lowercase() == "video" -> ArtifactType.Video
             typePrefixPattern.find(labelHint.orEmpty())?.groupValues?.get(1)?.lowercase() == "image" -> ArtifactType.Image
             typePrefixPattern.find(labelHint.orEmpty())?.groupValues?.get(1)?.lowercase() == "audio" -> ArtifactType.Audio
             else -> ArtifactType.File

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactModels.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactModels.kt
@@ -4,6 +4,7 @@ package com.unsupportedpastels.mercury.core.artifacts
 enum class ArtifactType {
     Image,
     Audio,
+    Video,
     File,
 }
 

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ManagedVideoPolicy.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ManagedVideoPolicy.kt
@@ -1,0 +1,20 @@
+package com.unsupportedpastels.mercury.core.artifacts
+
+/** Transport-free managed-video rules shared by both native clients. */
+object ManagedVideoPolicy {
+    const val MAX_DOWNLOAD_BYTES: Long = 256L * 1024 * 1024
+    const val MAX_CACHE_BYTES: Long = 512L * 1024 * 1024
+    internal val extensions = setOf("mp4", "webm", "mov", "m4v", "mkv")
+
+    fun isVideoMimeType(contentType: String): Boolean {
+        val mime = contentType.substringBefore(';').trim().lowercase()
+        return mime.startsWith("video/") && mime.substringAfter('/').isNotEmpty() &&
+            mime.substringAfter('/').all { it.isLetterOrDigit() || it in "!#$&^_.+-" }
+    }
+
+    fun isManagedVideoPath(path: String): Boolean =
+        path.length in 2..4096 && path.startsWith('/') && !path.startsWith("//") &&
+            path.none { it.isISOControl() || it == '\\' } &&
+            path.split('/').none { it == "." || it == ".." } &&
+            path.substringAfterLast('.', "").lowercase() in extensions
+}

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/sessions/SessionPresencePolicy.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/sessions/SessionPresencePolicy.kt
@@ -1,0 +1,61 @@
+package com.unsupportedpastels.mercury.core.sessions
+
+/**
+ * One row of the official read-only `session.active_list` JSON-RPC snapshot
+ * (live, in-memory sessions of the connected gateway process).
+ *
+ * `sessionKey` is the durable stored session ID used by REST session lists —
+ * the only field a presence join may key on. The runtime `id` is opaque and
+ * must never be joined to durable rows.
+ */
+data class SessionActiveListRow(
+    val id: String,
+    val sessionKey: String,
+    val status: String,
+)
+
+/**
+ * Working-state presence decided once for both clients from the official
+ * `session.active_list` snapshot.
+ *
+ * Authoritative for sessions live in the connected gateway process: a session
+ * is "working" only when its `status` is exactly `working`. The other
+ * documented statuses (`starting`, `idle`, `waiting`) never light the
+ * indicator — `waiting` includes approval/clarification pends and must not
+ * read as model work, and `idle` rows must not be relabelled as active.
+ *
+ * The result is observer-only presence for rendering a working indicator; it
+ * never implies runtime ownership and must never gate resume/activate
+ * affordances. The snapshot is process-local (profile-scoped Desktop/TUI
+ * child backends are invisible), so absence of a row is "unknown", not
+ * "idle" — callers fail closed by simply clearing the indicator.
+ */
+object SessionPresencePolicy {
+    const val WORKING_STATUS = "working"
+    const val MAX_ROWS = 256
+
+    /** Bounded, tolerant parse of the `sessions` array of `session.active_list`. */
+    fun parseRows(result: Map<*, *>?): List<SessionActiveListRow> {
+        if (result == null) return emptyList()
+        val rows = result["sessions"] as? List<*> ?: return emptyList()
+        return rows.asSequence()
+            .filterIsInstance<Map<*, *>>()
+            .mapNotNull { row ->
+                val id = (row["id"] as? String)?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+                val sessionKey = row["session_key"] as? String ?: return@mapNotNull null
+                if (sessionKey.isEmpty()) return@mapNotNull null
+                val status = (row["status"] as? String)?.trim()?.takeIf { it.isNotEmpty() }
+                    ?: return@mapNotNull null
+                SessionActiveListRow(id = id, sessionKey = sessionKey, status = status)
+            }
+            .take(MAX_ROWS)
+            .toList()
+    }
+
+    /** Durable session IDs currently running a turn (`status == "working"`). */
+    fun workingSessionIds(rows: List<SessionActiveListRow>): Set<String> =
+        rows.asSequence()
+            .filter { it.status == WORKING_STATUS }
+            .map { it.sessionKey }
+            .toSet()
+}

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/artifacts/ManagedVideoPolicyTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/artifacts/ManagedVideoPolicyTest.kt
@@ -1,0 +1,38 @@
+package com.unsupportedpastels.mercury.core.artifacts
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class ManagedVideoPolicyTest {
+    @Test fun standaloneVideoGrammarIsSharedByInlineAndCatalogConsumers() {
+        for (directive in listOf("MEDIA: /tmp/clip.mp4", "  MEDIA:/tmp/clip.mp4  ", "MEDIA: \"/tmp/clip.mp4\"", "`MEDIA:/tmp/clip.mp4`")) {
+            assertEquals("/tmp/clip.mp4", ArtifactExtractor.standaloneMediaSource(directive))
+            assertEquals(ArtifactType.Video, ArtifactExtractor.extract(directive).single().type)
+        }
+        for (malformed in listOf("Here is MEDIA: /tmp/clip.mp4", "MEDIA: /tmp/clip.mp4 trailing", "MEDIA:", "MEDIA: \"/tmp/clip.mp4")) {
+            assertEquals(null, ArtifactExtractor.standaloneMediaSource(malformed))
+        }
+    }
+
+    @Test fun videoExtensionsAndLabelAreClassifiedAcrossOrigins() {
+        for (extension in listOf("mp4", "webm", "mov", "m4v", "mkv", "MP4")) {
+            assertEquals(ArtifactType.Video, ArtifactExtractor.extract("MEDIA:/workspace/clip.$extension").single().type)
+            assertTrue(ManagedVideoPolicy.isManagedVideoPath("/workspace/clip.$extension"))
+        }
+        assertEquals(ArtifactType.Video, ArtifactExtractor.extract("[Video: demo](https://cdn.example/download)").single().type)
+        assertEquals(ArtifactType.Video, ArtifactExtractor.extract("https://cdn.example/clip.webm?dl=1").single().type)
+    }
+    @Test fun pathAndMimePolicyFailClosed() {
+        for (path in listOf("relative.mp4", "//host/clip.mp4", "/a/../clip.mp4", "/a/./clip.mp4", "/a\\clip.mp4", "/a/clip.pdf", "/a/clip.mp4?x=1", "/a/\u0000clip.mp4", "/" + "a".repeat(4096) + ".mp4")) {
+            assertFalse(ManagedVideoPolicy.isManagedVideoPath(path), path)
+        }
+        assertTrue(ManagedVideoPolicy.isVideoMimeType(" Video/MP4; codecs=avc1 "))
+        for (mime in listOf("video/", "image/mp4", "application/octet-stream", "video/mp4\r\nheader", "video/a b")) {
+            assertFalse(ManagedVideoPolicy.isVideoMimeType(mime), mime)
+        }
+        assertEquals(268435456L, ManagedVideoPolicy.MAX_DOWNLOAD_BYTES)
+        assertEquals(536870912L, ManagedVideoPolicy.MAX_CACHE_BYTES)
+    }
+}

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/sessions/SessionPresencePolicyTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/sessions/SessionPresencePolicyTest.kt
@@ -1,0 +1,102 @@
+package com.unsupportedpastels.mercury.core.sessions
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SessionPresencePolicyTest {
+
+    private fun row(
+        id: String,
+        sessionKey: String,
+        status: String,
+    ) = mapOf("id" to id, "session_key" to sessionKey, "status" to status)
+
+    @Test
+    fun parseExtractsWellFormedRows() {
+        val rows = SessionPresencePolicy.parseRows(
+            mapOf(
+                "sessions" to listOf(
+                    row("r1", "dur-1", "working"),
+                    row("r2", "dur-2", "idle"),
+                ),
+            ),
+        )
+        assertEquals(2, rows.size)
+        assertEquals(SessionActiveListRow("r1", "dur-1", "working"), rows[0])
+        assertEquals(SessionActiveListRow("r2", "dur-2", "idle"), rows[1])
+    }
+
+    @Test
+    fun parseRejectsMalformedAndMissingFields() {
+        val rows = SessionPresencePolicy.parseRows(
+            mapOf(
+                "sessions" to listOf(
+                    mapOf("id" to "r1", "status" to "working"), // no session_key
+                    mapOf("id" to "r2", "session_key" to "", "status" to "working"), // empty key
+                    mapOf("id" to "r3", "session_key" to "dur-3"), // no status
+                    mapOf("id" to "r4", "session_key" to "dur-4", "status" to "  "), // blank status
+                    row("r5", "dur-5", "working"),
+                    "not-a-map",
+                    42,
+                ),
+            ),
+        )
+        assertEquals(listOf(SessionActiveListRow("r5", "dur-5", "working")), rows)
+    }
+
+    @Test
+    fun parseToleratesNullAndWrongShapes() {
+        assertEquals(emptyList(), SessionPresencePolicy.parseRows(null))
+        assertEquals(emptyList(), SessionPresencePolicy.parseRows(mapOf<String, Any>()))
+        assertEquals(emptyList(), SessionPresencePolicy.parseRows(mapOf("sessions" to "nope")))
+        assertEquals(emptyList(), SessionPresencePolicy.parseRows(Any() as? Map<*, *>))
+    }
+
+    @Test
+    fun parseBoundsRowCount() {
+        val many = (1..(SessionPresencePolicy.MAX_ROWS + 50)).map { index ->
+            row("r$index", "dur-$index", "working")
+        }
+        val rows = SessionPresencePolicy.parseRows(mapOf("sessions" to many))
+        assertEquals(SessionPresencePolicy.MAX_ROWS, rows.size)
+    }
+
+    @Test
+    fun onlyWorkingStatusLightsTheIndicator() {
+        val rows = SessionPresencePolicy.parseRows(
+            mapOf(
+                "sessions" to listOf(
+                    row("r1", "dur-working", "working"),
+                    row("r2", "dur-idle", "idle"),
+                    row("r3", "dur-starting", "starting"),
+                    row("r4", "dur-waiting", "waiting"),
+                    row("r5", "dur-trim", "  working  "),
+                    row("r6", "dur-unknown", "dancing"),
+                ),
+            ),
+        )
+        val working = SessionPresencePolicy.workingSessionIds(rows)
+        // Trimmed whitespace normalizes to the exact status; untrimmed unknown
+        // statuses are inert. `waiting` (approval/clarification pends) must not
+        // read as model work.
+        assertEquals(setOf("dur-working", "dur-trim"), working)
+    }
+
+    @Test
+    fun joinIsBySessionKeyNotRuntimeId() {
+        val rows = SessionPresencePolicy.parseRows(
+            mapOf(
+                "sessions" to listOf(row("runtime-id-value", "durable-1", "working")),
+            ),
+        )
+        val working = SessionPresencePolicy.workingSessionIds(rows)
+        assertTrue("durable-1" in working)
+        assertTrue("runtime-id-value" !in working)
+    }
+
+    @Test
+    fun emptySnapshotFailsClosedToEmptyWorkingSet() {
+        assertEquals(emptySet(), SessionPresencePolicy.workingSessionIds(emptyList()))
+    }
+}

--- a/tools/fake-hermes/fake_hermes.py
+++ b/tools/fake-hermes/fake_hermes.py
@@ -17,12 +17,16 @@ Wire shapes were mined from:
 
 Usage:  python3 fake_hermes.py [PORT]     (default 8787, cleartext HTTP)
 
+Set MERCURY_E2E_VIDEO_FILE to a local synthetic MP4 to exercise authenticated
+managed-video download/playback. Only the fixed fixture path is served.
+
 Login:  any username, password "e2epass"  -> HttpOnly session cookie.
 """
 
 import base64
 import hashlib
 import json
+import os
 import secrets
 import struct
 import sys
@@ -38,6 +42,14 @@ RUNTIME_SESSION_ID = "rt-e2e-1"
 SENTINEL_TEXT = "Operation interrupted: waiting for model response (2s elapsed)."
 PROMPT_WAIT_SECONDS = 8.0
 WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+VIDEO_FIXTURE_FILE = os.environ.get("MERCURY_E2E_VIDEO_FILE")
+VIDEO_MANAGED_PATH = "/tmp/mercury-test-video.mp4"
+
+
+def transcript_messages():
+    if not VIDEO_FIXTURE_FILE:
+        return []
+    return [{"role": "assistant", "content": "Video playback fixture\nMEDIA: " + VIDEO_MANAGED_PATH}]
 
 _lock = threading.Lock()
 SESSION_TOKENS = set()      # cookie/bearer values minted by password-login
@@ -202,11 +214,30 @@ class Handler(BaseHTTPRequestHandler):
                 })
         elif path.startswith("/api/sessions/") and path.endswith("/messages"):
             if self.require_auth():
+                messages = transcript_messages()
                 self.send_json({
                     "session_id": path.split("/")[3],
-                    "messages": [],
-                    "pagination": {"limit": 100, "offset": 0, "returned": 0},
+                    "messages": messages,
+                    "pagination": {"limit": 100, "offset": 0, "returned": len(messages)},
                 })
+        elif path == "/api/files/download":
+            if not self.require_auth():
+                return
+            if not VIDEO_FIXTURE_FILE or query.get("path") != [VIDEO_MANAGED_PATH]:
+                self.send_json({"error": "fixture not found"}, status=404)
+                return
+            try:
+                fixture = open(VIDEO_FIXTURE_FILE, "rb")
+            except OSError:
+                self.send_json({"error": "fixture unavailable"}, status=404)
+                return
+            with fixture:
+                self.send_response(200)
+                self.send_header("Content-Type", "video/mp4")
+                self.send_header("Content-Length", str(os.fstat(fixture.fileno()).st_size))
+                self.end_headers()
+                while chunk := fixture.read(64 * 1024):
+                    self.wfile.write(chunk)
         elif path == "/api/model/options":
             if self.require_auth():
                 self.send_json({
@@ -447,7 +478,7 @@ class WsSession:
                 "session_id": RUNTIME_SESSION_ID,
                 "session_key": requested,
                 "resumed": True,
-                "messages": [],
+                "messages": transcript_messages(),
                 "running": False,
                 "info": {
                     "model": "fake-model",

--- a/tools/fake-hermes/test_fake_hermes.py
+++ b/tools/fake-hermes/test_fake_hermes.py
@@ -1,4 +1,11 @@
 import unittest
+import json
+from pathlib import Path
+import tempfile
+import threading
+from unittest.mock import patch
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
 
 import fake_hermes
 
@@ -16,6 +23,37 @@ class SafeLoggingTest(unittest.TestCase):
         self.assertEqual(fake_hermes.rpc_log_summary("send", event), "WS send: event message.delta")
         self.assertNotIn("private prompt", fake_hermes.rpc_log_summary("recv", prompt))
         self.assertNotIn("private transcript", fake_hermes.rpc_log_summary("send", event))
+
+
+class VideoFixtureTest(unittest.TestCase):
+    def test_video_fixture_requires_auth_and_only_serves_fixed_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "fixture.mp4"
+            fixture.write_bytes(b"synthetic-video-fixture")
+            with patch.object(fake_hermes, "VIDEO_FIXTURE_FILE", str(fixture), create=True):
+                server = fake_hermes.ThreadingHTTPServer(("127.0.0.1", 0), fake_hermes.Handler)
+                worker = threading.Thread(target=server.serve_forever, daemon=True)
+                worker.start()
+                origin = f"http://127.0.0.1:{server.server_port}"
+                try:
+                    with self.assertRaises(HTTPError) as failure:
+                        urlopen(origin + "/api/files/download?path=/tmp/mercury-test-video.mp4", timeout=2)
+                    self.assertEqual(failure.exception.code, 401)
+                    token = fake_hermes.mint_session_token()
+                    headers = {"Authorization": "Bearer " + token}
+                    with urlopen(Request(origin + "/api/files/download?path=/tmp/mercury-test-video.mp4", headers=headers), timeout=2) as response:
+                        self.assertEqual(response.headers["Content-Type"], "video/mp4")
+                        self.assertEqual(response.read(), fixture.read_bytes())
+                    with self.assertRaises(HTTPError) as failure:
+                        urlopen(Request(origin + "/api/files/download?path=/etc/passwd", headers=headers), timeout=2)
+                    self.assertEqual(failure.exception.code, 404)
+                    with urlopen(Request(origin + "/api/sessions/e2e-session-1/messages", headers=headers), timeout=2) as response:
+                        messages = json.load(response)["messages"]
+                    self.assertIn("MEDIA: /tmp/mercury-test-video.mp4", messages[0]["content"])
+                finally:
+                    server.shutdown()
+                    server.server_close()
+                    worker.join(timeout=2)
 
 
 if __name__ == "__main__":

--- a/tools/fake-hermes/verify.py
+++ b/tools/fake-hermes/verify.py
@@ -5,7 +5,7 @@ Walks: probe -> password login -> sessions -> transcript -> ws-ticket
        -> WS session.resume -> prompt.submit -> start/delta/delta
        -> session.interrupt -> sentinel message.complete.
 
-Usage: python3 verify.py [PORT]   (default 8787; server must be running)
+Usage: python3 verify.py [PORT] [--video]   (default 8787; server must be running)
 """
 
 import base64
@@ -18,6 +18,7 @@ import sys
 import urllib.request
 
 PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8787
+VIDEO_EXPECTED = "--video" in sys.argv[2:]
 BASE = f"http://127.0.0.1:{PORT}"
 SENTINEL = "Operation interrupted: waiting for model response (2s elapsed)."
 
@@ -87,7 +88,19 @@ check("sessions list has e2e-session-1",
 status, _, body = http_json(
     "GET", "/api/sessions/e2e-session-1/messages?limit=100&order=latest&profile=default",
     headers=auth)
-check("transcript empty", status == 200 and body.get("messages") == [], str(body))
+if VIDEO_EXPECTED:
+    messages = body.get("messages", [])
+    check("transcript contains managed video", status == 200 and len(messages) == 1
+          and "MEDIA: /tmp/mercury-test-video.mp4" in messages[0].get("content", ""))
+    request = urllib.request.Request(BASE + "/api/files/download?path=/tmp/mercury-test-video.mp4", headers=auth)
+    with urllib.request.urlopen(request, timeout=5) as response:
+        clip = response.read(1024 * 1024)
+        check("authenticated MP4 fixture download", response.status == 200
+              and response.headers.get("Content-Type") == "video/mp4"
+              and clip[4:8] == b"ftyp"
+              and len(clip) == int(response.headers.get("Content-Length", "0")))
+else:
+    check("transcript empty", status == 200 and body.get("messages") == [], str(body))
 
 status, _, body = http_json("GET", "/api/profiles", headers=auth)
 check("/api/profiles", status == 200 and body.get("profiles"), str(body))


### PR DESCRIPTION
## Summary

Two changes, landed together because they share the tree and both touch both platforms:

1. **Managed-video playback** — adapted from @forcewake's PR #48 onto current shared-core/screen boundaries (credit preserved in CONTRIBUTORS.md), plus native iOS playback.
2. **Live working-presence indicators** — home/recent session lists now show an "Agent is working" marker when a turn is actually running, on both transports.

### Managed video
- Shared `mercury-core` video policy (path/MIME/size bounds, standalone MEDIA grammar) with common tests; Android parses canonical `MEDIA: /path/video.mp4` forms instead of rendering the directive as text.
- Android: inline Media3 playback from bounded authenticated streaming to private local files; reference-counted cache leases (active/preparing players can't be evicted mid-playback); rejected/failed downloads never expose partial final files; no credentials reach player URLs; remote HTTPS videos remain external links; unsupported Relay video shows an explicit unavailable state.
- iOS: native AVPlayer with full-screen/error lifecycle preserved; one expired-bearer retry through the existing refresh provider (max two requests); bounded authenticated download.
- Gradle wrapper 9.7.1 and the reviewed pinned Actions updates (PRs #44/#45 adopted locally).
- CONTRIBUTORS.md credits @forcewake (implementation/tests) and @HotRod5k (earlier profile report); original authorship preserved.

### Working-presence indicators
- New shared `SessionPresencePolicy`: tolerant bounded parse of the official `session.active_list` snapshot; working set joined by durable `session_key` (never the runtime ID); only `status == "working"` lights the indicator (`starting`/`idle`/`waiting` are inert).
- Android: `loadActiveSessionPresence` on the chat session + `refreshActiveWorkingSessions()` in the connection ViewModel; Home and Recent Sessions poll silently every 3s while connected — direct via the metadata session, relay via the borrowed admitted controller (no extra device channel). Rows render a compact indicator with explicit "Agent is working" semantics.
- iOS: lifted the relay carve-out in `ProjectMetadataController` so the existing 3s `session.active_list` poll feeds the inbox running/unread indicators over relay too — previously disabled there, which left every row idle through relay.
- Fail closed: RPC error or unsupported server clears the working set rather than preserving stale spinners. Presence is render-only and never gates resume/activate affordances.

## Regression coverage
- Shared core: `ManagedVideoPolicyTest` (38), `SessionPresencePolicyTest` (8).
- Android: grammar/lease/cache/safety presentation tests, `ManagedVideoEndToEndTest` (instrumented, 3 window sizes), presence gateway + ViewModel tests (publish and fail-closed).
- iOS: `ManagedVideoTests` (250), `ManagedVideoUITests`, `MediaDirectiveExtractorTests` updated.

## Verification
- Android: **1,029 unit tests, 0 failures**; `testDebugUnitTest lintDebug assembleDebug`; screenshot gate 28 passed, references unchanged.
- Shared core: `:shared:mercury-core:check` green (163 tests).
- iOS: **730 tests, 0 failures** on iPhone 17 Pro simulator (xcodegen + xcodebuild on mark-mac); changed-file source hashes verified identical between authoring tree and Mac build root.
- Emulator playback exercised with real Media3 clock advance at compact/medium/expanded; iPhone/iPad simulator playback passed with a video-only H.264 fixture; fake-hermes `default` and `--video` contract checks passed.
- `git diff --check` clean; single commit, 50 files, +3162/−44.

## Known limitation (not hidden)
Audio-bearing MP4 playback is **not certified on iOS simulators**: a standalone AVPlayer probe with no Mercury code also stalls at time zero (H.264/AAC, iOS 26.5 and 18.4), while the identical clip without the audio track plays. No workaround was added to production. Physical-device playback of an audio-bearing clip should be confirmed before calling this release-validated.

## Scope and risk
Client-only; no server or relay contract changes. Supersedes the file overlap of PR #48 (happy to rebase/close whichever way the maintainer prefers — the credit for the original implementation is retained either way).
