### PR TITLE
fix: decode and answer batch clarify requests on both platforms

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/MainActivity.kt
@@ -198,8 +198,8 @@ class MainActivity : ComponentActivity() {
                     onSteerMessage = connectionViewModel::steerSession,
                     onReasoningSelected = connectionViewModel::setReasoningEffort,
                     onFastSelected = connectionViewModel::setFast,
-                    onClarificationResponse = { sessionId, requestId, answer ->
-                        connectionViewModel.respondToClarification(sessionId, requestId, answer)
+                    onClarificationResponse = { sessionId, requestId, questionId, answer ->
+                        connectionViewModel.respondToClarification(sessionId, requestId, questionId, answer)
                     },
                     onApprovalResponse = { sessionId, choice, all ->
                         connectionViewModel.respondToApproval(sessionId, choice, all)
@@ -299,7 +299,7 @@ internal fun HermesAppHost(
     onSteerMessage: (DurableSessionId, String) -> Unit = { _, _ -> },
     onReasoningSelected: (DurableSessionId, String) -> Unit = { _, _ -> },
     onFastSelected: (DurableSessionId, Boolean) -> Unit = { _, _ -> },
-    onClarificationResponse: (DurableSessionId, String, String) -> Unit = { _, _, _ -> },
+    onClarificationResponse: (DurableSessionId, String, String?, String) -> Unit = { _, _, _, _ -> },
     onApprovalResponse: (DurableSessionId, String, Boolean) -> Unit = { _, _, _ -> },
     onBlockingResponse: (DurableSessionId, UnsupportedBlockingKind, String, String) -> Unit = { _, _, _, _ -> },
     onStopSession: (DurableSessionId) -> Unit = {},

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/app/RunEventModels.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/app/RunEventModels.kt
@@ -3,6 +3,8 @@ package com.unsupportedpastels.hermesandroid.app
 import com.unsupportedpastels.hermesandroid.gateway.HermesChatEvent
 import com.unsupportedpastels.hermesandroid.gateway.RuntimeSessionId
 import com.unsupportedpastels.hermesandroid.gateway.UnsupportedBlockingKind
+import com.unsupportedpastels.mercury.core.interaction.ClarifyAnswerPolicy
+import com.unsupportedpastels.mercury.core.transcript.ClarifyQuestion
 
 const val MAX_RUN_TOOL_ROWS = 50
 const val MAX_RUN_TODO_ITEMS = 50
@@ -66,7 +68,21 @@ data class ClarificationInteraction(
     val choices: List<String>,
     val multiSelect: Boolean,
     val lifecycle: RunInteractionLifecycle = RunInteractionLifecycle.Pending,
-)
+    /** Batch form; empty for a single question. */
+    val questions: List<ClarifyQuestion> = emptyList(),
+    val answeredQuestionIds: Set<String> = emptySet(),
+) {
+    val isBatch: Boolean get() = questions.isNotEmpty()
+
+    /** The question to show now: the next unanswered one of a batch (shared decision). */
+    val currentQuestion: ClarifyQuestion?
+        get() = ClarifyAnswerPolicy.nextQuestion(questions, answeredQuestionIds)
+
+    /** Text, choices and mode to render: the current batch question or the single question. */
+    val displayQuestion: String get() = currentQuestion?.question ?: question
+    val displayChoices: List<String> get() = currentQuestion?.choices ?: choices
+    val displayMultiSelect: Boolean get() = currentQuestion?.multiSelect ?: multiSelect
+}
 
 data class ApprovalInteraction(
     val runtimeSessionId: RuntimeSessionId,
@@ -207,8 +223,33 @@ data class RunEventState(
                     .take(MAX_RUN_INTERACTION_CHOICES)
                     .map { it.take(MAX_RUN_INTERACTION_CHOICE_CHARS) },
                 multiSelect = event.multiSelect,
+                questions = event.questions.take(MAX_RUN_INTERACTION_CHOICES).map { entry ->
+                    ClarifyQuestion(
+                        qid = entry.qid.take(MAX_RUN_INTERACTION_ID_CHARS),
+                        question = entry.question.take(MAX_RUN_INTERACTION_TEXT_CHARS),
+                        choices = entry.choices
+                            .take(MAX_RUN_INTERACTION_CHOICES)
+                            .map { it.take(MAX_RUN_INTERACTION_CHOICE_CHARS) },
+                        multiSelect = entry.multiSelect,
+                    )
+                },
             ),
         )
+
+    /**
+     * Records one answered batch question. The card stays pending while
+     * questions remain; the host resolves the request after the last one.
+     */
+    fun markClarificationQuestionAnswered(requestId: String, questionId: String): RunEventState {
+        val current = clarification ?: return this
+        if (current.requestId != requestId.take(MAX_RUN_INTERACTION_ID_CHARS)) return this
+        return copy(
+            clarification = current.copy(
+                answeredQuestionIds = current.answeredQuestionIds + questionId,
+                lifecycle = RunInteractionLifecycle.Pending,
+            ),
+        )
+    }
 
     private fun reduceClarificationExpiry(event: HermesChatEvent.ClarifyExpire): RunEventState {
         val current = clarification ?: return this

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -3475,12 +3475,20 @@ class HermesConnectionViewModel(
         durableSessionId: DurableSessionId,
         requestId: String,
         answer: String,
+    ): Job = respondToClarification(durableSessionId, requestId, questionId = null, answer = answer)
+
+    /** [questionId] names the batch question being answered; null for a single-question request. */
+    fun respondToClarification(
+        durableSessionId: DurableSessionId,
+        requestId: String,
+        questionId: String?,
+        answer: String,
     ): Job {
         val operation = beginClarificationResponse(durableSessionId, requestId)
             ?: return viewModelScope.launch { }
         return viewModelScope.launch {
             try {
-                val response = operation.session.respondToClarification(requestId, answer)
+                val response = operation.session.respondToClarification(requestId, questionId, answer)
                 currentCoroutineContext().ensureActive()
                 val lifecycle = when (response.status) {
                     HermesChatResponseStatus.Ok,
@@ -3491,14 +3499,14 @@ class HermesConnectionViewModel(
                     HermesChatResponseStatus.Unknown,
                     -> RunInteractionLifecycle.Failed
                 }
-                publishClarificationResponse(operation, lifecycle)
+                publishClarificationResponse(operation, lifecycle, questionId)
                 if (lifecycle == RunInteractionLifecycle.Failed) {
                     publishControllerError(operation, "Could not respond to clarification")
                 }
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (_: Exception) {
-                publishClarificationResponse(operation, RunInteractionLifecycle.Failed)
+                publishClarificationResponse(operation, RunInteractionLifecycle.Failed, questionId)
                 publishControllerError(operation, "Could not respond to clarification")
             }
         }
@@ -6029,6 +6037,7 @@ class HermesConnectionViewModel(
     private fun publishClarificationResponse(
         operation: ControllerOperation,
         lifecycle: RunInteractionLifecycle,
+        questionId: String? = null,
     ) {
         synchronized(controllerLock) {
             if (!isCurrentControllerOperation(operation)) return
@@ -6046,9 +6055,17 @@ class HermesConnectionViewModel(
             // responds rather than lingering until the next turn. A failed send
             // reverts to Pending so the user can retry; an expiry keeps the
             // informational settled state.
+            // A batch stays on screen until its last question is answered; the
+            // host only resolves the request then.
+            val remainingAfterAnswer = questionId != null && current.isBatch &&
+                current.questions.any { it.qid != questionId && it.qid !in current.answeredQuestionIds }
             val nextRunState = when (lifecycle) {
                 RunInteractionLifecycle.Resolved ->
-                    chat.runState.copy(clarification = null)
+                    if (remainingAfterAnswer) {
+                        chat.runState.markClarificationQuestionAnswered(checkNotNull(operation.requestId), checkNotNull(questionId))
+                    } else {
+                        chat.runState.copy(clarification = null)
+                    }
                 RunInteractionLifecycle.Failed ->
                     chat.runState.transitionClarificationLifecycle(
                         checkNotNull(operation.requestId),

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/ChatModels.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/ChatModels.kt
@@ -1,5 +1,6 @@
 package com.unsupportedpastels.hermesandroid.gateway
 
+import com.unsupportedpastels.mercury.core.transcript.ClarifyQuestion
 import com.unsupportedpastels.hermesandroid.app.DurableSessionId
 import com.unsupportedpastels.hermesandroid.app.RunTodoItem
 import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
@@ -334,6 +335,8 @@ interface HermesChatEvent {
         val question: String,
         val choices: List<String>,
         val multiSelect: Boolean,
+        /** Batch form: answered one `qid` at a time; empty for a single question. */
+        val questions: List<ClarifyQuestion> = emptyList(),
     ) : HermesChatEvent
 
     data class ClarifyExpire(

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
@@ -449,9 +449,16 @@ class HermesChatConnection internal constructor(
     override suspend fun respondToClarification(
         requestId: String,
         answer: String,
+    ): HermesChatResponse = respondToClarification(requestId, questionId = null, answer = answer)
+
+    override suspend fun respondToClarification(
+        requestId: String,
+        questionId: String?,
+        answer: String,
     ): HermesChatResponse {
         val params = buildJsonObject {
             put("request_id", boundedRpcInput(requestId, HERMES_CHAT_MAX_EVENT_ID_CHARS, "request ID"))
+            questionId?.let { put("question_id", boundedRpcInput(it, HERMES_CHAT_MAX_EVENT_ID_CHARS, "question ID")) }
             put("answer", boundedRpcInput(answer, HERMES_CHAT_MAX_EVENT_TEXT_CHARS, "answer", allowBlank = true))
         }
         return parseInteractionResponse(request("clarify.respond", params))

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatSession.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatSession.kt
@@ -155,6 +155,13 @@ interface HermesChatSession {
         answer: String,
     ): HermesChatResponse = throw HermesChatProtocolException("Clarification response is not available")
 
+    /** Batch clarify: answers one question of the request by its `qid`. */
+    suspend fun respondToClarification(
+        requestId: String,
+        questionId: String?,
+        answer: String,
+    ): HermesChatResponse = respondToClarification(requestId, answer)
+
     suspend fun respondToApproval(
         runtimeSessionId: RuntimeSessionId,
         choice: String,

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/SharedChatEventAdapters.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/SharedChatEventAdapters.kt
@@ -44,7 +44,7 @@ internal fun SharedChatEvent.toAndroidEvent(todos: List<RunTodoItem>? = null): H
         is SharedChatEvent.ToolComplete -> HermesChatEvent.ToolComplete(runtimeId, toolId, name, summary, todos)
         is SharedChatEvent.StatusUpdate -> HermesChatEvent.StatusUpdate(runtimeId, kind, text)
         is SharedChatEvent.ClarifyRequest ->
-            HermesChatEvent.ClarifyRequest(runtimeId, requestId, question, choices, multiSelect)
+            HermesChatEvent.ClarifyRequest(runtimeId, requestId, question, choices, multiSelect, questions)
         is SharedChatEvent.ClarifyExpire -> HermesChatEvent.ClarifyExpire(runtimeId, requestId)
         is SharedChatEvent.ApprovalRequest ->
             HermesChatEvent.ApprovalRequest(runtimeId, requestId, command, description, choices)
@@ -96,7 +96,7 @@ internal fun HermesChatEvent.toSharedEvent(): SharedChatEvent? = when (this) {
     is HermesChatEvent.ToolComplete -> SharedChatEvent.ToolComplete(sessionId.value, toolId, name, summary)
     is HermesChatEvent.StatusUpdate -> SharedChatEvent.StatusUpdate(sessionId.value, kind, text)
     is HermesChatEvent.ClarifyRequest ->
-        SharedChatEvent.ClarifyRequest(sessionId.value, requestId, question, choices, multiSelect)
+        SharedChatEvent.ClarifyRequest(sessionId.value, requestId, question, choices, multiSelect, questions)
     is HermesChatEvent.ClarifyExpire -> SharedChatEvent.ClarifyExpire(sessionId.value, requestId)
     is HermesChatEvent.ApprovalRequest ->
         SharedChatEvent.ApprovalRequest(sessionId.value, requestId, command, description, choices)

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/HermesApp.kt
@@ -188,7 +188,7 @@ fun HermesApp(
     onSteerMessage: (DurableSessionId, String) -> Unit = { _, _ -> },
     onReasoningSelected: (DurableSessionId, String) -> Unit = { _, _ -> },
     onFastSelected: (DurableSessionId, Boolean) -> Unit = { _, _ -> },
-    onClarificationResponse: (DurableSessionId, String, String) -> Unit = { _, _, _ -> },
+    onClarificationResponse: (DurableSessionId, String, String?, String) -> Unit = { _, _, _, _ -> },
     onApprovalResponse: (DurableSessionId, String, Boolean) -> Unit = { _, _, _ -> },
     onBlockingResponse: (DurableSessionId, UnsupportedBlockingKind, String, String) -> Unit = { _, _, _, _ -> },
     onStopSession: (DurableSessionId) -> Unit = {},
@@ -852,8 +852,8 @@ fun HermesApp(
                         onBranchSession = { count, name ->
                             onBranchSession(session.id, count, name)
                         },
-                        onClarificationResponse = { requestId, answer ->
-                            onClarificationResponse(session.id, requestId, answer)
+                        onClarificationResponse = { requestId, questionId, answer ->
+                            onClarificationResponse(session.id, requestId, questionId, answer)
                         },
                         onApprovalResponse = { choice, all ->
                             onApprovalResponse(session.id, choice, all)

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/RunInteractionCards.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/RunInteractionCards.kt
@@ -133,11 +133,18 @@ internal fun ThinkingBlock(
 internal fun ClarificationCard(
     durableSessionId: DurableSessionId,
     interaction: ClarificationInteraction,
-    onResponse: (String, String) -> Unit,
+    onResponse: (requestId: String, questionId: String?, answer: String) -> Unit,
 ) {
+    // A batch presents one question at a time (shared decision); a single
+    // request renders its only question.
+    val current = interaction.currentQuestion
+    val questionId = current?.qid
+    val questionText = interaction.displayQuestion
+    val choices = interaction.displayChoices
+    val multiSelect = interaction.displayMultiSelect
     // Answer semantics are the shared clarify decision (same on iOS).
-    var clarifyState by remember(interaction.requestId) {
-        mutableStateOf(ClarifyAnswerState(interaction.choices, interaction.multiSelect))
+    var clarifyState by remember(interaction.requestId, questionId) {
+        mutableStateOf(ClarifyAnswerState(choices, multiSelect))
     }
     val pending = interaction.lifecycle == RunInteractionLifecycle.Pending
     Card(modifier = Modifier.fillMaxWidth()) {
@@ -146,20 +153,27 @@ internal fun ClarificationCard(
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text("Clarification", style = MaterialTheme.typography.titleSmall)
-            Text(interaction.question)
+            if (current != null && interaction.questions.size > 1) {
+                Text(
+                    "Question ${ClarifyAnswerPolicy.positionOf(interaction.questions, current)} of ${interaction.questions.size}",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(questionText)
             if (pending) {
                 // Grounded in the desktop clarify card: choices are shown as
                 // selectable rows, an "Other" free-text field is ALWAYS offered
                 // alongside them, and the card is confirmed with Skip / Continue.
                 // Typing in the field and picking a choice are mutually exclusive.
-                if (interaction.choices.isNotEmpty()) {
-                    if (interaction.multiSelect) {
+                if (choices.isNotEmpty()) {
+                    if (multiSelect) {
                         FlowRow(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalArrangement = Arrangement.spacedBy(4.dp),
                         ) {
-                            interaction.choices.forEach { choice ->
+                            choices.forEach { choice ->
                                 FilterChip(
                                     selected = choice in clarifyState.selectedChoices,
                                     onClick = { clarifyState = clarifyState.select(choice) },
@@ -172,7 +186,7 @@ internal fun ClarificationCard(
                             modifier = Modifier.fillMaxWidth(),
                             verticalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
-                            interaction.choices.forEach { choice ->
+                            choices.forEach { choice ->
                                 val chosen = choice in clarifyState.selectedChoices
                                 Surface(
                                     onClick = { clarifyState = clarifyState.select(choice) },
@@ -203,7 +217,7 @@ internal fun ClarificationCard(
                     value = clarifyState.answer,
                     onValueChange = { clarifyState = clarifyState.typeAnswer(it) },
                     label = {
-                        Text(ClarifyAnswerPolicy.otherFieldLabel(hasChoices = interaction.choices.isNotEmpty()))
+                        Text(ClarifyAnswerPolicy.otherFieldLabel(hasChoices = choices.isNotEmpty()))
                     },
                     modifier = Modifier.fillMaxWidth(),
                     enabled = true,
@@ -218,7 +232,7 @@ internal fun ClarificationCard(
                     // treats it as "no preference / proceed".
                     TextButton(
                         onClick = {
-                            onResponse(interaction.requestId, ClarifyAnswerPolicy.SKIP_ANSWER)
+                            onResponse(interaction.requestId, questionId, ClarifyAnswerPolicy.SKIP_ANSWER)
                         },
                     ) {
                         Text("Skip")
@@ -226,7 +240,7 @@ internal fun ClarificationCard(
                     Button(
                         enabled = pendingAnswer != null,
                         onClick = {
-                            pendingAnswer?.let { onResponse(interaction.requestId, it) }
+                            pendingAnswer?.let { onResponse(interaction.requestId, questionId, it) }
                         },
                     ) {
                         Text("Continue")

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetailScreen.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetailScreen.kt
@@ -194,7 +194,7 @@ internal fun SessionDetailScreen(
     onReasoningSelected: (String) -> Unit,
     onFastSelected: (Boolean) -> Unit,
     onOpenModelPicker: () -> Unit,
-    onClarificationResponse: (String, String) -> Unit,
+    onClarificationResponse: (String, String?, String) -> Unit,
     onApprovalResponse: (String, Boolean) -> Unit,
     onBlockingResponse: (UnsupportedBlockingKind, String, String) -> Unit,
     showStop: Boolean,
@@ -1245,7 +1245,7 @@ private fun RunStateContent(
     processRows: List<ProcessRow>,
     runActive: Boolean,
     durableSessionId: DurableSessionId,
-    onClarificationResponse: (String, String) -> Unit,
+    onClarificationResponse: (String, String?, String) -> Unit,
     onApprovalResponse: (String, Boolean) -> Unit,
     onBlockingResponse: (UnsupportedBlockingKind, String, String) -> Unit,
 ) {

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/HermesAppHostTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/HermesAppHostTest.kt
@@ -233,7 +233,7 @@ class HermesAppHostTest {
                             sessionId to ChatSessionSnapshot(isSending = true, runState = runState),
                         ),
                     ),
-                    onClarificationResponse = { id, request, answer ->
+                    onClarificationResponse = { id, request, _, answer ->
                         clarification = Triple(id, request, answer)
                     },
                     onApprovalResponse = { id, choice, all ->

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/app/RunEventModelsTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/app/RunEventModelsTest.kt
@@ -373,4 +373,27 @@ class RunEventModelsTest {
         )
         assertEquals(null, terminal.status)
     }
+
+    @Test
+    fun batchClarificationPresentsOneQuestionAtATimeUntilAllAreAnswered() {
+        val questions = listOf(
+            com.unsupportedpastels.mercury.core.transcript.ClarifyQuestion("q0", "Target?", listOf("staging", "prod"), false),
+            com.unsupportedpastels.mercury.core.transcript.ClarifyQuestion("q1", "Regions?", listOf("eu", "us"), true),
+        )
+        val state = RunEventState().reduce(
+            HermesChatEvent.ClarifyRequest(RuntimeSessionId("rt"), "rid", "Target?", listOf("staging", "prod"), false, questions),
+        )
+        val clarification = checkNotNull(state.clarification)
+        assertEquals(true, clarification.isBatch)
+        assertEquals("q0", clarification.currentQuestion?.qid)
+        assertEquals("Target?", clarification.displayQuestion)
+
+        val afterFirst = state.markClarificationQuestionAnswered("rid", "q0")
+        val remaining = checkNotNull(afterFirst.clarification)
+        assertEquals("q1", remaining.currentQuestion?.qid)
+        assertEquals(listOf("eu", "us"), remaining.displayChoices)
+        assertEquals(true, remaining.displayMultiSelect)
+        assertEquals(RunInteractionLifecycle.Pending, remaining.lifecycle)
+        assertEquals(null, afterFirst.markClarificationQuestionAnswered("rid", "q1").clarification?.currentQuestion)
+    }
 }

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/ComposerRecoveryTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/ComposerRecoveryTest.kt
@@ -35,7 +35,7 @@ class ComposerRecoveryTest {
                     onAddAttachments = { emptyList() }, onRemoveAttachment = {},
                     onRemoveHostReference = {}, onSend = { sends++ }, onSteer = { steers++ },
                     onReasoningSelected = {}, onFastSelected = {}, onOpenModelPicker = {},
-                    onClarificationResponse = { _, _ -> }, onApprovalResponse = { _, _ -> },
+                    onClarificationResponse = { _, _, _ -> }, onApprovalResponse = { _, _ -> },
                     onBlockingResponse = { _, _, _ -> }, showStop = controller, stopping = false,
                     onStop = {}, onLoadSessionInsights = {}, maintenanceAvailable = false,
                     maintenanceEnabled = false, onCompressSession = {}, onUndoSession = {},

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/HermesAppTest.kt
@@ -1743,7 +1743,7 @@ class HermesAppTest {
             HermesAndroidTheme {
                 HermesApp(
                     snapshot = pending,
-                    onClarificationResponse = { id, request, answer ->
+                    onClarificationResponse = { id, request, _, answer ->
                         response = Triple(id, request, answer)
                     },
                 )
@@ -1786,7 +1786,7 @@ class HermesAppTest {
             HermesAndroidTheme {
                 HermesApp(
                     snapshot = pending,
-                    onClarificationResponse = { id, request, answer ->
+                    onClarificationResponse = { id, request, _, answer ->
                         response = Triple(id, request, answer)
                     },
                 )
@@ -1852,7 +1852,7 @@ class HermesAppTest {
             HermesAndroidTheme {
                 HermesApp(
                     snapshot = snapshot,
-                    onClarificationResponse = { id, request, answer ->
+                    onClarificationResponse = { id, request, _, answer ->
                         response = Triple(id, request, answer)
                     },
                 )

--- a/ios/Mercury/MercuryKit/Chat/ChatConnection.swift
+++ b/ios/Mercury/MercuryKit/Chat/ChatConnection.swift
@@ -184,13 +184,18 @@ final class ChatConnection: @unchecked Sendable {
         return PromptSubmission(status: status)
     }
 
-    func respondToClarification(requestID: String, answer: String) async throws -> ChatResponse {
+    func respondToClarification(requestID: String, answer: String, questionID: String? = nil) async throws -> ChatResponse {
         let boundedRequestID = try boundedRPCInput(requestID, maxChars: maxEventIDChars, label: "request ID")
         let boundedAnswer = try boundedRPCInput(answer, maxChars: maxEventTextChars, label: "answer", allowBlank: true)
-        let result = try await request("clarify.respond", [
+        var params: [String: Any] = [
             "request_id": boundedRequestID,
             "answer": boundedAnswer,
-        ])
+        ]
+        // Batch clarify answers one question at a time by its qid.
+        if let questionID {
+            params["question_id"] = try boundedRPCInput(questionID, maxChars: maxEventIDChars, label: "question ID")
+        }
+        let result = try await request("clarify.respond", params)
         return try parseInteractionResponse(result)
     }
 

--- a/ios/Mercury/MercuryKit/Chat/ChatEventSessionID.swift
+++ b/ios/Mercury/MercuryKit/Chat/ChatEventSessionID.swift
@@ -49,8 +49,8 @@ extension ChatEvent {
             return .toolComplete(sessionID: newID, toolID: toolID, name: name, summary: summary)
         case .statusUpdate(_, let kind, let text):
             return .statusUpdate(sessionID: newID, kind: kind, text: text)
-        case .clarifyRequest(_, let requestID, let question, let choices, let multiSelect):
-            return .clarifyRequest(sessionID: newID, requestID: requestID, question: question, choices: choices, multiSelect: multiSelect)
+        case .clarifyRequest(_, let requestID, let question, let choices, let multiSelect, let questions):
+            return .clarifyRequest(sessionID: newID, requestID: requestID, question: question, choices: choices, multiSelect: multiSelect, questions: questions)
         case .clarifyExpire(_, let requestID):
             return .clarifyExpire(sessionID: newID, requestID: requestID)
         case .approvalRequest(_, let requestID, let command, let description, let choices):

--- a/ios/Mercury/MercuryKit/Chat/ChatEvents.swift
+++ b/ios/Mercury/MercuryKit/Chat/ChatEvents.swift
@@ -86,7 +86,9 @@ enum ChatEvent: Sendable, Equatable {
     case toolStart(sessionID: String, toolID: String, name: String, context: String?)
     case toolComplete(sessionID: String, toolID: String, name: String, summary: String?)
     case statusUpdate(sessionID: String, kind: String, text: String)
-    case clarifyRequest(sessionID: String, requestID: String, question: String, choices: [String], multiSelect: Bool)
+    /// A batch request carries `questions`; the top-level fields mirror the
+    /// first question so single-question code paths keep working.
+    case clarifyRequest(sessionID: String, requestID: String, question: String, choices: [String], multiSelect: Bool, questions: [ClarifyQuestion] = [])
     case clarifyExpire(sessionID: String, requestID: String)
     case approvalRequest(sessionID: String, requestID: String?, command: String?, description: String?, choices: [String])
     case approvalExpire(sessionID: String, requestID: String)
@@ -102,7 +104,7 @@ enum ChatEvent: Sendable, Equatable {
              .toolGenerating(let s, _), .sessionTitle(let s, _),
              .sessionInfo(let s, _, _, _, _, _, _, _), .error(let s, _),
              .toolStart(let s, _, _, _), .toolComplete(let s, _, _, _),
-             .statusUpdate(let s, _, _), .clarifyRequest(let s, _, _, _, _),
+             .statusUpdate(let s, _, _), .clarifyRequest(let s, _, _, _, _, _),
              .clarifyExpire(let s, _), .approvalRequest(let s, _, _, _, _),
              .approvalExpire(let s, _),
              .unsupportedBlockingRequest(let s, _, _, _),
@@ -184,4 +186,12 @@ struct ChatResponse: Sendable, Equatable {
 
     var status: Status
     var nextApproval: ChatEvent?
+}
+
+/// One question of a batch clarify request; `qid` is echoed back in `clarify.respond`.
+struct ClarifyQuestion: Equatable, Sendable, Hashable {
+    let qid: String
+    let question: String
+    let choices: [String]
+    let multiSelect: Bool
 }

--- a/ios/Mercury/MercuryKit/Chat/SharedChatEventBridge.swift
+++ b/ios/Mercury/MercuryKit/Chat/SharedChatEventBridge.swift
@@ -75,7 +75,10 @@ extension ChatEvent {
                 requestID: value.requestId,
                 question: value.question,
                 choices: value.choices,
-                multiSelect: value.multiSelect
+                multiSelect: value.multiSelect,
+                questions: value.questions.map {
+                    ClarifyQuestion(qid: $0.qid, question: $0.question, choices: $0.choices, multiSelect: $0.multiSelect)
+                }
             )
         case let value as MercuryCore.ChatEventClarifyExpire:
             self = .clarifyExpire(sessionID: value.sessionId, requestID: value.requestId)

--- a/ios/Mercury/MercuryKit/Chat/TranscriptReducer.swift
+++ b/ios/Mercury/MercuryKit/Chat/TranscriptReducer.swift
@@ -317,10 +317,13 @@ private extension ChatEvent {
             )
         case .statusUpdate(let sessionID, let kind, let text):
             return MercuryCore.ChatEventStatusUpdate(sessionId: sessionID, kind: kind, text: text)
-        case .clarifyRequest(let sessionID, let requestID, let question, let choices, let multiSelect):
+        case .clarifyRequest(let sessionID, let requestID, let question, let choices, let multiSelect, let questions):
             return MercuryCore.ChatEventClarifyRequest(
                 sessionId: sessionID, requestId: requestID, question: question,
-                choices: choices, multiSelect: multiSelect
+                choices: choices, multiSelect: multiSelect,
+                questions: questions.map {
+                    MercuryCore.ClarifyQuestion(qid: $0.qid, question: $0.question, choices: $0.choices, multiSelect: $0.multiSelect)
+                }
             )
         case .clarifyExpire(let sessionID, let requestID):
             return MercuryCore.ChatEventClarifyExpire(sessionId: sessionID, requestId: requestID)

--- a/ios/Mercury/MercuryKit/Notifications/NotificationDecisionReducer.swift
+++ b/ios/Mercury/MercuryKit/Notifications/NotificationDecisionReducer.swift
@@ -79,7 +79,7 @@ enum NotificationDecisionReducer {
                 body: preview
             )
 
-        case .clarifyRequest(_, _, let question, _, _):
+        case .clarifyRequest(_, _, let question, _, _, _):
             guard !watermark.hasOpenClarify else { return nil }
             watermark.hasOpenClarify = true
             guard NotificationVisibilityPolicy.shouldPost(

--- a/ios/Mercury/Views/ApprovalSheet.swift
+++ b/ios/Mercury/Views/ApprovalSheet.swift
@@ -18,6 +18,10 @@ struct ApprovalSheet: View {
     let onApprovalChoice: (String) async -> Void
     let onClarifyAnswer: (String) async -> Void
     let onDismiss: () -> Void
+    /// Batch clarify: the question to present now and its 1-based position;
+    /// nil renders the request's single question.
+    var clarifyQuestion: ClarifyQuestion? = nil
+    var clarifyPosition: (index: Int, total: Int)? = nil
 
     var body: some View {
         NavigationStack {
@@ -85,8 +89,16 @@ struct ApprovalSheet: View {
 
     @ViewBuilder
     private func clarifyBody(_ event: ChatEvent) -> some View {
-        if case .clarifyRequest(_, _, let question, let choices, let multiSelect) = event {
+        if case .clarifyRequest(_, _, let singleQuestion, let singleChoices, let singleMultiSelect, _) = event {
+        let question = clarifyQuestion?.question ?? singleQuestion
+        let choices = clarifyQuestion?.choices ?? singleChoices
+        let multiSelect = clarifyQuestion?.multiSelect ?? singleMultiSelect
         VStack(alignment: .leading, spacing: 14) {
+            if let clarifyPosition, clarifyPosition.total > 1 {
+                Text("Question \(clarifyPosition.index) of \(clarifyPosition.total)")
+                    .font(.subheadline)
+                    .foregroundStyle(Color.secondaryContent)
+            }
             Text(question)
                 .font(.headline)
                 .textSelection(.enabled)
@@ -144,6 +156,9 @@ struct ApprovalSheet: View {
             clarifyState = ClarifySheetPolicy.State(choices: choices, multiSelect: multiSelect)
         }
         .onChange(of: event) {
+            clarifyState = ClarifySheetPolicy.State(choices: choices, multiSelect: multiSelect)
+        }
+        .onChange(of: clarifyQuestion?.qid) {
             clarifyState = ClarifySheetPolicy.State(choices: choices, multiSelect: multiSelect)
         }
         }

--- a/ios/Mercury/Views/ChatEventApplier.swift
+++ b/ios/Mercury/Views/ChatEventApplier.swift
@@ -65,6 +65,7 @@ extension ChatView {
             Task { await loadProcessRows() }
 
         case .approvalRequest, .clarifyRequest:
+            state.clarifyAnsweredIDs = []
             state.pendingRequest = state.transcript.pendingRequest.map { request in
                 switch request {
                 case .approval(let approvalEvent): return .approval(approvalEvent)

--- a/ios/Mercury/Views/ChatSessionState.swift
+++ b/ios/Mercury/Views/ChatSessionState.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import MercuryCore
 
 extension ChatView {
     /// Secret/sudo prompt awaiting user input. terminalRead/previewRead/
@@ -122,6 +123,26 @@ final class ChatSessionState {
     var durableID: String?
     var eventTask: Task<Void, Never>?
     var pendingRequest: ApprovalSheet.Request?
+    /// Batch clarify: qids already answered for the pending request.
+    var clarifyAnsweredIDs: Set<String> = []
+
+    /// The batch questions of the pending clarify request, if it is a batch.
+    var clarifyQuestions: [ClarifyQuestion] {
+        guard let pendingRequest, case .clarify(let event) = pendingRequest,
+              case .clarifyRequest(_, _, _, _, _, let questions) = event else { return [] }
+        return questions
+    }
+
+    /// The batch question to present now (shared decision), nil for a single question.
+    var currentClarifyQuestion: ClarifyQuestion? {
+        let questions = clarifyQuestions
+        guard !questions.isEmpty else { return nil }
+        let next = MercuryCore.ClarifyAnswerPolicy.shared.nextQuestion(
+            questions: questions.map { MercuryCore.ClarifyQuestion(qid: $0.qid, question: $0.question, choices: $0.choices, multiSelect: $0.multiSelect) },
+            answeredIds: clarifyAnsweredIDs
+        )
+        return next.flatMap { core in questions.first { $0.qid == core.qid } }
+    }
     var didOpen = false
 
     // MARK: Reconnect policy (Android recoverChat parity)
@@ -220,7 +241,7 @@ final class ChatSessionState {
         case .approval(let event):
             if case .approvalRequest(_, let id, _, _, _) = event { return id }
         case .clarify(let event):
-            if case .clarifyRequest(_, let id, _, _, _) = event { return id }
+            if case .clarifyRequest(_, let id, _, _, _, _) = event { return id }
         }
         return nil
     }

--- a/ios/Mercury/Views/ChatSheetAnswers.swift
+++ b/ios/Mercury/Views/ChatSheetAnswers.swift
@@ -16,14 +16,25 @@ extension ChatView {
         }
     }
 
+    /// Answers the pending clarify. A batch is answered one question at a
+    /// time by qid (shared queue decision); the sheet stays up until the last
+    /// question, which is when the host resolves the request.
     func answerClarify(_ answer: String) async {
         guard let connection = state.connection, let requestID = state.requestID else { return }
-        defer { state.pendingRequest = nil }
+        let current = state.currentClarifyQuestion
         do {
-            _ = try await connection.respondToClarification(requestID: requestID, answer: answer)
+            _ = try await connection.respondToClarification(
+                requestID: requestID, answer: answer, questionID: current?.qid
+            )
+            if let current {
+                state.clarifyAnsweredIDs.insert(current.qid)
+                if state.currentClarifyQuestion != nil { return }
+            }
         } catch {
             state.composerError = "Could not send clarification."
         }
+        state.pendingRequest = nil
+        state.clarifyAnsweredIDs = []
     }
 
     /// Responds to a secure blocking prompt (secret/sudo) or auto-answers an

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -328,7 +328,11 @@ struct ChatView: View {
                 onClarifyAnswer: { answer in
                     await answerClarify(answer)
                 },
-                onDismiss: { state.pendingRequest = nil }
+                onDismiss: { state.pendingRequest = nil },
+                clarifyQuestion: state.currentClarifyQuestion,
+                clarifyPosition: state.currentClarifyQuestion.map { current in
+                    (index: (state.clarifyQuestions.firstIndex(of: current) ?? 0) + 1, total: state.clarifyQuestions.count)
+                }
             )
         }
         .sheet(item: $state.pendingSecure) { secure in
@@ -413,7 +417,7 @@ extension ApprovalSheet.Request: Identifiable {
             }
             return "approval:\(requestID ?? [command ?? "", description ?? "", choices.joined(separator: "\u{1F}")].joined(separator: "\u{1E}"))"
         case .clarify(let event):
-            guard case .clarifyRequest(_, let requestID, _, _, _) = event else {
+            guard case .clarifyRequest(_, let requestID, _, _, _, _) = event else {
                 return "clarify:unknown"
             }
             return "clarify:\(requestID)"

--- a/ios/MercuryTests/ChatConnectionTests.swift
+++ b/ios/MercuryTests/ChatConnectionTests.swift
@@ -1087,6 +1087,24 @@ final class ChatConnectionTests: XCTestCase {
         XCTAssertEqual(params.count, 1)
     }
 
+    func testClarifyRespondSendsQuestionIDOnlyForBatchAnswers() async throws {
+        let socket = m7Socket(method: "clarify.respond", result: #"{"status":"ok","remaining":["q1"]}"#)
+        let connection = try ChatConnection(socket: socket)
+        _ = connection.start()
+        let response = try await connection.respondToClarification(requestID: "rid", answer: "staging", questionID: "q0")
+        XCTAssertEqual(response.status, .ok)
+        let params = try decodedSentParams(of: socket)
+        XCTAssertEqual(params["request_id"] as? String, "rid")
+        XCTAssertEqual(params["question_id"] as? String, "q0")
+        XCTAssertEqual(params["answer"] as? String, "staging")
+
+        let single = m7Socket(method: "clarify.respond", result: #"{"status":"ok"}"#)
+        let singleConnection = try ChatConnection(socket: single)
+        _ = singleConnection.start()
+        _ = try await singleConnection.respondToClarification(requestID: "rid", answer: "")
+        XCTAssertNil(try decodedSentParams(of: single)["question_id"])
+    }
+
     func testM7MethodNotFoundPreservesExactMethod() async throws {
         let socket = ConnectionTestSocket(frames: [])
         socket.autoRespond = { sent in

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/interaction/ClarifyAnswerPolicy.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/interaction/ClarifyAnswerPolicy.kt
@@ -1,5 +1,7 @@
 package com.unsupportedpastels.mercury.core.interaction
 
+import com.unsupportedpastels.mercury.core.transcript.ClarifyQuestion
+
 /**
  * Answer state for a clarify request, shared by the Android card and the iOS
  * sheet (both grounded in the desktop clarify card): choices are selectable
@@ -41,4 +43,16 @@ object ClarifyAnswerPolicy {
     const val SKIP_ANSWER = ""
 
     fun otherFieldLabel(hasChoices: Boolean): String = if (hasChoices) "Other" else "Response"
+
+    /**
+     * The next question of a batch to present: the first one not yet
+     * answered, in wire order. Null when every question has an answer (the
+     * host then resolves the request) or when the request is not a batch.
+     */
+    fun nextQuestion(questions: List<ClarifyQuestion>, answeredIds: Set<String>): ClarifyQuestion? =
+        questions.firstOrNull { it.qid !in answeredIds }
+
+    /** 1-based position of [question] for a "Question 2 of 3" label. */
+    fun positionOf(questions: List<ClarifyQuestion>, question: ClarifyQuestion): Int =
+        questions.indexOfFirst { it.qid == question.qid } + 1
 }

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/ChatEvent.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/ChatEvent.kt
@@ -104,13 +104,22 @@ sealed interface ChatEvent {
 
     data class StatusUpdate(override val sessionId: String, val kind: String, val text: String) : ChatEvent
 
+    /**
+     * A clarify request. Hermes emits either one question (`question`,
+     * `choices`, `multi_select`) or a batch (`questions[]`, each answered
+     * separately by `question_id`). For a batch the top-level fields mirror
+     * the first question so single-question renderers still show something.
+     */
     data class ClarifyRequest(
         override val sessionId: String,
         val requestId: String,
         val question: String,
         val choices: List<String>,
         val multiSelect: Boolean,
-    ) : ChatEvent
+        val questions: List<ClarifyQuestion> = emptyList(),
+    ) : ChatEvent {
+        val isBatch: Boolean get() = questions.isNotEmpty()
+    }
 
     data class ClarifyExpire(override val sessionId: String, val requestId: String) : ChatEvent
 
@@ -137,3 +146,11 @@ sealed interface ChatEvent {
         val requestId: String,
     ) : ChatEvent
 }
+
+/** One question of a batch clarify request; `qid` is what `clarify.respond` echoes back. */
+data class ClarifyQuestion(
+    val qid: String,
+    val question: String,
+    val choices: List<String>,
+    val multiSelect: Boolean,
+)

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/ChatEventDecoder.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/ChatEventDecoder.kt
@@ -125,15 +125,28 @@ object ChatEventDecoder {
                 if (kind == null || text == null) null else ChatEvent.StatusUpdate(boundedSessionId, kind, text)
             }
             "clarify.request" -> {
-                val requestId = payload.boundedRequired("request_id", MAX_EVENT_ID_CHARS)
-                val question = payload.boundedRequired("question", MAX_EVENT_TEXT_CHARS)
-                if (requestId == null || question == null) null else ChatEvent.ClarifyRequest(
-                    boundedSessionId,
-                    requestId,
-                    question,
-                    payload.boundedChoices(),
-                    payload.booleanValue("multi_select") ?: false,
-                )
+                val requestId = payload.boundedRequired("request_id", MAX_EVENT_ID_CHARS) ?: return null
+                val questions = payload.boundedQuestions()
+                if (questions.isNotEmpty()) {
+                    val first = questions.first()
+                    ChatEvent.ClarifyRequest(
+                        boundedSessionId,
+                        requestId,
+                        first.question,
+                        first.choices,
+                        first.multiSelect,
+                        questions,
+                    )
+                } else {
+                    val question = payload.boundedRequired("question", MAX_EVENT_TEXT_CHARS) ?: return null
+                    ChatEvent.ClarifyRequest(
+                        boundedSessionId,
+                        requestId,
+                        question,
+                        payload.boundedChoices(),
+                        payload.booleanValue("multi_select") ?: false,
+                    )
+                }
             }
             "clarify.expire" -> payload.boundedRequired("request_id", MAX_EVENT_ID_CHARS)
                 ?.let { ChatEvent.ClarifyExpire(boundedSessionId, it) }
@@ -176,6 +189,19 @@ object ChatEventDecoder {
     private fun JsonObject.isDispatchedBackgroundDelegation(): Boolean {
         val result = this["result"] as? JsonObject ?: return false
         return result.stringValue("status") == "dispatched" && result.stringValue("mode") == "background"
+    }
+
+    /** Batch clarify rows; malformed rows are skipped, duplicate qids keep the first. */
+    private fun JsonObject.boundedQuestions(): List<ClarifyQuestion> {
+        val rows = this["questions"] as? JsonArray ?: return emptyList()
+        val seen = HashSet<String>()
+        return rows.take(MAX_EVENT_CHOICES).mapNotNull { element ->
+            val row = element as? JsonObject ?: return@mapNotNull null
+            val qid = row.boundedRequired("qid", MAX_EVENT_ID_CHARS) ?: return@mapNotNull null
+            val question = row.boundedRequired("question", MAX_EVENT_TEXT_CHARS) ?: return@mapNotNull null
+            if (!seen.add(qid)) return@mapNotNull null
+            ClarifyQuestion(qid, question, row.boundedChoices(), row.booleanValue("multi_select") ?: false)
+        }
     }
 
     private fun JsonObject.boundedChoices(): List<String> =

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/interaction/ClarifyAnswerPolicyTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/interaction/ClarifyAnswerPolicyTest.kt
@@ -1,5 +1,7 @@
 package com.unsupportedpastels.mercury.core.interaction
 
+import com.unsupportedpastels.mercury.core.transcript.ClarifyQuestion
+
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -22,6 +24,20 @@ class ClarifyAnswerPolicyTest {
         val state = ClarifyAnswerState(listOf("A", "B", "C"), multiSelect = true).select("C").select("A")
         assertEquals("A, C", state.pendingAnswer)
         assertFalse(state.select("A").select("C").canContinue)
+    }
+
+    @Test
+    fun batchQuestionsArePresentedInWireOrderUntilAllAreAnswered() {
+        val questions = listOf(
+            ClarifyQuestion("q0", "first", emptyList(), false),
+            ClarifyQuestion("q1", "second", listOf("a"), true),
+        )
+        assertEquals("q0", ClarifyAnswerPolicy.nextQuestion(questions, emptySet())?.qid)
+        assertEquals("q1", ClarifyAnswerPolicy.nextQuestion(questions, setOf("q0"))?.qid)
+        assertEquals("q0", ClarifyAnswerPolicy.nextQuestion(questions, setOf("q1"))?.qid)
+        assertEquals(null, ClarifyAnswerPolicy.nextQuestion(questions, setOf("q0", "q1")))
+        assertEquals(null, ClarifyAnswerPolicy.nextQuestion(emptyList(), emptySet()))
+        assertEquals(2, ClarifyAnswerPolicy.positionOf(questions, questions[1]))
     }
 
     @Test

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/ChatEventDecoderTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/ChatEventDecoderTest.kt
@@ -47,6 +47,35 @@ class ChatEventDecoderTest {
     }
 
     @Test
+    fun batchClarifyDecodesEveryQuestionAndMirrorsTheFirst() {
+        val event = ChatEventDecoder.decode(
+            "clarify.request",
+            "runtime-1",
+            """{"request_id":"rid","questions":[
+                {"qid":"q0","question":"Which target?","choices":["staging","prod"],"multi_select":false},
+                {"qid":"q1","question":"Which regions?","choices":["eu","us"],"multi_select":true},
+                {"qid":"q0","question":"duplicate"},{"question":"no qid"},"junk"]}""",
+        )
+        val clarify = assertIs<ChatEvent.ClarifyRequest>(event)
+        assertEquals(true, clarify.isBatch)
+        assertEquals(listOf("q0", "q1"), clarify.questions.map(ClarifyQuestion::qid))
+        assertEquals("Which target?", clarify.question)
+        assertEquals(listOf("staging", "prod"), clarify.choices)
+        assertEquals(true, clarify.questions[1].multiSelect)
+    }
+
+    @Test
+    fun singleClarifyStillDecodesAndEmptyBatchFallsBackToIt() {
+        val single = assertIs<ChatEvent.ClarifyRequest>(
+            ChatEventDecoder.decode("clarify.request", "runtime-1", """{"request_id":"rid","question":"Which?","choices":["a"]}"""),
+        )
+        assertEquals(false, single.isBatch)
+        assertEquals("Which?", single.question)
+        assertNull(ChatEventDecoder.decode("clarify.request", "runtime-1", """{"request_id":"rid","questions":[]}"""))
+        assertNull(ChatEventDecoder.decode("clarify.request", "runtime-1", """{"questions":[{"qid":"q0","question":"x"}]}"""))
+    }
+
+    @Test
     fun terminalErrorWithoutUsableMessageStillDecodesWithFallback() {
         val fallback = ChatEvent.Error("runtime-1", ChatEventDecoder.ERROR_MESSAGE_FALLBACK)
         assertEquals(fallback, ChatEventDecoder.decode("error", "runtime-1", "{}"))


### PR DESCRIPTION
Stacked on #61 (retarget once it merges).

## What
Hermes now emits `clarify.request` as a batch: `request_id` plus `questions[{qid, question, choices, multi_select}]` with no top-level `question`, and expects one `clarify.respond` per question (`request_id`, `question_id`, `answer`). The shared decoder required a top-level `question`, so **both apps silently dropped the event**: the tool row showed "Running clarify" and no card or sheet appeared until the request timed out on the host (seen on the Fold, confirmed in the host's agent log: clarify completed after 1,117 s unanswered).

- **mercury-core**: `ClarifyRequest` carries `questions`; top-level fields mirror the first question; the legacy single form still decodes. `ClarifyAnswerPolicy.nextQuestion` / `positionOf` decide which question to present.
- **Android**: the interaction keeps the batch and answered qids, the card shows one question at a time with "Question n of m", `respondToClarification` sends `question_id`, and the card stays until the last answer (the host resolves then).
- **iOS**: the event case gains `questions` (defaulted, constructors unchanged), the sheet presents the current question, `answerClarify` sends `question_id` and advances through the batch.

## Verification
- `./gradlew :shared:mercury-core:check testDebugUnitTest lintDebug assembleDebug`: 205 shared + 961 app, lint clean. New tests: decoder batch/legacy cases, queue policy, Android reducer batch, iOS `clarify.respond` params.
- iOS gate: one run crashed at test-host bootstrap (simulator flake); the rerun passed but overlapped another Xcode job on the same Mac and reported a partial suite count, so it will be rerun when the Mac is free. CI on this PR only runs once retargeted to main.
- On the Fold: installed; single-question and batch clarify still need an on-device pass.