### PR TITLE
feat(ios): improve startup and chat navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,11 @@
 
 Mercury is a native Android and iOS client for the official interfaces of an unchanged shared `hermes serve` process. Direct mode must never add, require, or assume custom server routes, forks, dashboard extensions, or gateway workers, and must keep working with no Mercury plugin installed.
 
-One scoped exception exists: **Mercury Relay** is an optional, separately paired transport (iOS first) that carries the same official Hermes JSON-RPC session contract end-to-end encrypted through the Mercury Relay host plugin and an opaque hosted router. Relay code must stay isolated from direct-mode connection, credential, and catalog state; it never changes Hermes itself, tunnels no private Hermes route, and is never a requirement for any direct-mode feature.
+**We own the Mercury stack.** The Android and iOS apps, shared core, Mercury Relay host plugin, hosted router, and Mercury management surfaces may be changed together to deliver product features. A missing Mercury capability is an implementation gap, not a permanent product limitation. The boundary is the actual Hermes API: do not require changes to Hermes itself, alter its official API contracts, or depend on a Hermes fork or private route.
+
+**Mercury Relay** is an optional, separately paired transport that carries the official Hermes JSON-RPC session contract end-to-end encrypted through the Mercury Relay host plugin and an opaque hosted router. New Mercury-owned relay operations and host-plugin capabilities are permitted, including folder browsing and creation, provided they do not require changing the Hermes API. Implement host-plugin operations as Mercury-owned services or adapters over existing official Hermes interfaces; do not disguise private Hermes routes as a relay API. Keep direct-mode connection, credential, and catalog state isolated, and never make Relay or its plugin a requirement for a direct-mode feature.
+
+Evolve Mercury-owned contracts with explicit versioning/capability advertisement and compatibility tests across the affected stack. Preserve end-to-end encryption and router opacity, pairing authorization, host filesystem permissions and applicable managed-root restrictions. Older clients or hosts must receive a supported fallback or clear upgrade guidance, not a misleading authentication error.
 
 Released Hermes compatibility is conservative: observe durable/live metadata without implicit transport takeover. Resume or activate another remote connected client's runtime only after explicit user action. Never close a shared runtime merely because this client disconnects. Capability-gate multi-subscriber streaming until a safe released transport advertises it.
 
@@ -36,9 +40,12 @@ cross-platform change until proven otherwise:
 - **Tests travel with the behavior.** A shared-core change ships with a
   common test; a platform change ships with the matching test on each
   platform it touches. Both gates below must be green before merge.
-- **Mercury Relay availability differs.** Relay features on either platform
-  are limited to what the paired transport advertises; never add relay
-  contracts or direct-mode dependencies to reach UI parity.
+- **Mercury Relay capabilities evolve across the stack.** Add or extend
+  Mercury-owned relay contracts and host-plugin support when a feature needs
+  them; coordinate the shared contract, native consumers, and affected host/router
+  components. At runtime, enable features only when the paired transport
+  advertises support. Keep older peers compatible and direct mode independent;
+  do not change the actual Hermes API to achieve parity.
 
 ## Android architecture
 

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
@@ -1,6 +1,7 @@
 package com.unsupportedpastels.hermesandroid.connection
 
 import com.unsupportedpastels.mercury.core.artifacts.ManagedVideoPolicy
+import com.unsupportedpastels.mercury.core.profiles.ProfileCatalogPolicy
 
 import com.unsupportedpastels.hermesandroid.app.DurableSessionId
 import com.unsupportedpastels.hermesandroid.app.SessionSummary
@@ -993,14 +994,11 @@ class HttpHermesConnectionClient(
         if (!response.status.isSuccess()) {
             throw HermesConnectionException("Hermes profiles returned HTTP ${response.status.value}")
         }
-        return json.decodeFromString<ProfilesResponse>(body).profiles
-            .mapNotNull { row ->
+        return ProfileCatalogPolicy.sanitizeRestNames(
+            json.decodeFromString<ProfilesResponse>(body).profiles.mapNotNull { row ->
                 row["name"]?.jsonPrimitive?.contentOrNull
-                    ?.trim()
-                    ?.takeIf { it.isNotEmpty() && it.length <= 64 }
-            }
-            .distinct()
-            .take(32)
+            },
+        )
     }
 
     override suspend fun loadDefaultModelOptions(

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -2958,9 +2958,36 @@ class HermesConnectionViewModel(
         }
     }
 
-    private fun clearAttachments(durableSessionId: DurableSessionId) {
-        if (mutableAttachments.value.containsKey(durableSessionId)) {
-            mutableAttachments.value = mutableAttachments.value - durableSessionId
+    private fun clearAttachments(
+        durableSessionId: DurableSessionId,
+        attachmentIds: Set<String>? = null,
+    ) {
+        val current = mutableAttachments.value[durableSessionId].orEmpty()
+        if (current.isEmpty()) return
+        val updated = if (attachmentIds == null) {
+            emptyList()
+        } else {
+            current.filterNot { it.id in attachmentIds }
+        }
+        mutableAttachments.value = if (updated.isEmpty()) {
+            mutableAttachments.value - durableSessionId
+        } else {
+            mutableAttachments.value + (durableSessionId to updated)
+        }
+    }
+
+    private fun acknowledgeTerminalSubmission(
+        durableSessionId: DurableSessionId,
+        effect: PromptSubmissionLifecycle.TerminalEffect.ReleasedPending,
+    ) {
+        clearAttachments(durableSessionId, effect.attachmentIds.toSet())
+        updateChat(durableSessionId) { current ->
+            current.copy(
+                acceptedSubmissionCount = current.acceptedSubmissionCount + 1,
+                acceptedSubmissionText = effect.draft,
+                isSending = false,
+                connectionPhase = ChatConnectionPhase.Idle,
+            )
         }
     }
 
@@ -3236,6 +3263,15 @@ class HermesConnectionViewModel(
             rejectSubmission(durableSessionId, text, "No workspace")
             return viewModelScope.launch { }
         }
+        val pendingAttachments = mutableAttachments.value[durableSessionId].orEmpty()
+        val attempt = sessionControllerRegistry.beginPromptSubmission(
+            durableSessionId = durableSessionId,
+            draft = text,
+            attachmentIds = pendingAttachments.map(ComposerAttachment::id),
+        ) ?: run {
+            rejectSubmission(durableSessionId, text, "A submission is already pending")
+            return viewModelScope.launch { }
+        }
         val operationGeneration = sessionControllerRegistry.nextOperationGeneration(durableSessionId)
         sessionControllerRegistry.cancelOperationJob(durableSessionId)
         clearSendingState(durableSessionId)
@@ -3244,6 +3280,7 @@ class HermesConnectionViewModel(
         }
         val job = viewModelScope.launch {
             val origin = activeOrigin ?: run {
+                sessionControllerRegistry.resolvePromptSubmission(durableSessionId, attempt, accepted = false)
                 updateChat(durableSessionId) { it.copy(connectionPhase = ChatConnectionPhase.Idle, error = "Not connected") }
                 rejectSubmission(durableSessionId, text, "Not connected")
                 return@launch
@@ -3284,7 +3321,6 @@ class HermesConnectionViewModel(
                 // Stage attachments on the host BEFORE the optimistic bubble: bytes
                 // live on this device, so nothing can be sent without uploading
                 // them first, and chips must survive a staging failure.
-                val pendingAttachments = mutableAttachments.value[durableSessionId].orEmpty()
                 var submittedText = text
                 if (pendingAttachments.isNotEmpty()) {
                     try {
@@ -3331,26 +3367,33 @@ class HermesConnectionViewModel(
                 } else {
                     session.submitPrompt(runtimeId, submittedText, interrupted)
                 }
-                currentCoroutineContext().ensureActive()
+                val resolution = sessionControllerRegistry.resolvePromptSubmission(
+                    durableSessionId = durableSessionId,
+                    attempt = attempt,
+                    accepted = true,
+                )
+                if (resolution !is PromptSubmissionLifecycle.Resolution.Accepted) return@launch
+                accepted = true
                 if (!isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) return@launch
-                updateChat(durableSessionId) {
-                    it.copy(
-                        acceptedSubmissionCount = it.acceptedSubmissionCount + 1,
-                        acceptedSubmissionText = text,
-                        connectionPhase = ChatConnectionPhase.Idle,
+                clearAttachments(durableSessionId, resolution.attachmentIds.toSet())
+                if (!resolution.terminalAlreadyObserved) {
+                    updateChat(durableSessionId) {
+                        it.copy(
+                            acceptedSubmissionCount = it.acceptedSubmissionCount + 1,
+                            acceptedSubmissionText = resolution.draft,
+                            connectionPhase = ChatConnectionPhase.Idle,
+                        )
+                    }
+                    // Commit accepted prompt state before any auxiliary suspension. A
+                    // replacement/steer may cancel this job while metadata is loading.
+                    markTurnActive(durableSessionId)
+                    markDraftPersisted(
+                        durableSessionId,
+                        origin,
+                        originGeneration,
+                        operationGeneration,
                     )
                 }
-                accepted = true
-                // Commit accepted prompt state before any auxiliary suspension. A
-                // replacement/steer may cancel this job while metadata is loading.
-                markTurnActive(durableSessionId)
-                markDraftPersisted(
-                    durableSessionId,
-                    origin,
-                    originGeneration,
-                    operationGeneration,
-                )
-                if (pendingAttachments.isNotEmpty()) clearAttachments(durableSessionId)
                 // A prompt can launch background processes, so refresh the activity
                 // stack only after the turn is accepted: the pre-submit snapshot
                 // cannot contain processes created by this turn.
@@ -3363,11 +3406,20 @@ class HermesConnectionViewModel(
                     operationGeneration = operationGeneration,
                 )
             } catch (cancelled: CancellationException) {
-                if (isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) {
-                    clearSendingState(durableSessionId)
+                when (sessionControllerRegistry.resolvePromptSubmission(durableSessionId, attempt, accepted = false)) {
+                    PromptSubmissionLifecycle.Resolution.AuthoritativeTerminal -> accepted = true
+                    PromptSubmissionLifecycle.Resolution.Stale -> Unit
+                    else -> if (isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) {
+                        clearSendingState(durableSessionId)
+                    }
                 }
                 throw cancelled
             } catch (_: NativeRefreshExpiredException) {
+                if (sessionControllerRegistry.resolvePromptSubmission(durableSessionId, attempt, accepted = false) ==
+                    PromptSubmissionLifecycle.Resolution.AuthoritativeTerminal
+                ) {
+                    accepted = true
+                }
                 if (isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) {
                     disconnectChat()
                     publishSignInRequired()
@@ -3376,12 +3428,28 @@ class HermesConnectionViewModel(
                 // A ws-ticket/connect 401 despite a just-refreshed access token means
                 // the session is terminally rejected — drop to a clean sign-in rather
                 // than spinning recovery against a credential the server won't accept.
+                if (sessionControllerRegistry.resolvePromptSubmission(durableSessionId, attempt, accepted = false) ==
+                    PromptSubmissionLifecycle.Resolution.AuthoritativeTerminal
+                ) {
+                    accepted = true
+                }
                 if (isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) {
                     disconnectChat()
                     publishSignInRequired()
                 }
             } catch (error: Exception) {
-                if (!isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) return@launch
+                val resolution = sessionControllerRegistry.resolvePromptSubmission(
+                    durableSessionId = durableSessionId,
+                    attempt = attempt,
+                    accepted = false,
+                )
+                if (resolution == PromptSubmissionLifecycle.Resolution.AuthoritativeTerminal) {
+                    accepted = true
+                    return@launch
+                }
+                if (resolution == PromptSubmissionLifecycle.Resolution.Stale ||
+                    !isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)
+                ) return@launch
                 if (stagingFailed) {
                     // Nothing was submitted; the draft stays editable with its chips.
                     // A fresh draft runtime may hold partially staged orphaned files,
@@ -4963,9 +5031,15 @@ class HermesConnectionViewModel(
                                 "Hermes response failed"
                             }
                         }
+                        when (val terminalEffect = sessionControllerRegistry.observePromptTerminal(durableSessionId)) {
+                            is PromptSubmissionLifecycle.TerminalEffect.ReleasedPending ->
+                                acknowledgeTerminalSubmission(durableSessionId, terminalEffect)
+                            PromptSubmissionLifecycle.TerminalEffect.Ignored -> Unit
+                        }
                         updateChat(durableSessionId) {
                             it.copy(
                                 isSending = false,
+                                connectionPhase = ChatConnectionPhase.Idle,
                                 error = terminalError,
                                 notice = event.warning?.takeIf(String::isNotBlank),
                                 billingNotice = billingNotice,
@@ -4990,6 +5064,18 @@ class HermesConnectionViewModel(
                         )
                     }
                     is HermesChatEvent.Error -> {
+                        when (val terminalEffect = sessionControllerRegistry.observePromptTerminal(durableSessionId)) {
+                            is PromptSubmissionLifecycle.TerminalEffect.ReleasedPending -> {
+                                acknowledgeTerminalSubmission(durableSessionId, terminalEffect)
+                                markDraftPersisted(
+                                    durableSessionId,
+                                    origin,
+                                    originGeneration,
+                                    operationGeneration,
+                                )
+                            }
+                            PromptSubmissionLifecycle.TerminalEffect.Ignored -> Unit
+                        }
                         updateChat(durableSessionId) {
                             it.applyTranscriptEvent(event).copy(
                                 isSending = false,

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/PerSessionController.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/PerSessionController.kt
@@ -59,6 +59,7 @@ internal class PerSessionControllerRegistry {
     val lock = Any()
     val controllers = mutableMapOf<DurableSessionId, PerSessionController>()
     val chatJobs = mutableMapOf<DurableSessionId, Job>()
+    private val promptSubmissionLifecycles = mutableMapOf<DurableSessionId, PromptSubmissionLifecycle>()
     // Recovery can outlive removal of its failed controller and event-job slot.
     private val recoveryJobs = mutableMapOf<DurableSessionId, Job>()
 
@@ -102,6 +103,32 @@ internal class PerSessionControllerRegistry {
 
     fun setOperationJob(durableSessionId: DurableSessionId, job: Job) {
         chatJobs[durableSessionId] = job
+    }
+
+    fun beginPromptSubmission(
+        durableSessionId: DurableSessionId,
+        draft: String,
+        attachmentIds: List<String>,
+    ): PromptSubmissionLifecycle.Attempt? = promptSubmissionLifecycles
+        .getOrPut(durableSessionId, ::PromptSubmissionLifecycle)
+        .begin(draft, attachmentIds)
+
+    fun observePromptTerminal(durableSessionId: DurableSessionId): PromptSubmissionLifecycle.TerminalEffect =
+        promptSubmissionLifecycles[durableSessionId]?.observeTerminal()
+            ?: PromptSubmissionLifecycle.TerminalEffect.Ignored
+
+    fun resolvePromptSubmission(
+        durableSessionId: DurableSessionId,
+        attempt: PromptSubmissionLifecycle.Attempt,
+        accepted: Boolean,
+    ): PromptSubmissionLifecycle.Resolution {
+        val lifecycle = promptSubmissionLifecycles[durableSessionId]
+            ?: return PromptSubmissionLifecycle.Resolution.Stale
+        val resolution = lifecycle.resolve(attempt, accepted)
+        if (resolution !is PromptSubmissionLifecycle.Resolution.Stale) {
+            promptSubmissionLifecycles.remove(durableSessionId)
+        }
+        return resolution
     }
 
     fun controller(durableSessionId: DurableSessionId): PerSessionController? =
@@ -194,6 +221,7 @@ internal class PerSessionControllerRegistry {
         chatJobs.values.forEach(Job::cancel)
         chatJobs.clear()
         chatOperationGenerations.clear()
+        promptSubmissionLifecycles.clear()
     }
 
     /** Cancels operation work while leaving close/adoption to [detachAll]. */
@@ -203,6 +231,7 @@ internal class PerSessionControllerRegistry {
         chatJobs.values.forEach(Job::cancel)
         chatJobs.clear()
         chatOperationGenerations.clear()
+        promptSubmissionLifecycles.clear()
         sessionInsightsJobs.values.forEach(Job::cancel)
         sessionInsightsJobs.clear()
         sessionInsightsGenerations.clear()
@@ -238,6 +267,7 @@ internal class PerSessionControllerRegistry {
         val detached = controllers.values.toList()
         controllers.clear()
         chatOperationGenerations.clear()
+        promptSubmissionLifecycles.clear()
         cancelRecoveryJobs()
         chatJobs.values.forEach(Job::cancel)
         chatJobs.clear()

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/PromptSubmissionLifecycle.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/PromptSubmissionLifecycle.kt
@@ -1,0 +1,111 @@
+package com.unsupportedpastels.hermesandroid.connection
+
+import com.unsupportedpastels.mercury.core.transcript.PromptSubmissionDecision
+import com.unsupportedpastels.mercury.core.transcript.PromptSubmissionPolicy
+
+/**
+ * Native owner for one per-session prompt.submit admission attempt.
+ *
+ * The event stream and the correlated prompt.submit response are independent
+ * asynchronous results. A terminal event may therefore arrive while the ACK
+ * is still pending. Keep the attempt identity and terminal-before-ACK fact
+ * together so a late callback cannot settle a replacement draft.
+ */
+internal class PromptSubmissionLifecycle {
+    /** Each Attempt instance is an identity token; fields are never used to settle callbacks. */
+    internal class Attempt(
+        val draft: String,
+        val attachmentIds: List<String>,
+    )
+
+    internal enum class Phase {
+        Idle,
+        AwaitingAcceptance,
+        TerminalBeforeAcceptance,
+    }
+
+    internal sealed interface TerminalEffect {
+        data class ReleasedPending(
+            val draft: String,
+            val attachmentIds: List<String>,
+        ) : TerminalEffect
+
+        data object Ignored : TerminalEffect
+    }
+
+    internal sealed interface Resolution {
+        data class Accepted(
+            val draft: String,
+            val attachmentIds: List<String>,
+            val terminalAlreadyObserved: Boolean,
+        ) : Resolution
+
+        data class RestoreDraft(val draft: String) : Resolution
+
+        data object AuthoritativeTerminal : Resolution
+
+        data object Stale : Resolution
+    }
+
+    var phase: Phase = Phase.Idle
+        private set
+
+    private var currentAttempt: Attempt? = null
+
+    /** Starts a new attempt unless the current attempt still awaits its ACK. */
+    fun begin(draft: String, attachmentIds: List<String>): Attempt? {
+        if (phase == Phase.AwaitingAcceptance) return null
+        val attempt = Attempt(
+            draft = draft,
+            attachmentIds = attachmentIds.toList(),
+        )
+        currentAttempt = attempt
+        phase = Phase.AwaitingAcceptance
+        return attempt
+    }
+
+    /** Releases admission only for a terminal event on the current attempt. */
+    fun observeTerminal(): TerminalEffect {
+        val attempt = currentAttempt ?: return TerminalEffect.Ignored
+        if (phase != Phase.AwaitingAcceptance) return TerminalEffect.Ignored
+        if (PromptSubmissionPolicy.onTerminalEvent(awaitingAcceptance = true) !=
+            PromptSubmissionDecision.RELEASE_PENDING
+        ) {
+            return TerminalEffect.Ignored
+        }
+        phase = Phase.TerminalBeforeAcceptance
+        return TerminalEffect.ReleasedPending(
+            draft = attempt.draft,
+            attachmentIds = attempt.attachmentIds,
+        )
+    }
+
+    /**
+     * Settles one asynchronous acknowledgement. An attempt identity mismatch
+     * is a strict no-op; it cannot touch the current replacement attempt.
+     */
+    fun resolve(attempt: Attempt, accepted: Boolean): Resolution {
+        val current = currentAttempt
+        if (current == null || current !== attempt) return Resolution.Stale
+
+        val terminalAlreadyObserved = phase == Phase.TerminalBeforeAcceptance
+        val decision = PromptSubmissionPolicy.onAcknowledgement(
+            authoritativeTerminal = terminalAlreadyObserved,
+            accepted = accepted,
+        )
+        currentAttempt = null
+        phase = Phase.Idle
+
+        return when (decision) {
+            PromptSubmissionDecision.ACCEPTED -> Resolution.Accepted(
+                draft = current.draft,
+                attachmentIds = current.attachmentIds,
+                terminalAlreadyObserved = terminalAlreadyObserved,
+            )
+            PromptSubmissionDecision.RESTORE_DRAFT -> Resolution.RestoreDraft(current.draft)
+            PromptSubmissionDecision.IGNORE,
+            PromptSubmissionDecision.RELEASE_PENDING,
+            -> Resolution.AuthoritativeTerminal
+        }
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGateway.kt
@@ -11,6 +11,7 @@ import com.unsupportedpastels.hermesandroid.app.ProcessRow
 import com.unsupportedpastels.hermesandroid.app.MAX_PROCESS_ROWS
 import com.unsupportedpastels.hermesandroid.app.validProjectWorkspacePath
 import com.unsupportedpastels.hermesandroid.connection.ServerOrigin
+import com.unsupportedpastels.mercury.core.profiles.ProfileCatalogPolicy
 import com.unsupportedpastels.mercury.core.sessions.SessionPresencePolicy
 import com.unsupportedpastels.mercury.core.rpc.RpcResultDecoder
 import com.unsupportedpastels.mercury.core.transcript.ChatEventDecoder
@@ -141,16 +142,12 @@ class HermesChatConnection internal constructor(
             "profiles.list",
             buildJsonObject { put("include_sessions", false) },
         )
-        return (result["profiles"] as? JsonArray)
-            .orEmpty()
-            .mapNotNull { element ->
+        return ProfileCatalogPolicy.sanitizeRpcNames(
+            (result["profiles"] as? JsonArray).orEmpty().mapNotNull { element ->
                 val row = element as? JsonObject ?: return@mapNotNull null
-                (row["name"] as? JsonPrimitive)
-                    ?.contentOrNull
-                    ?.takeIf { it.matches(Regex("^[a-z0-9][a-z0-9_-]{0,63}$")) }
-            }
-            .distinct()
-            .take(64)
+                (row["name"] as? JsonPrimitive)?.contentOrNull
+            },
+        )
     }
 
     override suspend fun loadDelegationStatus(): DelegationStatus {

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
@@ -13,6 +13,7 @@ import com.unsupportedpastels.hermesandroid.attachment.AttachmentReadException
 import com.unsupportedpastels.hermesandroid.gateway.AuthenticationState
 import com.unsupportedpastels.hermesandroid.gateway.ActiveRuntimeSession
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessageRole
+import com.unsupportedpastels.hermesandroid.gateway.ChatConnectionPhase
 import com.unsupportedpastels.hermesandroid.gateway.ConnectionState
 import com.unsupportedpastels.hermesandroid.gateway.DelegationPauseResult
 import com.unsupportedpastels.hermesandroid.gateway.HermesChatConnector
@@ -581,6 +582,93 @@ class HermesChatIntegrationTest {
         assertFalse(chat.isSending)
         assertFalse(chat.messages.last().isStreaming)
         assertEquals("temporary failure", chat.error)
+    }
+
+    @Test
+    fun terminalCompletionBeforeSubmitAckReleasesAdmissionAndCommitsAcceptance() = runTest(dispatcher) {
+        val session = DeferredAckChatSession()
+        val viewModel = chatViewModel(
+            session,
+            attachmentReader = AttachmentByteReader { "attachment".toByteArray() },
+        )
+        advanceUntilIdle()
+        viewModel.addAttachments(
+            durableId,
+            listOf(ComposerAttachment("first-attachment", "content://provider/first", "first.txt", "text/plain", 10)),
+        )
+
+        val send = viewModel.sendMessage(durableId, "first")
+        runCurrent()
+        session.firstSubmitStarted.await()
+        runCurrent()
+        val terminal = viewModel.snapshots.value.chatSessions.getValue(durableId)
+
+        // Release the deferred so a RED assertion cannot strand the fake's
+        // non-cooperative submit task when the expected lifecycle is missing.
+        session.firstAck.complete(DeferredSubmitOutcome.Accepted)
+        runCurrent()
+        send.join()
+        advanceUntilIdle()
+
+        assertFalse(terminal.isSending)
+        assertEquals(ChatConnectionPhase.Idle, terminal.connectionPhase)
+        assertEquals(1L, terminal.acceptedSubmissionCount)
+        assertEquals("first", terminal.acceptedSubmissionText)
+        assertTrue(viewModel.attachments.value[durableId].orEmpty().isEmpty())
+        assertEquals(1L, viewModel.snapshots.value.chatSessions.getValue(durableId).acceptedSubmissionCount)
+    }
+
+    @Test
+    fun lateOldSubmitFailureCannotRejectReplacementOrTouchAnotherSession() = runTest(dispatcher) {
+        val first = DeferredAckChatSession(runtimeId = "runtime-first")
+        val other = StreamingChatSession()
+        val sessions = ArrayDeque<HermesChatSession>().apply {
+            add(first)
+            add(other)
+        }
+        val viewModel = HermesConnectionViewModel(
+            settingsStates = MutableStateFlow(ServerSettingsState.Ready(origin)),
+            client = ChatConnectionClient(),
+            tokenStore = MemoryTokenStore(tokens),
+            chatConnector = HermesChatConnector { _, _ -> sessions.removeFirst() },
+            nowEpochSeconds = { 1_900_000_000 },
+        )
+        advanceUntilIdle()
+
+        val firstSend = viewModel.sendMessage(durableId, "first")
+        runCurrent()
+        first.firstSubmitStarted.await()
+        runCurrent()
+
+        val otherId = DurableSessionId("durable-other")
+        val otherSend = viewModel.sendMessage(otherId, "other")
+        runCurrent()
+        val replacement = viewModel.sendMessage(durableId, "second")
+        runCurrent()
+        val replacementWasSubmitted = first.secondSubmitStarted.isCompleted
+        val replacementAcceptedBeforeOldAck = viewModel.snapshots.value.chatSessions
+            .getValue(durableId)
+            .let { it.acceptedSubmissionCount == 2L && it.acceptedSubmissionText == "second" }
+
+        // The old task remains in its ACK barrier even after replacement has
+        // cancelled its per-session job. Its failure is delivered last.
+        first.firstAck.complete(DeferredSubmitOutcome.Failed)
+        firstSend.join()
+        replacement.join()
+        otherSend.join()
+        advanceUntilIdle()
+
+        val replacementChat = viewModel.snapshots.value.chatSessions.getValue(durableId)
+        val otherChat = viewModel.snapshots.value.chatSessions.getValue(otherId)
+        assertTrue(replacementWasSubmitted)
+        assertTrue(replacementAcceptedBeforeOldAck)
+        assertEquals(2L, replacementChat.acceptedSubmissionCount)
+        assertEquals("second", replacementChat.acceptedSubmissionText)
+        assertEquals(0L, replacementChat.rejectedSubmissionCount)
+        assertFalse(replacementChat.error == "late submit failure")
+        assertEquals(1L, otherChat.acceptedSubmissionCount)
+        assertEquals("other", otherChat.acceptedSubmissionText)
+        assertFalse(otherChat.error == "late submit failure")
     }
 
     @Test
@@ -3047,6 +3135,67 @@ private class TerminalEventChatSession(
     }
 
     override suspend fun close() = Unit
+}
+
+private enum class DeferredSubmitOutcome {
+    Accepted,
+    Failed,
+}
+
+/** Delivers a terminal event before the first submit acknowledgement. */
+private class DeferredAckChatSession(
+    private val runtimeId: String = "runtime-deferred-ack",
+) : HermesChatSession {
+    private val runtimeSessionId = RuntimeSessionId(runtimeId)
+    private val channel = Channel<HermesChatEvent>(Channel.UNLIMITED)
+    override val events: Flow<HermesChatEvent> = channel.receiveAsFlow()
+    val firstSubmitStarted = CompletableDeferred<Unit>()
+    val secondSubmitStarted = CompletableDeferred<Unit>()
+    val firstAck = CompletableDeferred<DeferredSubmitOutcome>()
+    var submitCalls = 0
+        private set
+
+    override suspend fun resume(
+        durableSessionId: DurableSessionId,
+        profile: String?,
+    ) = ResumedChatSession(
+        runtimeSessionId = runtimeSessionId,
+        durableSessionId = durableSessionId,
+        resumed = true,
+        messages = emptyList(),
+        running = false,
+        inflight = null,
+    )
+
+    override suspend fun submitPrompt(
+        runtimeSessionId: RuntimeSessionId,
+        text: String,
+    ): PromptSubmission {
+        submitCalls += 1
+        channel.send(HermesChatEvent.MessageStart(runtimeSessionId, null))
+        if (submitCalls == 1) {
+            channel.send(HermesChatEvent.MessageComplete(runtimeSessionId, "first response", "complete"))
+            firstSubmitStarted.complete(Unit)
+            return when (withContext(NonCancellable) { firstAck.await() }) {
+                DeferredSubmitOutcome.Accepted -> PromptSubmission("accepted")
+                DeferredSubmitOutcome.Failed -> throw HermesChatProtocolException("late submit failure")
+            }
+        }
+        secondSubmitStarted.complete(Unit)
+        channel.send(HermesChatEvent.MessageComplete(runtimeSessionId, "second response", "complete"))
+        return PromptSubmission("accepted")
+    }
+
+    override suspend fun attachFile(
+        runtimeSessionId: RuntimeSessionId,
+        filename: String,
+        mimeType: String,
+        base64Content: String,
+    ): String = "@file:$filename"
+
+    override suspend fun close() {
+        channel.close()
+    }
 }
 
 private class CompletableSlashChatSession(

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
@@ -115,6 +115,22 @@ class HermesConnectionClientTest {
     }
 
     @Test
+    fun profileRestNamesPreserveTrimmingAndLegacyGrammar() = runTest {
+        val engine = MockEngine { request ->
+            assertEquals("/api/profiles", request.url.encodedPath)
+            respond(
+                """{"profiles":[{"name":" default "},{"name":"Work Profile"},{"name":"default"},{"name":"  "},{"name":"work"}]}""",
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val profiles = HttpHermesConnectionClient(HttpClient(engine)).loadProfiles(
+            ServerOrigin.parse("https://hermes.example"),
+            "opaque-access",
+        )
+        assertEquals(listOf("default", "Work Profile", "work"), profiles)
+    }
+
+    @Test
     fun settingsLoadsProfilesAndProfileDefaultAndRequiresExplicitExpensiveConfirmation() = runTest {
         val requested = mutableListOf<String>()
         val engine = MockEngine { request ->

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/NativeLifecycleOwnersTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/NativeLifecycleOwnersTest.kt
@@ -134,6 +134,33 @@ class NativeLifecycleOwnersTest {
     }
 
     @Test
+    fun recreatedPromptLifecycleDoesNotResolveOldAttemptAgainstNewAttempt() {
+        val registry = PerSessionControllerRegistry()
+        val durableId = DurableSessionId("durable-prompt")
+        val first = checkNotNull(registry.beginPromptSubmission(durableId, "first", emptyList()))
+
+        assertEquals(
+            PromptSubmissionLifecycle.Resolution.RestoreDraft("first"),
+            registry.resolvePromptSubmission(durableId, first, accepted = false),
+        )
+        // Resolution removed the old lifecycle; the next attempt starts from a
+        // fresh native owner and must still reject the old callback by identity.
+        val replacement = checkNotNull(registry.beginPromptSubmission(durableId, "second", emptyList()))
+        assertEquals(
+            PromptSubmissionLifecycle.Resolution.Stale,
+            registry.resolvePromptSubmission(durableId, first, accepted = true),
+        )
+        assertEquals(
+            PromptSubmissionLifecycle.Resolution.Accepted(
+                draft = "second",
+                attachmentIds = emptyList(),
+                terminalAlreadyObserved = false,
+            ),
+            registry.resolvePromptSubmission(durableId, replacement, accepted = true),
+        )
+    }
+
+    @Test
     fun recoveryIsBoundedAndConcurrentAttemptCannotBeStartedTwice() = runTest {
         val registry = PerSessionControllerRegistry()
         val durableId = DurableSessionId("durable")

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayProjectTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/gateway/HermesChatGatewayProjectTest.kt
@@ -57,7 +57,7 @@ class HermesChatGatewayProjectTest {
             assertEquals("profiles.list", request["method"]!!.jsonPrimitive.content)
             assertFalse(request["params"]!!.jsonObject["include_sessions"]!!.jsonPrimitive.content.toBoolean())
             socket.offer(
-                """{"jsonrpc":"2.0","id":${request["id"]!!.jsonPrimitive.content},"result":{"profiles":[{"name":"default"},{"name":"work"},{"name":"../invalid"},{"name":"work"}]}}""",
+                """{"jsonrpc":"2.0","id":${request["id"]!!.jsonPrimitive.content},"result":{"profiles":[{"name":"default"},{"name":"work"},{"name":"../invalid"},{"name":"work"},{"name":" default "},{"name":"Work Profile"}]}}""",
             )
         }
         val connection = HermesChatGateway(

--- a/ios/Mercury/AppModel.swift
+++ b/ios/Mercury/AppModel.swift
@@ -86,10 +86,25 @@ final class AppModel {
 
     private let serverCatalogStore: ServerCatalogStore
     let offlineCacheStore: OfflineCacheStore
+    private let relayTargetStore: RelayTargetStore
+    private let startupChoiceStore: StartupConnectionChoiceStore
+    private var relayPairingModel: RelayAppModel?
     private(set) var serverCatalog: ServerCatalog = .empty
+    private(set) var relayTargets: [RelayPairedTarget] = []
+    private(set) var relayTargetsError: String?
+    private(set) var startupState: StartupConnectionState = .loading
+    private(set) var startupLastSuccessfulChoice: StartupConnectionIdentity?
     private(set) var transcriptCachingEnabled = false
     private(set) var localSettingsError: String?
     private var serverSwitchGeneration: UInt64 = 0
+    private var startupDecisionGeneration: UInt64 = 0
+    private var startupBootstrapStarted = false
+    #if DEBUG
+    private var startupUIFixtureActive = false
+    #endif
+    private var startupUserInteraction = false
+    private var startupAttemptIdentity: StartupConnectionIdentity?
+    private var activeConnectionAttempt: Task<Void, Never>?
     private(set) var pendingShareEntries: [ShareInboxEntry] = []
     private var shareInboxStore: ShareInboxStore?
 
@@ -272,10 +287,69 @@ final class AppModel {
 
     init(
         serverCatalogStore: ServerCatalogStore = ServerCatalogStore(),
-        offlineCacheStore: OfflineCacheStore = OfflineCacheStore()
+        offlineCacheStore: OfflineCacheStore = OfflineCacheStore(),
+        relayTargetStore: RelayTargetStore = RelayTargetStore(),
+        startupChoiceStore: StartupConnectionChoiceStore = StartupConnectionChoiceStore()
     ) {
         self.serverCatalogStore = serverCatalogStore
         self.offlineCacheStore = offlineCacheStore
+        self.relayTargetStore = relayTargetStore
+        self.startupChoiceStore = startupChoiceStore
+    }
+
+    /// The currently live, successfully selected identity. It is derived from
+    /// the active transport and never from a catalog's selection marker.
+    var activeStartupIdentity: StartupConnectionIdentity? {
+        if let target = activeRelayTarget {
+            return StartupConnectionIdentity(kind: .relay, id: target.id)
+        }
+        guard let origin = serverOrigin,
+              let entry = serverCatalog.entries.first(where: { $0.origin == origin }) else {
+            return nil
+        }
+        return StartupConnectionIdentity(kind: .direct, id: entry.id)
+    }
+
+    /// Secret-free rows used by the startup picker. Relay key material stays in
+    /// `relayTargets` and is resolved only after an explicit approved selection.
+    var startupTargetRows: [StartupConnectionTargetRow] {
+        let direct = serverCatalog.entries.map {
+            StartupConnectionTargetRow(
+                identity: StartupConnectionIdentity(kind: .direct, id: $0.id),
+                title: $0.displayLabel,
+                detail: $0.origin,
+                isUsable: true,
+                isPendingRelay: false
+            )
+        }
+        let relay = relayTargets.map {
+            StartupConnectionTargetRow(
+                identity: StartupConnectionIdentity(kind: .relay, id: $0.id),
+                title: $0.displayLabel,
+                detail: $0.status == .approved
+                    ? "Mercury Relay · Ready"
+                    : "Mercury Relay · Waiting for host approval",
+                isUsable: $0.status == .approved,
+                isPendingRelay: $0.status != .approved
+            )
+        }
+        return direct + relay
+    }
+
+    private var startupCandidates: [StartupConnectionCandidate] {
+        startupTargetRows.map {
+            StartupConnectionCandidate(identity: $0.identity, isUsable: $0.isUsable)
+        }
+    }
+
+    /// Creates one relay pairing model over the same store actor used by
+    /// startup. Keeping this instance shared prevents a pairing write from
+    /// being hidden behind another actor's stale in-memory catalog cache.
+    func makeRelayAppModel() -> RelayAppModel {
+        if let relayPairingModel { return relayPairingModel }
+        let model = RelayAppModel(store: relayTargetStore)
+        relayPairingModel = model
+        return model
     }
 
     // MARK: - Controller
@@ -297,21 +371,96 @@ final class AppModel {
     }
 
     func bootstrapSavedServer() async {
+        guard !startupBootstrapStarted else { return }
+        startupBootstrapStarted = true
+        let decisionGeneration = startupDecisionGeneration
         do {
-            serverCatalog = try await serverCatalogStore.load()
-            transcriptCachingEnabled = await offlineCacheStore.isTranscriptCachingEnabled()
-            guard let active = serverCatalog.activeEntry else { return }
-            await switchServer(active)
+            // Both independent catalogs and the last-successful preference are
+            // loaded before the shared policy is consulted. A pending relay is
+            // therefore visible in the same decision as direct targets.
+            async let catalogResult: ServerCatalog? = try? serverCatalogStore.load()
+            async let relayResult: [RelayPairedTarget]? = try? relayTargetStore.load()
+            async let cacheEnabled = offlineCacheStore.isTranscriptCachingEnabled()
+            async let savedChoice = startupChoiceStore.load()
+            let (catalog, relays, caching, choice) = try await (
+                catalogResult,
+                relayResult,
+                cacheEnabled,
+                savedChoice
+            )
+            guard decisionGeneration == startupDecisionGeneration,
+                  !startupUserInteraction else { return }
+
+            serverCatalog = catalog ?? .empty
+            relayTargets = relays ?? []
+            relayTargetsError = relays == nil ? "Saved relay pairings could not be read." : nil
+            transcriptCachingEnabled = caching
+            startupLastSuccessfulChoice = choice
+            guard catalog != nil, relays != nil else {
+                localSettingsError = "Some saved connections could not be loaded. Choose an available connection or add one."
+                startupState = .chooseTarget(savedChoiceUnavailable: choice != nil)
+                return
+            }
+
+            let decision = StartupConnectionDecisionPolicy.decide(
+                candidates: startupCandidates,
+                lastSuccessful: choice
+            )
+            switch decision.action {
+            case .onboarding:
+                startupState = .onboarding
+            case .chooseTarget:
+                startupState = .chooseTarget(
+                    savedChoiceUnavailable: decision.savedChoiceUnavailable
+                )
+            case .autoConnect:
+                guard let selected = decision.selected else {
+                    startupState = .chooseTarget(savedChoiceUnavailable: true)
+                    return
+                }
+                startupAttemptIdentity = selected
+                startupState = .connecting(selected)
+                let task = launchConnectionAttempt(selected, userInitiated: false)
+                await task.value
+            }
         } catch {
-            localSettingsError = "Saved server settings could not be loaded."
+            guard decisionGeneration == startupDecisionGeneration,
+                  !startupUserInteraction else { return }
+            localSettingsError = "Saved connection settings could not be loaded."
+            startupState = .onboarding
+        }
+    }
+
+    /// Reloads only the relay catalog after pairing/removal. The startup
+    /// preference remains untouched until a connection reaches `.connected`.
+    func loadRelayTargets() async {
+        #if DEBUG
+        guard !startupUIFixtureActive else { return }
+        #endif
+        do {
+            relayTargets = try await relayTargetStore.load()
+            relayTargetsError = nil
+        } catch {
+            relayTargets = []
+            relayTargetsError = "Saved relay pairings could not be read."
         }
     }
 
     func addServer(origin: String, label: String) async {
+        // Adding a server is an explicit user boundary. Invalidate bootstrap
+        // before the catalog write so a late load cannot replace this choice.
+        markStartupInteraction()
+        let generation = startupDecisionGeneration
         do {
             let entry = try await serverCatalogStore.add(origin: origin, label: label)
-            serverCatalog = try await serverCatalogStore.load()
-            await switchServer(entry)
+            let catalog = try await serverCatalogStore.load()
+            guard generation == startupDecisionGeneration else { return }
+            serverCatalog = catalog
+            let task = launchConnectionAttempt(
+                StartupConnectionIdentity(kind: .direct, id: entry.id),
+                userInitiated: false
+            )
+            await task.value
         } catch let error as LocalizedError {
             localSettingsError = error.errorDescription
         } catch {
@@ -344,17 +493,106 @@ final class AppModel {
         }
     }
 
-    func switchServer(_ entry: ServerCatalogEntry) async {
+    func renameRelay(_ target: RelayPairedTarget, label: String) async {
         do {
-            try await serverCatalogStore.select(id: entry.id)
-            serverCatalog = try await serverCatalogStore.load()
+            try await relayTargetStore.updateLabel(id: target.id, label: label)
+            relayTargets = try await relayTargetStore.load()
+            localSettingsError = nil
+        } catch let error as LocalizedError {
+            localSettingsError = error.errorDescription
         } catch {
-            localSettingsError = "The selected server could not be saved."
+            localSettingsError = "The relay label could not be saved."
+        }
+    }
+
+    func removeRelay(_ target: RelayPairedTarget) async {
+        guard activeRelayTarget?.id != target.id,
+              selectedRelayTarget?.id != target.id else {
+            localSettingsError = "Disconnect from this relay before removing its pairing."
             return
         }
+        do {
+            try await relayTargetStore.remove(id: target.id)
+            relayTargets = try await relayTargetStore.load()
+            localSettingsError = nil
+        } catch {
+            localSettingsError = "The relay pairing could not be removed."
+        }
+    }
+
+    /// Explicit server selection from Settings or the startup picker. The
+    /// returned task is the single owner of the in-flight connection attempt.
+    func switchServer(_ entry: ServerCatalogEntry) async {
+        let task = launchConnectionAttempt(
+            StartupConnectionIdentity(kind: .direct, id: entry.id),
+            userInitiated: true
+        )
+        await task.value
+    }
+
+    private func performStartupConnection(
+        _ identity: StartupConnectionIdentity,
+        decisionGeneration: UInt64
+    ) async {
+        guard decisionGeneration == startupDecisionGeneration else { return }
+        switch identity.kind {
+        case .direct:
+            do {
+                let catalog = try await serverCatalogStore.load()
+                guard decisionGeneration == startupDecisionGeneration, !Task.isCancelled else { return }
+                serverCatalog = catalog
+            } catch {
+                guard decisionGeneration == startupDecisionGeneration else { return }
+                setPhase(.failed("Saved server settings could not be loaded."))
+                return
+            }
+            guard let entry = serverCatalog.entries.first(where: { $0.id == identity.id }) else {
+                startupState = .chooseTarget(savedChoiceUnavailable: true)
+                return
+            }
+            await performDirectConnection(entry)
+        case .relay:
+            guard let target = relayTargets.first(where: { $0.id == identity.id }),
+                  target.status == .approved else {
+                startupState = .chooseTarget(savedChoiceUnavailable: true)
+                return
+            }
+            await performRelayConnection(target)
+        }
+    }
+
+    /// Starts and owns exactly one startup/direct/relay attempt. User-facing
+    /// entry points use this instead of creating detached Tasks themselves.
+    @discardableResult
+    private func launchConnectionAttempt(
+        _ identity: StartupConnectionIdentity,
+        userInitiated: Bool
+    ) -> Task<Void, Never> {
+        if userInitiated { markStartupInteraction() }
+        activeConnectionAttempt?.cancel()
+        let decisionGeneration = startupDecisionGeneration
+        startupAttemptIdentity = identity
+        startupState = .connecting(identity)
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.performStartupConnection(identity, decisionGeneration: decisionGeneration)
+            guard self.startupDecisionGeneration == decisionGeneration else { return }
+            self.activeConnectionAttempt = nil
+        }
+        activeConnectionAttempt = task
+        return task
+    }
+
+    private func performDirectConnection(_ entry: ServerCatalogEntry) async {
+        let identity = StartupConnectionIdentity(kind: .direct, id: entry.id)
+        startupAttemptIdentity = identity
+        startupState = .connecting(identity)
         serverSwitchGeneration &+= 1
         let generation = serverSwitchGeneration
+        endRelaySelection()
         serverOrigin = entry.origin
+        activeRelayTarget = nil
+        selectedRelayTarget = nil
         hermesVersion = nil
         sessions = []
         sessionsError = nil
@@ -472,10 +710,69 @@ final class AppModel {
         guard ProcessInfo.processInfo.arguments.contains("-uitest-reset-local-state") else { return }
         KeychainServerCatalogPersistence().clearCatalogData()
         UserDefaultsLegacyServerOrigin().clearLegacyOrigin()
-        try? await RelayTargetStore().removeAll()
+        try? await relayTargetStore.removeAll()
+        try? await startupChoiceStore.clear()
         try? await offlineCacheStore.clear()
         serverCatalog = .empty
+        relayTargets = []
+        relayTargetsError = nil
+        startupLastSuccessfulChoice = nil
+        startupState = .loading
         sessions = []
+    }
+
+    /// In-memory only startup fixtures. They use `.test` identities and empty
+    /// key data, never real origins or credentials, and are not written to any
+    /// catalog. The UI suite uses them to exercise picker/failure boundaries.
+    func applyStartupUITestFixtureIfRequested() -> Bool {
+        guard ProcessInfo.processInfo.arguments.contains(where: {
+            $0 == "-uitest-startup-empty"
+                || $0 == "-uitest-startup-multiple"
+                || $0 == "-uitest-startup-failed"
+        }) else { return false }
+        startupBootstrapStarted = true
+        startupUIFixtureActive = true
+        startupUserInteraction = true
+        startupLastSuccessfulChoice = nil
+        let directID = UUID(uuidString: "00000000-0000-0000-0000-000000000701")!
+        let relayID = UUID(uuidString: "00000000-0000-0000-0000-000000000702")!
+        if ProcessInfo.processInfo.arguments.contains("-uitest-startup-empty") {
+            serverCatalog = .empty
+            relayTargets = []
+            startupState = .onboarding
+            connectionPhase = .disconnected
+            return true
+        }
+        let direct = try! ServerCatalogEntry(
+            id: directID,
+            origin: "https://direct.test",
+            label: "Direct test server"
+        )
+        let pendingRelay = RelayPairedTarget(
+            id: relayID,
+            label: "Pending relay test",
+            relayOrigin: "wss://relay.test",
+            installationID: Data(),
+            hostPublicKey: Data(),
+            deviceID: "fixture-device",
+            deviceStaticPrivateKey: Data(),
+            fingerprint: "fixture",
+            status: .pending,
+            createdAtEpochSeconds: 0,
+            lastUsedEpochSeconds: nil
+        )
+        serverCatalog = ServerCatalog(entries: [direct], activeID: nil)
+        relayTargets = [pendingRelay]
+        if ProcessInfo.processInfo.arguments.contains("-uitest-startup-failed") {
+            let identity = StartupConnectionIdentity(kind: .direct, id: directID)
+            startupAttemptIdentity = identity
+            startupState = .failed(identity, "Could not connect to the last server.")
+            connectionPhase = .failed("Could not connect to the last server.")
+        } else {
+            startupState = .chooseTarget(savedChoiceUnavailable: false)
+            connectionPhase = .disconnected
+        }
+        return true
     }
 
     func enqueueSharedTextForUITest(_ text: String) {
@@ -550,21 +847,58 @@ final class AppModel {
     // MARK: - Connection lifecycle
 
     /// Validates the entered origin synchronously and kicks off the probe in
-    /// a task. Returns the normalized origin, or `nil` after setting a
-    /// `.failed` phase for bad input.
+    /// the model-owned connection task. Returns the normalized origin, or
+    /// `nil` after setting a `.failed` phase for bad input.
     @discardableResult
     func beginProbe(origin rawOrigin: String) -> String? {
         guard let normalized = ServerOrigin.normalize(rawOrigin) else {
             connectionPhase = .failed("Enter a valid server address, e.g. hermes.example.com")
             return nil
         }
-        Task { await controller.probeSelfHosted(origin: normalized) }
+        launchManualProbe(normalized, userInitiated: true)
         return normalized
     }
 
-    /// Runs the probe inline; prefer `beginProbe` from synchronous call sites.
+    /// Runs a manually entered origin through the same single owned task used
+    /// by startup and configured-target selection.
     func probeSelfHosted(origin: String) async {
-        await controller.probeSelfHosted(origin: origin)
+        let task = launchManualProbe(origin, userInitiated: true)
+        await task.value
+    }
+
+    @discardableResult
+    private func launchManualProbe(
+        _ origin: String,
+        userInitiated: Bool
+    ) -> Task<Void, Never> {
+        if userInitiated { markStartupInteraction() }
+        activeConnectionAttempt?.cancel()
+        let decisionGeneration = startupDecisionGeneration
+        startupAttemptIdentity = serverCatalog.entries
+            .first(where: { $0.origin == origin })
+            .map { StartupConnectionIdentity(kind: .direct, id: $0.id) }
+        if let identity = startupAttemptIdentity {
+            startupState = .connecting(identity)
+        } else {
+            // A manually entered origin has no local typed identity until the
+            // controller successfully catalogs it. Never retain an older ID.
+            startupState = .onboarding
+        }
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.controller.probeSelfHosted(origin: origin)
+            guard self.startupDecisionGeneration == decisionGeneration else { return }
+            self.activeConnectionAttempt = nil
+        }
+        activeConnectionAttempt = task
+        return task
+    }
+
+    private func cancelConnectionAttempt() {
+        activeConnectionAttempt?.cancel()
+        activeConnectionAttempt = nil
+        serverSwitchGeneration &+= 1
+        relaySelectionGeneration &+= 1
     }
 
     /// Opens the native sign-in browser flow and awaits callback + exchange.
@@ -861,6 +1195,62 @@ final class AppModel {
 
     // MARK: - Local transitions
 
+    private func markStartupInteraction() {
+        startupUserInteraction = true
+        startupDecisionGeneration &+= 1
+        activeConnectionAttempt?.cancel()
+        activeConnectionAttempt = nil
+        controller.resetProfileCatalogForConnectionBoundary()
+    }
+
+    /// Shows the configured-target list after an explicit user request. It
+    /// never starts a connection itself, even when only one row is usable.
+    func showStartupPicker() {
+        markStartupInteraction()
+        serverSwitchGeneration &+= 1
+        endRelaySelection()
+        activeRelayTarget = nil
+        selectedRelayTarget = nil
+        serverOrigin = nil
+        hermesVersion = nil
+        sessions = []
+        sessionsError = nil
+        authenticationError = nil
+        authProviders = []
+        startupAttemptIdentity = nil
+        connectionPhase = .disconnected
+        startupState = .chooseTarget(savedChoiceUnavailable: false)
+    }
+
+    func beginManualStartupSelection() {
+        markStartupInteraction()
+        serverSwitchGeneration &+= 1
+        endRelaySelection()
+        activeRelayTarget = nil
+        selectedRelayTarget = nil
+        serverOrigin = nil
+        startupAttemptIdentity = nil
+        startupState = .onboarding
+        connectionPhase = .disconnected
+    }
+
+    /// Retries the exact failed identity. No other target is considered.
+    func retryStartupConnection() {
+        guard case .failed(let identity?, _) = startupState else { return }
+        _ = launchConnectionAttempt(identity, userInitiated: true)
+    }
+
+    /// Starts one explicitly selected approved target. Pending relays are
+    /// intentionally disabled by the picker and never enter this path.
+    func selectStartupTarget(_ identity: StartupConnectionIdentity) {
+        guard let row = startupTargetRows.first(where: { $0.identity == identity }),
+              row.isUsable else {
+            localSettingsError = "This relay is waiting for host approval."
+            return
+        }
+        _ = launchConnectionAttempt(identity, userInitiated: true)
+    }
+
     private func endRelaySelection() {
         relaySelectionGeneration &+= 1
         let token = relaySelectionGeneration
@@ -875,19 +1265,50 @@ final class AppModel {
     }
 
     func disconnect() {
+        markStartupInteraction()
+        cancelConnectionAttempt()
         endRelaySelection()
         activeRelayTarget = nil
         selectedRelayTarget = nil
+        serverOrigin = nil
         sessionsError = nil
         connectionPhase = .disconnected
+        startupAttemptIdentity = nil
+        startupState = .chooseTarget(savedChoiceUnavailable: false)
     }
 
     /// Connects through a paired, approved Mercury Relay target and enters
-    /// the normal connected experience.
+    /// the normal connected experience using the same owned task as startup.
     func connectRelay(_ target: RelayPairedTarget) async {
+        markStartupInteraction()
+        let generation = startupDecisionGeneration
+        await loadRelayTargets()
+        guard generation == startupDecisionGeneration else { return }
+        guard relayTargets.contains(where: { $0.id == target.id && $0.status == .approved }) else {
+            localSettingsError = "This relay is no longer configured."
+            return
+        }
+        let task = launchConnectionAttempt(
+            StartupConnectionIdentity(kind: .relay, id: target.id),
+            userInitiated: false
+        )
+        await task.value
+    }
+
+    private func performRelayConnection(_ target: RelayPairedTarget) async {
+        guard target.status == .approved else {
+            startupState = .chooseTarget(savedChoiceUnavailable: false)
+            localSettingsError = "This relay is waiting for host approval."
+            return
+        }
         relaySelectionGeneration &+= 1
+        let generation = relaySelectionGeneration
+        let identity = StartupConnectionIdentity(kind: .relay, id: target.id)
+        startupAttemptIdentity = identity
+        startupState = .connecting(identity)
         selectedRelayTarget = target
         await controller.connectRelay(target: target)
+        guard relaySelectionGeneration == generation else { return }
     }
 
     func signedOutPreservingServer(_ origin: String) {
@@ -903,9 +1324,12 @@ final class AppModel {
         connectionPhase = .signInRequired
     }
 
-    /// Clears transient connection state without touching stored credentials.
+    /// Clears transient connection state without touching stored credentials or
+    /// the last successful startup identity. This is intentionally not a user
+    /// interaction boundary: internal controller reset paths must not cancel
+    /// their own active task or invalidate a newer selection.
     func reset() {
-        endRelaySelection()
+        controller.resetProfileCatalogForConnectionBoundary()
         activeRelayTarget = nil
         selectedRelayTarget = nil
         serverOrigin = nil
@@ -915,6 +1339,7 @@ final class AppModel {
         authProviders = []
         pendingPortalDeviceCode = nil
         connectionPhase = .disconnected
+        startupState = .onboarding
         canLoadMoreSessions = false
         isLoadingMoreSessions = false
         sessionArchived = [:]
@@ -935,16 +1360,44 @@ final class AppModel {
 
     func setPhase(_ phase: ConnectionPhase) {
         connectionPhase = phase
-        // Bind notification dedupe state to the live origin the moment a
-        // connection is established, so live events can be deduped/persisted.
-        if case .connected = phase, let origin = serverOrigin {
-            configureNotifications(origin: origin)
+        switch phase {
+        case .connected:
+            // The catalog/relay store has already been updated by the
+            // controller before it emits `.connected`. Resolve the identity
+            // from the live transport now so a newly entered origin gets its
+            // newly generated catalog UUID, never a stale previous attempt.
+            if let identity = activeStartupIdentity {
+                startupLastSuccessfulChoice = identity
+                startupState = .connected(identity)
+                // Saving is deliberately triggered only by this successful
+                // transition. A selected/added/paired row never writes here.
+                Task { @MainActor [weak self] in
+                    await self?.recordSuccessfulStartupChoice(identity)
+                }
+            }
+            // Bind notification dedupe state to the live origin the moment a
+            // connection is established, so live events can be deduped/persisted.
+            if let origin = serverOrigin {
+                configureNotifications(origin: origin)
+            }
             // A retained deep-link route (notification/Live Activity tap that
             // arrived before this server finished connecting or signing in)
             // completes now.
             completePendingRouteIfReady()
+        case .failed(let message):
+            if let identity = startupAttemptIdentity {
+                startupState = .failed(identity, message)
+            }
+        default:
+            break
         }
     }
+
+    private func recordSuccessfulStartupChoice(_ identity: StartupConnectionIdentity) async {
+        guard startupLastSuccessfulChoice == identity else { return }
+        try? await startupChoiceStore.save(identity)
+    }
+
     func setServerOrigin(_ origin: String?) { serverOrigin = origin }
     func setActiveRelayTarget(_ target: RelayPairedTarget?) { activeRelayTarget = target }
     func setHermesVersion(_ version: String?) { hermesVersion = version }
@@ -953,7 +1406,16 @@ final class AppModel {
     func setAuthenticationError(_ message: String?) { authenticationError = message }
     func setPendingPortalDeviceCode(_ code: DeviceCode?) { pendingPortalDeviceCode = code }
     func setSigningIn(_ value: Bool) { isSigningIn = value }
-    func setActiveProfile(_ profile: String) { activeProfile = profile }
+    func setActiveProfile(_ profile: String) {
+        guard activeProfile != profile else { return }
+        activeProfile = profile
+        sessions = []
+        sessionsError = nil
+        canLoadMoreSessions = false
+        isLoadingMoreSessions = false
+        sessionArchived = [:]
+        sessionPinned = [:]
+    }
     func setCanLoadMoreSessions(_ value: Bool) { canLoadMoreSessions = value }
     func setIsLoadingMoreSessions(_ value: Bool) { isLoadingMoreSessions = value }
     func setCloudPolling(_ value: Bool) { isCloudPolling = value }

--- a/ios/Mercury/MercuryApp.swift
+++ b/ios/Mercury/MercuryApp.swift
@@ -88,9 +88,12 @@ struct MercuryApp: App {
                     if ProcessInfo.processInfo.arguments.contains("-uitest-reset-local-state") {
                         await appModel.resetLocalStateForUITest()
                     }
+                    let startupFixtureApplied = appModel.applyStartupUITestFixtureIfRequested()
                     if let sharedText = Self.launchArgumentValue("-uitest-share-text") {
                         appModel.enqueueSharedTextForUITest(sharedText)
                     }
+                    #else
+                    let startupFixtureApplied = false
                     #endif
                     appModel.loadSharedInbox()
                     // Load persisted notification/Live Activity preferences and
@@ -123,7 +126,7 @@ struct MercuryApp: App {
                     // the sign-in/session screens without typing.
                     if let origin = Self.launchArgumentValue("-uitest-probe") {
                         await appModel.probeSelfHosted(origin: origin)
-                    } else {
+                    } else if !startupFixtureApplied {
                         await appModel.bootstrapSavedServer()
                     }
                 }

--- a/ios/Mercury/MercuryKit/AppFlow/ConnectionController.swift
+++ b/ios/Mercury/MercuryKit/AppFlow/ConnectionController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MercuryCore
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -71,6 +72,32 @@ final class ConnectionController {
     /// Builds the sign-in flow for a given origin. Injectable for tests.
     private let signInFlowFactory: @MainActor (String) -> SelfHostedSignInFlowing
 
+    /// Optional profile seams. Production uses the official direct REST
+    /// endpoint and the existing relay pool read channel; tests inject real
+    /// `ProfilesClient` instances or deterministic fakes.
+    private let directProfilesClientFactory: (@MainActor (String) -> any ProfilesListing)?
+    private let relayProfilesClientFactory: (@MainActor (RelayPairedTarget, String) async throws -> any ProfilesListing)?
+    private let relaySessionsPageLoader: (@MainActor (RelayPairedTarget, String, Int, Int) async throws -> SessionPage)?
+    private let sessionPageLoader: (@MainActor (String, String, Int, Int) async throws -> SessionPage)?
+
+    /// Monotonic controller identity. Cancellation is an optimization; these
+    /// generations are the publication fence for non-cooperative responses.
+    private var connectionGeneration: UInt64 = 0
+    private var sessionRequestGeneration: UInt64 = 0
+
+    private struct SessionRequestScope: Equatable {
+        let origin: String?
+        let relayTargetID: UUID?
+        let relaySelectionGeneration: UInt64
+        let profile: String
+        let connectionGeneration: UInt64
+    }
+
+    /// Scope of the rows currently known to be an authoritative server page.
+    /// Cached/startup rows are intentionally unscoped until a refresh succeeds;
+    /// this prevents pagination from appending a new profile/host to stale rows.
+    private var publishedSessionScope: SessionRequestScope?
+
     /// Opens a URL in the user's browser. Injectable so tests never launch
     /// Safari. Default routes through `UIApplication.shared.open`.
     var openExternalURL: @MainActor (URL) async -> Void = ConnectionController.defaultURLOpener
@@ -87,7 +114,11 @@ final class ConnectionController {
         appModel: AppModel,
         urlSession: URLSession = .shared,
         credentialStore: CredentialStoring = KeychainCredentialStore(),
-        signInFlowFactory: @escaping @MainActor (String) -> SelfHostedSignInFlowing = { NativePKCEFlow(origin: $0) }
+        signInFlowFactory: @escaping @MainActor (String) -> SelfHostedSignInFlowing = { NativePKCEFlow(origin: $0) },
+        directProfilesClientFactory: (@MainActor (String) -> any ProfilesListing)? = nil,
+        relayProfilesClientFactory: (@MainActor (RelayPairedTarget, String) async throws -> any ProfilesListing)? = nil,
+        relaySessionsPageLoader: (@MainActor (RelayPairedTarget, String, Int, Int) async throws -> SessionPage)? = nil,
+        sessionPageLoader: (@MainActor (String, String, Int, Int) async throws -> SessionPage)? = nil
     ) {
         self.appModel = appModel
         self.urlSession = urlSession
@@ -96,6 +127,10 @@ final class ConnectionController {
         self.hermesURLSession = urlSession === URLSession.shared ? HermesURLSession.noRedirects : urlSession
         self.credentialStore = credentialStore
         self.signInFlowFactory = signInFlowFactory
+        self.directProfilesClientFactory = directProfilesClientFactory
+        self.relayProfilesClientFactory = relayProfilesClientFactory
+        self.relaySessionsPageLoader = relaySessionsPageLoader
+        self.sessionPageLoader = sessionPageLoader
     }
 
     // MARK: - Self-hosted probe
@@ -115,7 +150,9 @@ final class ConnectionController {
             return
         }
 
+        let generation = beginDirectConnectionBoundary(origin: origin)
         appModel.setServerOrigin(origin)
+        appModel.setActiveRelayTarget(nil)
         appModel.setPhase(.probing)
         appModel.setAuthProviders([])
         appModel.setAuthenticationError(nil)
@@ -127,28 +164,30 @@ final class ConnectionController {
         do {
             status = try await probe.probe()
         } catch {
-            guard appModel.serverOrigin == origin else { return }
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
             appModel.setPhase(.failed(Self.failureMessage(for: error, origin: origin)))
             return
         }
 
-        guard appModel.serverOrigin == origin else { return }
+        guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
         await appModel.rememberServer(origin: origin)
-        guard appModel.serverOrigin == origin else { return }
+        guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
 
         appModel.setHermesVersion(status.version.isEmpty ? nil : status.version)
 
         guard status.authRequired else {
             appModel.setPhase(.connected)
+            await discoverDirectProfiles(origin: origin, generation: generation)
             return
         }
 
         if credentialStore.tokens(for: origin) != nil || hasSessionCookie(for: origin) {
             do {
                 let (_, response) = try await client.get(path: "/api/auth/me")
-                guard appModel.serverOrigin == origin else { return }
+                guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
                 if (200..<300).contains(response.statusCode) {
                     appModel.setPhase(.connected)
+                    await discoverDirectProfiles(origin: origin, generation: generation)
                     return
                 }
                 if response.statusCode != 401 && response.statusCode != 403 {
@@ -156,7 +195,7 @@ final class ConnectionController {
                     return
                 }
             } catch {
-                guard appModel.serverOrigin == origin else { return }
+                guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
                 appModel.setPhase(.failed(Self.failureMessage(for: error, origin: origin)))
                 return
             }
@@ -164,7 +203,7 @@ final class ConnectionController {
 
         do {
             let providers = try await probe.authProviders()
-            guard appModel.serverOrigin == origin else { return }
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
             appModel.setAuthProviders(providers.providers)
             if providers.providers.contains(where: {
                 $0.name.lowercased() == "nous" || $0.supportsPassword
@@ -176,7 +215,7 @@ final class ConnectionController {
                 ))
             }
         } catch {
-            guard appModel.serverOrigin == origin else { return }
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
             appModel.setPhase(.failed(Self.failureMessage(for: error, origin: origin)))
         }
     }
@@ -200,6 +239,7 @@ final class ConnectionController {
             return
         }
 
+        let generation = beginDirectConnectionBoundary(origin: origin)
         appModel.setSigningIn(true)
         appModel.setAuthenticationError(nil)
         defer { appModel.setSigningIn(false) }
@@ -225,16 +265,17 @@ final class ConnectionController {
             let outcome = try await flow.exchange(code: callback.code)
             authDebug("token-exchange-complete")
 
-            guard appModel.serverOrigin == origin else { return }
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
             persist(outcome: outcome, origin: origin)
             await appModel.rememberServer(origin: origin)
-            guard appModel.serverOrigin == origin else { return }
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
             appModel.setPhase(.connected)
+            await discoverDirectProfiles(origin: origin, generation: generation)
             authDebug("connected")
         } catch {
             authDebug("failed")
             flow.cancel()
-            guard appModel.serverOrigin == origin else { return }
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
             if case FlowError.stateMismatch = error {
                 appModel.setPhase(.failed("Sign-in failed"))
             } else {
@@ -258,6 +299,7 @@ final class ConnectionController {
             return
         }
 
+        let generation = beginDirectConnectionBoundary(origin: origin)
         appModel.setSigningIn(true)
         appModel.setAuthenticationError(nil)
         defer { appModel.setSigningIn(false) }
@@ -269,7 +311,7 @@ final class ConnectionController {
                 username: username,
                 password: password
             )
-            guard appModel.serverOrigin == origin else { return }
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
 
             // Android stores the password flow's intentionally-empty access
             // token before validation. Clearing the origin-scoped bearer is
@@ -282,7 +324,7 @@ final class ConnectionController {
             // login page is not success until the issued cookie opens an
             // authenticated API endpoint.
             let (_, response) = try await makeHTTPClient(origin: origin).get(path: "/api/auth/me")
-            guard appModel.serverOrigin == origin else { return }
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
             guard (200..<300).contains(response.statusCode) else {
                 if response.statusCode == 401 || response.statusCode == 403 {
                     throw PasswordLoginError.invalidCredentials
@@ -291,17 +333,18 @@ final class ConnectionController {
             }
 
             await appModel.rememberServer(origin: origin)
-            guard appModel.serverOrigin == origin else { return }
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
             appModel.setAuthenticationError(nil)
             appModel.setPhase(.connected)
+            await discoverDirectProfiles(origin: origin, generation: generation)
         } catch is CancellationError {
             return
         } catch PasswordLoginError.invalidCredentials {
-            guard appModel.serverOrigin == origin else { return }
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
             appModel.setAuthenticationError("Invalid username or password.")
             appModel.setPhase(.signInRequired)
         } catch {
-            guard appModel.serverOrigin == origin else { return }
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
             appModel.setAuthenticationError("Password sign-in is temporarily unavailable.")
             appModel.setPhase(.signInRequired)
         }
@@ -318,26 +361,89 @@ final class ConnectionController {
     /// in-process read, seeds the session list, and enters `.connected` with
     /// no server origin (origin-scoped REST features stand down on nil).
     func connectRelay(target: RelayPairedTarget) async {
-        let generation = appModel.relaySelectionGeneration
+        let generation = beginRelayConnectionBoundary(target: target)
+        let selectionGeneration = appModel.relaySelectionGeneration
         let profile = appModel.activeProfile
         await RelayConnectionPool.shared.select(target: target, profile: profile)
-        guard appModel.relaySelectionGeneration == generation else { return }
+        guard isCurrentRelayConnection(
+            target: target,
+            profile: profile,
+            generation: generation,
+            selectionGeneration: selectionGeneration
+        ) else { return }
         appModel.setActiveRelayTarget(nil)
         appModel.setServerOrigin(nil)
         appModel.setPhase(.connecting)
         do {
-            let page = try await Self.relaySessionsPage(
-                target: target, profile: profile, limit: 20, offset: 0
-            )
-            guard appModel.relaySelectionGeneration == generation else { return }
+            // Discovery is best-effort. A released Hermes host may not expose
+            // profiles.list; that must not turn a successful session-list read
+            // into a failed authenticated connection.
+            var discoveredProfiles: [String]?
+            do {
+                let profilesClient: any ProfilesListing
+                if let relayProfilesClientFactory {
+                    profilesClient = try await relayProfilesClientFactory(target, profile)
+                } else {
+                    let connection = try await RelayConnectionPool.shared.acquire(
+                        target: target,
+                        profile: profile
+                    )
+                    profilesClient = ProfilesClient(rpcRequest: { method, params in
+                        try await connection.relayRequest(method, params: params)
+                    })
+                }
+                discoveredProfiles = try await profilesClient.list()
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                discoveredProfiles = nil
+            }
+            guard isCurrentRelayConnection(
+                target: target,
+                profile: profile,
+                generation: generation,
+                selectionGeneration: selectionGeneration
+            ) else { return }
+
+            let page: SessionPage
+            if let relaySessionsPageLoader {
+                page = try await relaySessionsPageLoader(target, profile, 20, 0)
+            } else {
+                page = try await Self.relaySessionsPage(
+                    target: target, profile: profile, limit: 20, offset: 0
+                )
+            }
+            guard isCurrentRelayConnection(
+                target: target,
+                profile: profile,
+                generation: generation,
+                selectionGeneration: selectionGeneration
+            ) else { return }
             appModel.setActiveRelayTarget(target)
+            appModel.profiles = reconciledProfiles(
+                discoveredProfiles ?? [], selectedProfile: profile, rpc: true
+            )
             appModel.sessions = page.rows
+            publishedSessionScope = SessionRequestScope(
+                origin: nil,
+                relayTargetID: target.id,
+                relaySelectionGeneration: selectionGeneration,
+                profile: profile,
+                connectionGeneration: generation
+            )
             appModel.setCanLoadMoreSessions(page.hasMore)
             appModel.setSessionsError(nil)
             appModel.setHermesVersion(nil)
             appModel.setPhase(.connected)
+        } catch is CancellationError {
+            return
         } catch {
-            guard appModel.relaySelectionGeneration == generation else { return }
+            guard isCurrentRelayConnection(
+                target: target,
+                profile: profile,
+                generation: generation,
+                selectionGeneration: selectionGeneration
+            ) else { return }
             let message = Self.relayFailureMessage(error)
             // Cached sessions keep the list on screen; the banner carries the
             // reason so a stale list is never mistaken for a live one.
@@ -382,37 +488,80 @@ final class ConnectionController {
     /// Returns `nil` on failure; the previous rows are kept and
     /// `sessionsError` carries a friendly message (never token material).
     func loadSessionsPage(limit: Int = 20, offset: Int = 0) async -> SessionPage? {
+        let requestGeneration = beginSessionRequest()
+        let scope = captureSessionRequestScope()
+        return await loadSessionsPage(
+            limit: limit,
+            offset: offset,
+            requestGeneration: requestGeneration,
+            scope: scope
+        )
+    }
+
+    private func loadSessionsPage(
+        limit: Int,
+        offset: Int,
+        requestGeneration: UInt64,
+        scope: SessionRequestScope
+    ) async -> SessionPage? {
         guard case .connected = appModel.connectionPhase else { return nil }
 
-        if let target = appModel.activeRelayTarget {
+        if let targetID = scope.relayTargetID,
+           let target = appModel.activeRelayTarget,
+           target.id == targetID {
             // Reads use the default lease channel; open chats own their own
             // channels, so a visible chat never blocks a list refresh.
             do {
-                return try await Self.relaySessionsPage(
-                    target: target,
-                    profile: appModel.activeProfile,
-                    limit: limit,
-                    offset: offset
-                )
+                let page: SessionPage
+                if let relaySessionsPageLoader {
+                    page = try await relaySessionsPageLoader(
+                        target, scope.profile, limit, offset
+                    )
+                } else {
+                    page = try await Self.relaySessionsPage(
+                        target: target,
+                        profile: scope.profile,
+                        limit: limit,
+                        offset: offset
+                    )
+                }
+                guard isCurrentSessionRequest(requestGeneration: requestGeneration, scope: scope) else {
+                    return nil
+                }
+                return page
+            } catch is CancellationError {
+                return nil
             } catch {
-                guard appModel.activeRelayTarget?.id == target.id else { return nil }
+                guard isCurrentSessionRequest(requestGeneration: requestGeneration, scope: scope) else {
+                    return nil
+                }
                 appModel.setSessionsError(Self.relayFailureMessage(error))
                 return nil
             }
         }
 
-        guard let origin = appModel.serverOrigin else { return nil }
-
-        let sessionsClient = SessionsClient(
-            client: makeHTTPClient(origin: origin),
-            profile: appModel.activeProfile
-        )
+        guard scope.relayTargetID == nil, let origin = scope.origin else { return nil }
         do {
-            let page = try await sessionsClient.sessions(limit: limit, offset: offset)
-            guard appModel.serverOrigin == origin else { return nil }
+            let page: SessionPage
+            if let sessionPageLoader {
+                page = try await sessionPageLoader(origin, scope.profile, limit, offset)
+            } else {
+                let sessionsClient = SessionsClient(
+                    client: makeHTTPClient(origin: origin),
+                    profile: scope.profile
+                )
+                page = try await sessionsClient.sessions(limit: limit, offset: offset)
+            }
+            guard isCurrentSessionRequest(requestGeneration: requestGeneration, scope: scope) else {
+                return nil
+            }
             return page
+        } catch is CancellationError {
+            return nil
         } catch {
-            guard appModel.serverOrigin == origin else { return nil }
+            guard isCurrentSessionRequest(requestGeneration: requestGeneration, scope: scope) else {
+                return nil
+            }
             appModel.setSessionsError(Self.failureMessage(for: error, origin: origin))
             return nil
         }
@@ -425,18 +574,31 @@ final class ConnectionController {
     /// On failure the previous rows are kept and `sessionsError` carries a
     /// friendly message (never token material).
     func refreshSessions() async {
-        guard let page = await loadSessionsPage(limit: 20, offset: 0) else { return }
+        let requestGeneration = beginSessionRequest()
+        let scope = captureSessionRequestScope()
+        guard let page = await loadSessionsPage(
+            limit: 20,
+            offset: 0,
+            requestGeneration: requestGeneration,
+            scope: scope
+        ), isCurrentSessionRequest(requestGeneration: requestGeneration, scope: scope) else {
+            return
+        }
         let merged = SessionListMerge.merged(
             serverSessions: page.rows,
             currentSessions: appModel.sessions,
             pendingDraftIDs: []
         )
+        guard isCurrentSessionRequest(requestGeneration: requestGeneration, scope: scope) else {
+            return
+        }
         appModel.sessions = merged
+        publishedSessionScope = scope
         appModel.pruneLifecycleMirrors(keeping: Set(merged.map(\.id)))
         appModel.setCanLoadMoreSessions(page.hasMore)
         appModel.setSessionsError(nil)
-        if let origin = appModel.serverOrigin {
-            await appModel.cacheSessionMetadata(origin: origin, profile: appModel.activeProfile, rows: merged)
+        if let origin = scope.origin {
+            await appModel.cacheSessionMetadata(origin: origin, profile: scope.profile, rows: merged)
         }
     }
 
@@ -458,7 +620,18 @@ final class ConnectionController {
         appModel.setIsLoadingMoreSessions(true)
         defer { appModel.setIsLoadingMoreSessions(false) }
 
-        guard let page = await loadSessionsPage(limit: 20, offset: appModel.sessions.count) else {
+        let scope = captureSessionRequestScope()
+        guard publishedSessionScope == scope else {
+            return
+        }
+        let requestGeneration = beginSessionRequest()
+        let offset = appModel.sessions.count
+        guard let page = await loadSessionsPage(
+            limit: 20,
+            offset: offset,
+            requestGeneration: requestGeneration,
+            scope: scope
+        ), isCurrentSessionRequest(requestGeneration: requestGeneration, scope: scope) else {
             return
         }
         let existingIDs = Set(appModel.sessions.map(\.id))
@@ -621,6 +794,154 @@ final class ConnectionController {
 
     // MARK: - Internals
 
+    private func clearUnscopedSessionRows() {
+        appModel.sessions = []
+        appModel.setCanLoadMoreSessions(false)
+        appModel.setSessionsError(nil)
+        appModel.setIsLoadingMoreSessions(false)
+    }
+
+    /// Parent-owned AppModel transitions can call this before disconnect/reset.
+    /// It invalidates every in-flight catalog/session response and removes the
+    /// previous host's profile scope without changing credentials.
+    func resetProfileCatalogForConnectionBoundary() {
+        connectionGeneration &+= 1
+        sessionRequestGeneration &+= 1
+        publishedSessionScope = nil
+        clearUnscopedSessionRows()
+        appModel.profiles = ["default"]
+        appModel.setActiveProfile("default")
+    }
+
+    private func beginDirectConnectionBoundary(origin: String) -> UInt64 {
+        connectionGeneration &+= 1
+        sessionRequestGeneration &+= 1
+        publishedSessionScope = nil
+        if appModel.activeRelayTarget != nil || appModel.serverOrigin != nil && appModel.serverOrigin != origin {
+            clearUnscopedSessionRows()
+        }
+        appModel.profiles = ["default"]
+        appModel.setActiveProfile("default")
+        appModel.setActiveRelayTarget(nil)
+        return connectionGeneration
+    }
+
+    private func beginRelayConnectionBoundary(target: RelayPairedTarget) -> UInt64 {
+        connectionGeneration &+= 1
+        sessionRequestGeneration &+= 1
+        publishedSessionScope = nil
+        // A different relay is a different host scope. Never carry the prior
+        // host's selected profile into its admission; reconnecting the same
+        // target may retain the user's current profile.
+        if appModel.activeRelayTarget?.id != target.id {
+            appModel.setActiveProfile("default")
+        }
+        // Keep only the profile used for admission visible while the new host
+        // catalog is loading; do not expose the previous host's catalog.
+        appModel.profiles = [appModel.activeProfile]
+        return connectionGeneration
+    }
+
+    private func beginSessionRequest() -> UInt64 {
+        sessionRequestGeneration &+= 1
+        return sessionRequestGeneration
+    }
+
+    private func captureSessionRequestScope() -> SessionRequestScope {
+        let relayTargetID = appModel.activeRelayTarget?.id
+        return SessionRequestScope(
+            origin: relayTargetID == nil ? appModel.serverOrigin : nil,
+            relayTargetID: relayTargetID,
+            relaySelectionGeneration: appModel.relaySelectionGeneration,
+            profile: appModel.activeProfile,
+            connectionGeneration: connectionGeneration
+        )
+    }
+
+    private func isCurrentDirectConnection(origin: String, generation: UInt64) -> Bool {
+        connectionGeneration == generation &&
+            appModel.serverOrigin == origin &&
+            appModel.activeRelayTarget == nil
+    }
+
+    private func isCurrentRelayConnection(
+        target: RelayPairedTarget,
+        profile: String,
+        generation: UInt64,
+        selectionGeneration: UInt64
+    ) -> Bool {
+        connectionGeneration == generation &&
+            appModel.relaySelectionGeneration == selectionGeneration &&
+            appModel.selectedRelayTarget?.id == target.id &&
+            appModel.activeProfile == profile
+    }
+
+    private func isCurrentSessionRequest(
+        requestGeneration: UInt64,
+        scope: SessionRequestScope
+    ) -> Bool {
+        guard sessionRequestGeneration == requestGeneration,
+              connectionGeneration == scope.connectionGeneration,
+              appModel.activeProfile == scope.profile,
+              case .connected = appModel.connectionPhase else {
+            return false
+        }
+        if let targetID = scope.relayTargetID {
+            return appModel.serverOrigin == nil &&
+                appModel.relaySelectionGeneration == scope.relaySelectionGeneration &&
+                appModel.activeRelayTarget?.id == targetID
+        }
+        return appModel.activeRelayTarget == nil && appModel.serverOrigin == scope.origin
+    }
+
+    private func discoverDirectProfiles(origin: String, generation: UInt64) async {
+        guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
+        do {
+            let client: any ProfilesListing
+            if let directProfilesClientFactory {
+                client = directProfilesClientFactory(origin)
+            } else {
+                client = ProfilesClient(httpClient: makeHTTPClient(origin: origin))
+            }
+            let names = try await client.list()
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
+            appModel.profiles = reconciledProfiles(
+                names, selectedProfile: appModel.activeProfile, rpc: false
+            )
+        } catch is CancellationError {
+            return
+        } catch {
+            guard isCurrentDirectConnection(origin: origin, generation: generation) else { return }
+            appModel.profiles = reconciledProfiles(
+                [], selectedProfile: appModel.activeProfile, rpc: false
+            )
+        }
+    }
+
+    private func reconciledProfiles(
+        _ discovered: [String],
+        selectedProfile: String,
+        rpc: Bool
+    ) -> [String] {
+        let core = MercuryCore.ProfileCatalogPolicy.shared
+        let sanitized = rpc
+            ? Array(core.sanitizeRpcNames(names: discovered))
+            : Array(core.sanitizeRestNames(names: discovered))
+        let capacity = rpc ? Int(core.maxRpcProfiles) : Int(core.maxRestProfiles)
+        var names = sanitized.isEmpty ? ["default"] : sanitized
+        if !names.contains("default") {
+            if names.count >= capacity { names.removeLast() }
+            names.insert("default", at: 0)
+        }
+        if rpc,
+           !names.contains(selectedProfile),
+           core.isValidRpcName(name: selectedProfile) {
+            if names.count >= capacity { names.removeLast() }
+            names.append(selectedProfile)
+        }
+        return Array(names.prefix(capacity))
+    }
+
     private func makeHTTPClient(origin: String) -> HermesHTTPClient {
         HermesHTTPClient.makeAuthenticated(
             origin: origin,
@@ -711,6 +1032,7 @@ final class ConnectionController {
     func signOut(origin rawOrigin: String) async {
         guard let origin = ServerOrigin.normalize(rawOrigin) else { return }
 
+        resetProfileCatalogForConnectionBoundary()
         credentialStore.clearTokens(for: origin)
         purgeCookies(hostOf: origin)
         try? await appModel.offlineCacheStore.clearForLogout(origin: origin)

--- a/ios/Mercury/MercuryKit/AppFlow/StartupConnection.swift
+++ b/ios/Mercury/MercuryKit/AppFlow/StartupConnection.swift
@@ -1,0 +1,213 @@
+import Foundation
+import MercuryCore
+
+/// Typed namespace for a last-successful startup identity. The persisted form
+/// contains only this kind plus a local UUID; catalogs and credential stores are
+/// deliberately not used as a preference store.
+enum StartupConnectionKind: String, Codable, CaseIterable, Sendable {
+    case direct
+    case relay
+}
+
+struct StartupConnectionIdentity: Codable, Equatable, Hashable, Sendable {
+    let kind: StartupConnectionKind
+    let id: UUID
+
+    init(kind: StartupConnectionKind, id: UUID) {
+        self.kind = kind
+        self.id = id
+    }
+}
+
+struct StartupConnectionCandidate: Equatable, Sendable {
+    let identity: StartupConnectionIdentity
+    let isUsable: Bool
+}
+
+enum StartupConnectionDecisionAction: Equatable, Sendable {
+    case onboarding
+    case autoConnect
+    case chooseTarget
+}
+
+struct StartupConnectionDecision: Equatable, Sendable {
+    let action: StartupConnectionDecisionAction
+    let selected: StartupConnectionIdentity?
+    let savedChoiceUnavailable: Bool
+}
+
+/// Adapter over the shared pure policy. Only typed IDs and the usable bit cross
+/// the boundary; origins, cookies, tokens, and relay keys never do.
+enum StartupConnectionDecisionPolicy {
+    static func decide(
+        candidates: [StartupConnectionCandidate],
+        lastSuccessful: StartupConnectionIdentity?
+    ) -> StartupConnectionDecision {
+        let coreTargets = candidates.map {
+            MercuryCore.StartupConnectionTarget(
+                kind: $0.identity.kind.coreValue,
+                id: $0.identity.id.uuidString,
+                usable: $0.isUsable
+            )
+        }
+        let coreChoice = lastSuccessful.map {
+            MercuryCore.StartupConnectionChoice(
+                kind: $0.kind.coreValue,
+                id: $0.id.uuidString
+            )
+        }
+        let result = MercuryCore.StartupConnectionPolicy.shared.decide(
+            targets: coreTargets,
+            lastSuccessful: coreChoice
+        )
+        let selected = result.selected.flatMap(StartupConnectionIdentity.init(core:))
+        switch result.action {
+        case .onboarding:
+            return StartupConnectionDecision(
+                action: .onboarding,
+                selected: selected,
+                savedChoiceUnavailable: result.savedChoiceUnavailable
+            )
+        case .autoConnect:
+            return StartupConnectionDecision(
+                action: .autoConnect,
+                selected: selected,
+                savedChoiceUnavailable: result.savedChoiceUnavailable
+            )
+        case .showPicker:
+            return StartupConnectionDecision(
+                action: .chooseTarget,
+                selected: selected,
+                savedChoiceUnavailable: result.savedChoiceUnavailable
+            )
+        default:
+            // Keep the native client fail-closed if the generated framework ever
+            // adds an action before this adapter is updated.
+            return StartupConnectionDecision(
+                action: .chooseTarget,
+                selected: nil,
+                savedChoiceUnavailable: true
+            )
+        }
+    }
+}
+
+private extension StartupConnectionKind {
+    var coreValue: MercuryCore.StartupConnectionKind {
+        switch self {
+        case .direct: return .direct
+        case .relay: return .relay
+        }
+    }
+}
+
+private extension StartupConnectionIdentity {
+    init?(core choice: MercuryCore.StartupConnectionChoice) {
+        guard let id = UUID(uuidString: choice.id) else { return nil }
+        switch choice.kind {
+        case .direct: self.init(kind: .direct, id: id)
+        case .relay: self.init(kind: .relay, id: id)
+        default: return nil
+        }
+    }
+}
+
+/// A row projection for the native picker. It intentionally carries no relay
+/// key material; AppModel resolves the identity back to its catalog/target only
+/// after the user explicitly selects it.
+struct StartupConnectionTargetRow: Identifiable, Equatable, Sendable {
+    let identity: StartupConnectionIdentity
+    let title: String
+    let detail: String
+    let isUsable: Bool
+    let isPendingRelay: Bool
+
+    var id: StartupConnectionIdentity { identity }
+}
+
+enum StartupConnectionState: Equatable, Sendable {
+    case loading
+    case onboarding
+    case chooseTarget(savedChoiceUnavailable: Bool)
+    case connecting(StartupConnectionIdentity)
+    case failed(StartupConnectionIdentity?, String)
+    case connected(StartupConnectionIdentity)
+}
+
+// MARK: - Last-successful preference storage
+
+protocol StartupConnectionChoicePersisting: Sendable {
+    func readStartupChoiceData() throws -> Data?
+    func writeStartupChoiceData(_ data: Data) throws
+    func clearStartupChoiceData()
+}
+
+/// UserDefaults is sufficient for this non-secret preference. Only a typed
+/// local UUID and the direct/relay discriminator are encoded here; no origin,
+/// credential, cookie, relay token, or relay key can enter this store's API.
+final class UserDefaultsStartupConnectionChoicePersistence: StartupConnectionChoicePersisting, @unchecked Sendable {
+    private let defaults: UserDefaults
+    private let key: String
+
+    init(
+        defaults: UserDefaults = .standard,
+        key: String = "mercury.startup.last-successful-choice.v1"
+    ) {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    func readStartupChoiceData() throws -> Data? { defaults.data(forKey: key) }
+
+    func writeStartupChoiceData(_ data: Data) throws { defaults.set(data, forKey: key) }
+
+    func clearStartupChoiceData() { defaults.removeObject(forKey: key) }
+}
+
+actor StartupConnectionChoiceStore {
+    private static let version = 1
+    private static let maxPersistedBytes = 4 * 1024
+
+    private let persistence: StartupConnectionChoicePersisting
+
+    init(
+        persistence: StartupConnectionChoicePersisting = UserDefaultsStartupConnectionChoicePersistence()
+    ) {
+        self.persistence = persistence
+    }
+
+    func load() throws -> StartupConnectionIdentity? {
+        guard let data = try persistence.readStartupChoiceData(),
+              data.count <= Self.maxPersistedBytes,
+              let payload = try? JSONDecoder().decode(PersistedStartupConnectionChoice.self, from: data),
+              payload.version == Self.version,
+              let kind = StartupConnectionKind(rawValue: payload.kind),
+              let id = UUID(uuidString: payload.id)
+        else { return nil }
+        return StartupConnectionIdentity(kind: kind, id: id)
+    }
+
+    func save(_ identity: StartupConnectionIdentity) throws {
+        let data = try JSONEncoder().encode(
+            PersistedStartupConnectionChoice(
+                version: Self.version,
+                kind: identity.kind.rawValue,
+                id: identity.id.uuidString
+            )
+        )
+        guard data.count <= Self.maxPersistedBytes else { throw StartupConnectionStoreError.oversized }
+        try persistence.writeStartupChoiceData(data)
+    }
+
+    func clear() throws { persistence.clearStartupChoiceData() }
+}
+
+enum StartupConnectionStoreError: Error, Equatable {
+    case oversized
+}
+
+private struct PersistedStartupConnectionChoice: Codable {
+    let version: Int
+    let kind: String
+    let id: String
+}

--- a/ios/Mercury/MercuryKit/Chat/PromptSubmissionLifecycle.swift
+++ b/ios/Mercury/MercuryKit/Chat/PromptSubmissionLifecycle.swift
@@ -1,0 +1,105 @@
+import Foundation
+import MercuryCore
+
+/// Native owner for one prompt.submit admission attempt.
+///
+/// The WebSocket event stream and the correlated prompt.submit response are
+/// independent asynchronous results. A terminal event can therefore arrive
+/// while the RPC acknowledgement is still pending. This helper keeps the
+/// attempt identity and terminal-before-ack fact together so a late callback
+/// cannot settle a newer draft.
+struct PromptSubmissionLifecycle: Sendable, Equatable {
+    struct Attempt: Sendable, Equatable {
+        fileprivate let id: UInt64
+        fileprivate let draft: String
+        fileprivate let hostReferenceIDs: [String]
+    }
+
+    enum Phase: Equatable, Sendable {
+        case idle
+        case awaitingAcceptance
+        case terminalBeforeAcceptance
+    }
+
+    enum TerminalEffect: Equatable, Sendable {
+        case releasedPending(hostReferenceIDs: [String])
+        case ignored
+    }
+
+    enum Resolution: Equatable, Sendable {
+        case accepted(hostReferenceIDs: [String])
+        case restoreDraft(String)
+        case authoritativeTerminal
+        case stale
+    }
+
+    private(set) var phase: Phase = .idle
+    private var nextAttemptID: UInt64 = 0
+    private var currentAttempt: Attempt?
+
+    /// Starts a new admission attempt. A second attempt is rejected until the
+    /// current one is authoritatively terminal or has been acknowledged.
+    mutating func begin(draft: String, hostReferenceIDs: [String] = []) -> Attempt? {
+        guard phase != .awaitingAcceptance else { return nil }
+        nextAttemptID &+= 1
+        let attempt = Attempt(
+            id: nextAttemptID,
+            draft: draft,
+            hostReferenceIDs: hostReferenceIDs
+        )
+        currentAttempt = attempt
+        phase = .awaitingAcceptance
+        return attempt
+    }
+
+    /// Records a terminal message/error for the currently awaiting attempt.
+    /// The terminal event releases the UI gate before prompt.submit's ACK, but
+    /// does not discard the attempt: a late ACK still needs an identity check.
+    /// Reference ids are returned so the caller can remove only the accepted
+    /// attempt's host references before a follow-up send reuses the composer.
+    mutating func observeTerminal() -> TerminalEffect {
+        guard let currentAttempt, phase == .awaitingAcceptance else {
+            return .ignored
+        }
+        let decision = MercuryCore.PromptSubmissionPolicy.shared.onTerminalEvent(
+            awaitingAcceptance: true
+        )
+        guard decision == .releasePending else { return .ignored }
+        phase = .terminalBeforeAcceptance
+        return .releasedPending(hostReferenceIDs: currentAttempt.hostReferenceIDs)
+    }
+
+    /// Settles one asynchronous acknowledgement. Stale attempts are a strict
+    /// no-op: they cannot clear the current gate, surface an old error, restore
+    /// old text, or remove references staged for a newer submission.
+    mutating func resolve(attempt: Attempt, accepted: Bool) -> Resolution {
+        guard let currentAttempt, currentAttempt.id == attempt.id else {
+            return .stale
+        }
+
+        let decision = MercuryCore.PromptSubmissionPolicy.shared.onAcknowledgement(
+            authoritativeTerminal: phase == .terminalBeforeAcceptance,
+            accepted: accepted
+        )
+        self.currentAttempt = nil
+        phase = .idle
+
+        switch decision {
+        case .accepted:
+            return .accepted(hostReferenceIDs: currentAttempt.hostReferenceIDs)
+        case .restoreDraft:
+            return .restoreDraft(currentAttempt.draft)
+        case .ignore:
+            return .authoritativeTerminal
+        case .releasePending:
+            // This is not a valid acknowledgement decision, but fail closed
+            // if the shared policy grows a new outcome without this adapter
+            // being updated at the same time.
+            return .authoritativeTerminal
+        default:
+            // Keep the adapter bounded if the KMP enum gains a new outcome:
+            // never restore text or touch a newer action implicitly.
+            return .authoritativeTerminal
+        }
+    }
+}

--- a/ios/Mercury/MercuryKit/Files/HostFilesAccess.swift
+++ b/ios/Mercury/MercuryKit/Files/HostFilesAccess.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// The host-files browser is a direct Hermes REST feature. Relay is a separate
+/// transport and is usable here only if it advertises an equivalent contract;
+/// this client has no relay filesystem route to call.
+enum HostFilesCapability: Equatable, Sendable {
+    case direct
+    case relayUnsupported
+    case unavailable
+}
+
+enum HostFilesAccessError: Error, Equatable {
+    case relayUnsupported
+    case directOriginUnavailable
+}
+
+/// Creates an origin-scoped managed-files client without making views snapshot
+/// a bearer token. Refreshes read the current credential pair and persist the
+/// rotated pair, matching the existing Hermes native refresh contract.
+enum HostFilesAccess {
+    static func capability(origin: String?, relayActive: Bool) -> HostFilesCapability {
+        if relayActive { return .relayUnsupported }
+        guard let origin, ServerOrigin.normalize(origin) != nil else { return .unavailable }
+        return .direct
+    }
+
+    static func makeClient(
+        origin: String?,
+        relayActive: Bool,
+        urlSession: URLSession = HermesURLSession.noRedirects,
+        credentialStore: CredentialStoring = KeychainCredentialStore()
+    ) throws -> HostFilesClient {
+        if relayActive { throw HostFilesAccessError.relayUnsupported }
+        guard let origin else { throw HostFilesAccessError.directOriginUnavailable }
+        return try makeDirectClient(
+            origin: origin,
+            urlSession: urlSession,
+            credentialStore: credentialStore
+        )
+    }
+
+    static func makeDirectClient(
+        origin rawOrigin: String,
+        urlSession: URLSession = HermesURLSession.noRedirects,
+        credentialStore: CredentialStoring = KeychainCredentialStore()
+    ) throws -> HostFilesClient {
+        guard let origin = ServerOrigin.normalize(rawOrigin) else {
+            throw HostFilesClientError.invalidOrigin
+        }
+
+        // Reuse the app's authenticated-client factory rather than duplicating
+        // token lookup/refresh here. It reads the current origin-scoped pair on
+        // each 401, applies TokenRefreshPolicy, persists rotated credentials,
+        // and keeps provider routing identical to the rest of the app.
+        let authenticated = HermesHTTPClient.makeAuthenticated(
+            origin: origin,
+            urlSession: urlSession,
+            credentialStore: credentialStore
+        )
+
+        guard let accessToken = authenticated.bearerToken,
+              !accessToken.isEmpty else {
+            // Basic/password sessions are cookie-authenticated. The shared
+            // Hermes session carries the HttpOnly cookie and no stale bearer.
+            return try HostFilesClient(
+                cookieAuthenticatedOrigin: origin,
+                session: urlSession
+            )
+        }
+
+        return try HostFilesClient(
+            origin: origin,
+            bearerToken: accessToken,
+            session: urlSession,
+            refreshProvider: {
+                guard let refreshProvider = authenticated.refreshTokenProvider else {
+                    throw HermesAuthError.authRejected
+                }
+                guard let refreshed = await refreshProvider() else {
+                    throw HermesAuthError.authRejected
+                }
+                return refreshed.accessToken
+            }
+        )
+    }
+}
+
+/// Folder-picker-only projection of the server's managed-files metadata. It
+/// never constructs paths: entries and parent navigation remain server-owned.
+enum HostFilesFolderPickerPolicy {
+    static func canSelect(_ listing: HostFileListing) -> Bool {
+        validCanonicalHostFilePath(listing.path) != nil
+    }
+
+    static func directories(in listing: HostFileListing) -> [HostFileEntry] {
+        listing.entries.filter(\.isDirectory)
+    }
+
+    static func parentPath(in listing: HostFileListing) -> String? {
+        // can_change_path governs arbitrary path entry, not Up navigation.
+        // Hermes omits parent at the locked root and supplies it for allowed
+        // ancestors within that root. Do not invent a stricter client boundary.
+        listing.parentPath.flatMap(validCanonicalHostFilePath)
+    }
+}

--- a/ios/Mercury/MercuryKit/Files/HostFilesBrowserState.swift
+++ b/ios/Mercury/MercuryKit/Files/HostFilesBrowserState.swift
@@ -10,8 +10,15 @@ struct HostFilesBrowserState: Equatable {
         let path: String?
     }
 
+    struct OperationRequest: Equatable, Sendable {
+        let generation: UInt64
+        let scope: String
+        let path: String?
+    }
+
     private(set) var scope = ""
     private(set) var generation: UInt64 = 0
+    private(set) var operationGeneration: UInt64 = 0
     private(set) var listing: HostFileListing?
     private(set) var isLoading = false
     private(set) var errorMessage: String?
@@ -32,6 +39,7 @@ struct HostFilesBrowserState: Equatable {
     /// state because paths are identities only within the authenticated host.
     mutating func beginLoad(scope newScope: String, path: String?) -> LoadRequest {
         generation &+= 1
+        operationGeneration &+= 1
         if scope != newScope {
             scope = newScope
             listing = nil
@@ -40,6 +48,32 @@ struct HostFilesBrowserState: Equatable {
         isLoading = true
         errorMessage = nil
         return LoadRequest(generation: generation, scope: newScope, path: path)
+    }
+
+    /// Starts a preview operation without changing the visible listing. The
+    /// token is invalidated by any later list, preview, or create request.
+    mutating func beginPreview(path: String) -> OperationRequest {
+        beginOperation(path: path)
+    }
+
+    /// Starts a directory-creation operation rooted at the server-returned
+    /// parent path. The path is carried for identity only; callers must still
+    /// submit the server's canonical value unchanged.
+    mutating func beginCreate(parentPath: String) -> OperationRequest {
+        beginOperation(path: parentPath)
+    }
+
+    func isCurrent(_ request: OperationRequest) -> Bool {
+        request.generation == operationGeneration && request.scope == scope
+    }
+
+    private mutating func beginOperation(path: String) -> OperationRequest {
+        operationGeneration &+= 1
+        return OperationRequest(
+            generation: operationGeneration,
+            scope: scope,
+            path: path
+        )
     }
 
     @discardableResult

--- a/ios/Mercury/MercuryKit/Files/HostFilesClient.swift
+++ b/ios/Mercury/MercuryKit/Files/HostFilesClient.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Failures specific to the official managed-files REST contract. Authentication
-/// and retryable server statuses use `HermesAuthError` so callers can share the
-/// app's existing sign-in and retry classification.
+/// and retryable server statuses use `HermesAuthError`; managed-folder HTTP 403
+/// stays a `HostFilesClientError` so a denied path is not mistaken for sign-out.
 enum HostFilesClientError: Error, Equatable {
     case invalidOrigin
     case invalidBearerToken
@@ -296,6 +296,13 @@ final class HostFilesClient {
         // Classify status before MIME inspection or body decoding. In particular,
         // malformed/large error bodies cannot hide an auth rejection.
         guard (200...299).contains(http.statusCode) else {
+            // A folder-level 403 is an authorization decision for the selected
+            // path, not proof that the account session is gone. Keep it in the
+            // managed-files domain so callers can explain the denied folder
+            // without asking the user to sign in again.
+            if http.statusCode == 403 {
+                throw HostFilesClientError.httpStatus(403)
+            }
             if let classified = HermesAuthError.classify(http.statusCode) {
                 throw classified
             }

--- a/ios/Mercury/MercuryKit/Sessions/ProfilesClient.swift
+++ b/ios/Mercury/MercuryKit/Sessions/ProfilesClient.swift
@@ -1,0 +1,84 @@
+import Foundation
+import MercuryCore
+
+/// Profile discovery failures are deliberately non-fatal to an authenticated
+/// connection. Unsupported is distinct so callers can avoid surfacing a
+/// misleading connection error for older Hermes servers.
+enum ProfilesClientError: Error, Equatable {
+    case unsupported
+    case invalidResponse
+    case requestFailed
+}
+
+/// Narrow seam for controller tests and for the two official transports.
+protocol ProfilesListing {
+    func list() async throws -> [String]
+}
+
+/// Reads the official profile catalog without owning a connection.
+///
+/// Direct mode uses the released `GET /api/profiles` endpoint. Relay mode
+/// carries the released `profiles.list` JSON-RPC request through the already
+/// admitted `ChatConnection`; no `relay.profiles.list` method is invented.
+struct ProfilesClient: ProfilesListing {
+    typealias RPCRequest = (String, [String: Any]) async throws -> [String: Any]
+
+    private let load: () async throws -> [String]
+
+    init(httpClient: HermesHTTPClient) {
+        self.load = {
+            let (data, response) = try await httpClient.get(path: "/api/profiles")
+            if [404, 405, 501].contains(response.statusCode) {
+                throw ProfilesClientError.unsupported
+            }
+            guard (200..<300).contains(response.statusCode) else {
+                throw ProfilesClientError.requestFailed
+            }
+            guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let rawRows = root["profiles"] as? [Any] else {
+                throw ProfilesClientError.invalidResponse
+            }
+            let names = rawRows.compactMap { row -> String? in
+                guard let object = row as? [String: Any] else { return nil }
+                return object["name"] as? String
+            }
+            return Self.restNames(names)
+        }
+    }
+
+    init(rpcRequest: @escaping RPCRequest) {
+        self.load = {
+            let result: [String: Any]
+            do {
+                result = try await rpcRequest(
+                    "profiles.list",
+                    ["include_sessions": false]
+                )
+            } catch let error as ChatMethodNotFoundError where error.method == "profiles.list" {
+                throw ProfilesClientError.unsupported
+            }
+            guard let rawRows = result["profiles"] as? [Any] else {
+                throw ProfilesClientError.invalidResponse
+            }
+            let names = rawRows.compactMap { row -> String? in
+                guard let object = row as? [String: Any] else { return nil }
+                return object["name"] as? String
+            }
+            return Self.rpcNames(names)
+        }
+    }
+
+    func list() async throws -> [String] { try await load() }
+
+    /// Shared REST adapter, exposed for characterization tests and to keep the
+    /// transport distinction visible at the native boundary.
+    static func restNames(_ names: [String]) -> [String] {
+        Array(MercuryCore.ProfileCatalogPolicy.shared.sanitizeRestNames(names: names))
+    }
+
+    /// Shared JSON-RPC adapter, preserving the gateway's exact admission
+    /// grammar and cap.
+    static func rpcNames(_ names: [String]) -> [String] {
+        Array(MercuryCore.ProfileCatalogPolicy.shared.sanitizeRpcNames(names: names))
+    }
+}

--- a/ios/Mercury/Views/ChatComposerActions.swift
+++ b/ios/Mercury/Views/ChatComposerActions.swift
@@ -84,15 +84,26 @@ extension ChatView {
         }
     }
 
+    func clearStagedHostReferences(_ ids: [String]) {
+        guard !ids.isEmpty else { return }
+        let idSet = Set(ids)
+        state.stagedHostReferences.removeAll { idSet.contains($0.id) }
+    }
+
     private func submitPrompt(_ trimmed: String) {
         guard let connection = state.connection, let runtimeSessionID = state.runtimeSessionID else {
             state.composerError = "Not connected — reopen this session to chat."
             return
         }
 
+        let hostReferences = state.stagedHostReferences
+        guard let attempt = state.promptSubmission.begin(
+            draft: trimmed,
+            hostReferenceIDs: hostReferences.map(\.id)
+        ) else { return }
+
         let attachments = state.stagedAttachments
         let bytes = state.stagedBytes
-        let hostReferences = state.stagedHostReferences
         state.draft = ""
         clearSlashCompletion()
         state.composerError = nil
@@ -100,7 +111,6 @@ extension ChatView {
         state.isComposerActionPending = true
         state.followBottom = true
         Task {
-            var submissionAccepted = false
             do {
                 // Attach-on-send, Android parity: images ride the session's
                 // queued list (image.attach_bytes); files return @file: refs.
@@ -142,8 +152,13 @@ extension ChatView {
                 )
                 guard !prompt.isEmpty else {
                     await MainActor.run {
+                        let resolution = state.promptSubmission.resolve(attempt: attempt, accepted: false)
+                        guard resolution != .stale else { return }
                         state.isSending = false
                         state.isComposerActionPending = false
+                        if case .restoreDraft(let original) = resolution, state.draft.isEmpty {
+                            state.draft = original
+                        }
                     }
                     return
                 }
@@ -153,28 +168,37 @@ extension ChatView {
                     state.stagedBytes = [:]
                 }
                 _ = try await connection.submitPrompt(runtimeSessionID: runtimeSessionID, text: prompt)
-                // From this point on the server owns the turn. Do not restore
-                // the user's draft if a later cleanup/lifecycle operation
-                // fails or the turn is interrupted.
-                submissionAccepted = true
+                // A successful acknowledgement clears only references owned
+                // by this attempt. A stale callback has no newer UI effect.
                 await MainActor.run {
-                    state.stagedHostReferences.removeAll { staged in
-                        hostReferences.contains(where: { $0.id == staged.id })
+                    let resolution = state.promptSubmission.resolve(attempt: attempt, accepted: true)
+                    if case .accepted(let referenceIDs) = resolution {
+                        clearStagedHostReferences(referenceIDs)
                     }
+                    guard resolution != .stale else { return }
                     state.isComposerActionPending = false
                 }
             } catch {
                 await MainActor.run {
-                    state.composerError = "Send failed — check the connection and try again."
-                    state.isSending = false
-                    state.isComposerActionPending = false
-                    // Restore the typed text so nothing is lost; staged
-                    // attachments remain staged for retry.
-                    if state.draft.isEmpty,
-                       M7ComposerPolicy.shouldRestoreDraftAfterSubmissionFailure(
-                           submissionAccepted: submissionAccepted
-                       ) {
-                        state.draft = trimmed
+                    let resolution = state.promptSubmission.resolve(attempt: attempt, accepted: false)
+                    guard resolution != .stale else { return }
+                    switch resolution {
+                    case .restoreDraft(let original):
+                        state.composerError = "Send failed — check the connection and try again."
+                        state.isSending = false
+                        state.isComposerActionPending = false
+                        // Do not overwrite text the user entered for a newer
+                        // action while this attempt was awaiting its ACK.
+                        if state.draft.isEmpty { state.draft = original }
+                    case .authoritativeTerminal:
+                        // The terminal event already settled the turn. A late
+                        // RPC failure is not permission to restore the draft or
+                        // surface a second, stale send error.
+                        state.isComposerActionPending = false
+                    case .accepted:
+                        state.isComposerActionPending = false
+                    case .stale:
+                        break
                     }
                 }
             }

--- a/ios/Mercury/Views/ChatEventApplier.swift
+++ b/ios/Mercury/Views/ChatEventApplier.swift
@@ -51,12 +51,23 @@ extension ChatView {
             state.isSending = true
 
         case .messageComplete:
+            if case .releasedPending(let referenceIDs) = state.promptSubmission.observeTerminal() {
+                clearStagedHostReferences(referenceIDs)
+                // The terminal event is authoritative even if prompt.submit's
+                // RPC acknowledgement is still in flight. Let a follow-up
+                // draft start; the old task remains identity-fenced.
+                state.isComposerActionPending = false
+            }
             state.isSending = false
             state.isStopping = false
             Task { await cacheCurrentTranscript() }
             loadContext()
 
         case .error(_, let message):
+            if case .releasedPending(let referenceIDs) = state.promptSubmission.observeTerminal() {
+                clearStagedHostReferences(referenceIDs)
+                state.isComposerActionPending = false
+            }
             state.composerError = message
             state.isSending = false
             state.isStopping = false

--- a/ios/Mercury/Views/ChatSessionState.swift
+++ b/ios/Mercury/Views/ChatSessionState.swift
@@ -61,6 +61,7 @@ final class ChatSessionState {
     var isSending = false
     var isStopping = false
     var isComposerActionPending = false
+    var promptSubmission = PromptSubmissionLifecycle()
     var userMessageScrollGeneration = 0
     var connectionNote: String?
 

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -202,17 +202,6 @@ struct ChatView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.canvas, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
-        .toolbar {
-            if state.contextControlsSupported {
-                ToolbarItem(placement: .topBarTrailing) {
-                    ContextRingButton(
-                        percent: state.composerContextPercent,
-                        artifactCount: 0,
-                        action: openContextSheet
-                    )
-                }
-            }
-        }
         .task {
             // Visibility can change while SwiftUI retains this view and restarts
             // its task. Restore it even when the connection is already owned.

--- a/ios/Mercury/Views/ConnectView.swift
+++ b/ios/Mercury/Views/ConnectView.swift
@@ -13,7 +13,7 @@ struct ConnectView: View {
     @State private var useTls = true
     @State private var validationError: String?
     @State private var showSavedServers = false
-    @State private var relay = RelayAppModel()
+    @State private var relay: RelayAppModel?
     @State private var relayPendingRemoval: RelayPairedTarget?
     @State private var showRelayPairing = false
     /// Error banner text injected when arriving via `.failed(_)` phase.
@@ -31,10 +31,77 @@ struct ConnectView: View {
     }
 
     var body: some View {
+        Group {
+            switch appModel.startupState {
+            case .loading:
+                startupLoadingView
+            case .chooseTarget(let savedChoiceUnavailable):
+                startupPickerView(savedChoiceUnavailable: savedChoiceUnavailable)
+            case .failed(let identity?, let message):
+                startupFailureView(message: message, identity: identity)
+            case .connecting(let identity):
+                startupConnectingView(identity: identity)
+            default:
+                connectionForm
+            }
+        }
+        .amoledScreen()
+        .task {
+            let model = appModel.makeRelayAppModel()
+            relay = model
+            await model.loadTargets()
+            await appModel.loadRelayTargets()
+        }
+        .sheet(isPresented: $showRelayPairing, onDismiss: {
+            relay?.cancelPairing()
+            Task { await appModel.loadRelayTargets() }
+        }) {
+            if let relay { RelayPairingView(relay: relay) }
+        }
+        .sheet(isPresented: $showSavedServers) {
+            NavigationStack {
+                ServerListView(
+                    catalog: appModel.serverCatalog,
+                    relayTargets: appModel.relayTargets,
+                    activeIdentity: appModel.activeStartupIdentity,
+                    onSelect: { entry in
+                        showSavedServers = false
+                        Task { await appModel.switchServer(entry) }
+                    },
+                    onSelectRelay: { target in
+                        showSavedServers = false
+                        Task { await appModel.connectRelay(target) }
+                    },
+                    onAdd: { origin, label in
+                        showSavedServers = false
+                        Task { await appModel.addServer(origin: origin, label: label) }
+                    },
+                    onPairRelay: {
+                        showSavedServers = false
+                        mode = .mercuryRelay
+                        showRelayPairing = true
+                    },
+                    onEditLabel: { entry, label in
+                        Task { await appModel.renameServer(entry, label: label) }
+                    },
+                    onEditRelayLabel: { target, label in
+                        Task { await appModel.renameRelay(target, label: label) }
+                    },
+                    onRemove: { entry in
+                        Task { await appModel.removeServer(entry) }
+                    },
+                    onRemoveRelay: { target in
+                        Task { await appModel.removeRelay(target) }
+                    }
+                )
+            }
+        }
+    }
+
+    private var connectionForm: some View {
         GeometryReader { geometry in
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-
                     Text("Connect to Hermes")
                         .font(.largeTitle.bold())
                         .foregroundStyle(Color.primary)
@@ -71,27 +138,131 @@ struct ConnectView: View {
             }
             .scrollDismissesKeyboard(.interactively)
         }
-        .amoledScreen()
-        .task { await relay.loadTargets() }
-        .sheet(isPresented: $showRelayPairing, onDismiss: {
-            relay.cancelPairing()
-        }) {
-            RelayPairingView(relay: relay)
+    }
+
+    private var startupLoadingView: some View {
+        VStack(spacing: 14) {
+            ProgressView()
+            Text("Loading saved connections…")
+                .font(.subheadline)
+                .foregroundStyle(Color.secondary)
         }
-        .sheet(isPresented: $showSavedServers) {
-            NavigationStack {
-                ServerListView(
-                    catalog: appModel.serverCatalog,
-                    onSelect: { entry in
-                        showSavedServers = false
-                        Task { await appModel.switchServer(entry) }
-                    },
-                    onAdd: { origin, label in Task { await appModel.addServer(origin: origin, label: label) } },
-                    onEditLabel: { entry, label in Task { await appModel.renameServer(entry, label: label) } },
-                    onRemove: { entry in Task { await appModel.removeServer(entry) } }
-                )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func startupPickerView(savedChoiceUnavailable: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Choose a connection")
+                .font(.largeTitle.bold())
+            Text(
+                savedChoiceUnavailable
+                    ? "The last successful connection is no longer available. Choose another configured connection."
+                    : "Choose a configured Hermes server or paired relay."
+            )
+            .font(.subheadline)
+            .foregroundStyle(savedChoiceUnavailable ? Color.statusAlert : Color.secondary)
+
+            if let message = appModel.localSettingsError {
+                errorBanner(message)
+            }
+
+            ServerListView(
+                catalog: appModel.serverCatalog,
+                relayTargets: appModel.relayTargets,
+                activeIdentity: appModel.activeStartupIdentity,
+                onSelect: { entry in
+                    appModel.selectStartupTarget(
+                        StartupConnectionIdentity(kind: .direct, id: entry.id)
+                    )
+                },
+                onSelectRelay: { target in
+                    appModel.selectStartupTarget(
+                        StartupConnectionIdentity(kind: .relay, id: target.id)
+                    )
+                },
+                onAdd: { origin, label in
+                    Task { await appModel.addServer(origin: origin, label: label) }
+                },
+                onPairRelay: {
+                    mode = .mercuryRelay
+                    showRelayPairing = true
+                },
+                onEditLabel: { entry, label in
+                    Task { await appModel.renameServer(entry, label: label) }
+                },
+                onEditRelayLabel: { target, label in
+                    Task { await appModel.renameRelay(target, label: label) }
+                },
+                onRemove: { entry in
+                    Task { await appModel.removeServer(entry) }
+                },
+                onRemoveRelay: { target in
+                    Task { await appModel.removeRelay(target) }
+                },
+                embedded: true
+            )
+            Button("Connection options") {
+                appModel.beginManualStartupSelection()
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(.top, 24)
+        .padding(.horizontal, 16)
+        .frame(maxWidth: 620, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func startupConnectingView(identity: StartupConnectionIdentity) -> some View {
+        VStack(spacing: 16) {
+            ProgressView()
+            Text("Connecting…")
+                .font(.title2.bold())
+            if let row = appModel.startupTargetRows.first(where: { $0.identity == identity }) {
+                Text(row.title)
+                    .font(.headline)
+                Text(row.detail)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(Color.secondary)
+                    .lineLimit(1)
+            }
+            Button("Choose another") {
+                appModel.showStartupPicker()
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func startupFailureView(message: String, identity: StartupConnectionIdentity) -> some View {
+        VStack(spacing: 16) {
+            Label(message, systemImage: "exclamationmark.triangle.fill")
+                .font(.footnote)
+                .foregroundStyle(Color.statusAlert)
+                .multilineTextAlignment(.center)
+                .padding(12)
+                .frame(maxWidth: 520)
+                .background(Color.surfaceMid, in: RoundedRectangle(cornerRadius: 10))
+            if let row = appModel.startupTargetRows.first(where: { $0.identity == identity }) {
+                Text(row.title)
+                    .font(.headline)
+                Text(row.detail)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(Color.secondary)
+                    .lineLimit(1)
+            }
+            HStack(spacing: 12) {
+                Button("Retry") {
+                    appModel.retryStartupConnection()
+                }
+                .buttonStyle(.borderedProminent)
+                Button("Choose another") {
+                    appModel.showStartupPicker()
+                }
+                .buttonStyle(.bordered)
             }
         }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Self-hosted
@@ -268,6 +439,11 @@ struct ConnectView: View {
 
     @ViewBuilder
     private var relaySection: some View {
+        if let relay { relayControls(for: relay) }
+    }
+
+    @ViewBuilder
+    private func relayControls(for relay: RelayAppModel) -> some View {
         Button {
             showRelayPairing = true
         } label: {
@@ -349,6 +525,7 @@ struct ConnectView: View {
                                         appModel.disconnect()
                                     }
                                     await relay.removeTarget(target)
+                                    await appModel.loadRelayTargets()
                                 }
                             }
                         } message: {

--- a/ios/Mercury/Views/HostFilesView.swift
+++ b/ios/Mercury/Views/HostFilesView.swift
@@ -32,8 +32,37 @@ struct HostFilesView: View {
         var id: String { path }
     }
 
+    private var relayTarget: RelayPairedTarget? {
+        appModel.activeRelayTarget ?? appModel.selectedRelayTarget
+    }
+
     private var scope: String {
-        "\(appModel.serverOrigin ?? "")\u{0}\(appModel.activeProfile)"
+        if let target = relayTarget {
+            return "relay:\(target.relayOrigin)\u{0}\(target.id.uuidString)\u{0}\(appModel.activeProfile)"
+        }
+        return "direct:\(appModel.serverOrigin ?? "")\u{0}\(appModel.activeProfile)"
+    }
+
+    private var displayedEntries: [HostFileEntry] {
+        guard mode == .projectFolder, let listing = browser.listing else {
+            return browser.visibleEntries
+        }
+        let permittedPaths = Set(
+            HostFilesFolderPickerPolicy.directories(in: listing).map(\.path)
+        )
+        return browser.visibleEntries.filter { permittedPaths.contains($0.path) }
+    }
+
+    private var displayedIsEmpty: Bool {
+        if mode == .projectFolder, browser.listing != nil {
+            return !browser.isLoading && browser.errorMessage == nil && displayedEntries.isEmpty
+        }
+        return browser.isEmpty
+    }
+
+    private var parentPath: String? {
+        guard let listing = browser.listing else { return nil }
+        return HostFilesFolderPickerPolicy.parentPath(in: listing)
     }
 
     var body: some View {
@@ -52,7 +81,9 @@ struct HostFilesView: View {
                         } label: {
                             Label("Choose this folder", systemImage: "checkmark.circle.fill")
                         }
-                        .disabled(mutationPending)
+                        .disabled(
+                            mutationPending || !HostFilesFolderPickerPolicy.canSelect(listing)
+                        )
                     }
                 }
             }
@@ -70,12 +101,17 @@ struct HostFilesView: View {
                 if browser.isLoading && browser.listing == nil {
                     HStack { Spacer(); ProgressView(); Spacer() }
                         .listRowBackground(Color.clear)
-                } else if browser.isEmpty {
-                    Label(browser.filter.isEmpty ? "This folder is empty" : "No matching files", systemImage: "tray")
+                } else if displayedIsEmpty {
+                    Label(
+                        mode == .projectFolder
+                            ? (browser.filter.isEmpty ? "No permitted folders" : "No matching folders")
+                            : (browser.filter.isEmpty ? "This folder is empty" : "No matching files"),
+                        systemImage: "tray"
+                    )
                         .foregroundStyle(Color.secondary)
                 }
 
-                ForEach(browser.visibleEntries, id: \.path) { entry in
+                ForEach(displayedEntries, id: \.path) { entry in
                     row(entry)
                 }
             }
@@ -86,14 +122,16 @@ struct HostFilesView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
-                if browser.listing != nil {
+                if let listing = browser.listing {
                     Button {
                         folderName = ""
                         showCreateFolder = true
                     } label: {
                         Image(systemName: "folder.badge.plus")
                     }
-                    .disabled(mutationPending)
+                    .disabled(
+                        mutationPending || !HostFilesFolderPickerPolicy.canSelect(listing)
+                    )
                     .accessibilityLabel("Create folder")
                 }
                 Button { Task { await reloadCurrent() } } label: {
@@ -102,8 +140,13 @@ struct HostFilesView: View {
                 .disabled(browser.isLoading || mutationPending)
                 .accessibilityLabel("Refresh files")
             }
-            ToolbarItem(placement: .topBarLeading) {
-                if let parent = browser.listing?.parentPath {
+            ToolbarItemGroup(placement: .topBarLeading) {
+                Button { dismiss() } label: {
+                    Image(systemName: "chevron.left")
+                }
+                .accessibilityLabel("Back")
+
+                if let parent = parentPath {
                     Button {
                         Task { await load(path: parent) }
                     } label: {
@@ -158,6 +201,7 @@ struct HostFilesView: View {
             }
         }
         .amoledScreen()
+        .interactiveDismissDisabled(true)
     }
 
     @ViewBuilder
@@ -199,15 +243,27 @@ struct HostFilesView: View {
     }
 
     private func load(path: String?) async {
-        if browser.scope != scope { client = nil }
-        let request = browser.beginLoad(scope: scope, path: path)
+        let requestedScope = scope
+        let scopeChanged = browser.scope != requestedScope
+        if scopeChanged {
+            client = nil
+        }
+        preview = nil
+        previewLoading = false
+        mutationPending = false
+        // A path is only an identity within its origin/profile. A refresh
+        // racing a transport switch must restart at the new server's root.
+        let requestedPath = scopeChanged ? nil : path
+        let request = browser.beginLoad(scope: requestedScope, path: requestedPath)
         do {
             let activeClient = try filesClient()
-            let listing = try await activeClient.list(path: path)
+            let listing = try await activeClient.list(path: requestedPath)
+            guard request.scope == scope else { return }
             _ = browser.apply(listing, for: request)
         } catch is CancellationError {
             return
         } catch {
+            guard request.scope == scope else { return }
             _ = browser.fail(safeFilesError(error), for: request)
         }
     }
@@ -218,15 +274,10 @@ struct HostFilesView: View {
 
     private func filesClient() throws -> HostFilesClient {
         if let client { return client }
-        guard let origin = appModel.serverOrigin else { throw HermesAuthError.authRejected }
-        let created: HostFilesClient
-        if let pair = KeychainCredentialStore().tokens(for: origin),
-           let token = String(data: pair.accessToken, encoding: .utf8),
-           !token.isEmpty {
-            created = try HostFilesClient(origin: origin, bearerToken: token)
-        } else {
-            created = try HostFilesClient(cookieAuthenticatedOrigin: origin)
-        }
+        let created = try HostFilesAccess.makeClient(
+            origin: appModel.serverOrigin,
+            relayActive: relayTarget != nil
+        )
         client = created
         return created
     }
@@ -243,8 +294,10 @@ struct HostFilesView: View {
 
     private func previewFile(_ entry: HostFileEntry) {
         guard !entry.isDirectory else { return }
+        let request = browser.beginPreview(path: entry.path)
         previewLoading = true
         Task {
+            guard request.scope == scope, browser.isCurrent(request) else { return }
             do {
                 let content = try await filesClient().read(path: entry.path)
                 let textual = content.mimeType.hasPrefix("text/")
@@ -252,31 +305,58 @@ struct HostFilesView: View {
                     || content.mimeType == "application/xml"
                 let text = textual ? String(data: content.bytes, encoding: .utf8) : nil
                 await MainActor.run {
+                    guard request.scope == scope, browser.isCurrent(request) else { return }
                     previewLoading = false
                     preview = FilePreview(path: content.path, title: content.name, text: text, mimeType: content.mimeType)
                 }
-            } catch {
+            } catch is CancellationError {
                 await MainActor.run {
+                    guard request.scope == scope, browser.isCurrent(request) else { return }
                     previewLoading = false
-                    browser = failingCurrentState(safeFilesError(error))
+                }
+            } catch {
+                let message = safeFilesError(error)
+                await MainActor.run {
+                    guard request.scope == scope, browser.isCurrent(request) else { return }
+                    previewLoading = false
+                    browser = failingCurrentState(message)
                 }
             }
         }
     }
 
     private func createFolder() {
-        guard let parent = browser.listing?.path else { return }
+        guard let listing = browser.listing,
+              HostFilesFolderPickerPolicy.canSelect(listing),
+              let parent = validCanonicalHostFilePath(listing.path) else { return }
+        let request = browser.beginCreate(parentPath: parent)
         let requestedName = folderName
         mutationPending = true
         Task {
+            guard request.scope == scope, browser.isCurrent(request) else { return }
             do {
-                let listing = try await filesClient().createDirectory(parentPath: parent, name: requestedName)
-                let request = browser.beginLoad(scope: scope, path: listing.path)
-                _ = browser.apply(listing, for: request)
-                mutationPending = false
+                let created = try await filesClient().createDirectory(
+                    parentPath: parent,
+                    name: requestedName
+                )
+                await MainActor.run {
+                    guard request.scope == scope, browser.isCurrent(request) else { return }
+                    let loadRequest = browser.beginLoad(scope: request.scope, path: created.path)
+                    _ = browser.apply(created, for: loadRequest)
+                    mutationPending = false
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    guard request.scope == scope, browser.isCurrent(request) else { return }
+                    mutationPending = false
+                }
             } catch {
-                mutationPending = false
-                browser = failingCurrentState(safeFilesError(error))
+                let message = safeFilesError(error)
+                await MainActor.run {
+                    guard request.scope == scope, browser.isCurrent(request) else { return }
+                    mutationPending = false
+                    browser = failingCurrentState(message)
+                }
             }
         }
     }
@@ -289,6 +369,14 @@ struct HostFilesView: View {
     }
 
     private func safeFilesError(_ error: Error) -> String {
+        if let access = error as? HostFilesAccessError {
+            switch access {
+            case .relayUnsupported:
+                return "Folder browsing and creation are unavailable through Mercury Relay; enter an existing server folder path manually."
+            case .directOriginUnavailable:
+                return "Connect directly to a Hermes server to browse folders."
+            }
+        }
         if let auth = error as? HermesAuthError {
             switch auth {
             case .authRejected:

--- a/ios/Mercury/Views/ProjectsView.swift
+++ b/ios/Mercury/Views/ProjectsView.swift
@@ -297,8 +297,17 @@ private struct CreateProjectView: View {
     let controller: ProjectMetadataController
     @Environment(\.dismiss) private var dismiss
     @State private var name = ""
-    @State private var canonicalFolder: String?
+    @State private var folderPath = ""
     @State private var showFolderBrowser = false
+
+    private var canonicalFolder: String? {
+        validCanonicalHostFilePath(folderPath)
+    }
+
+    private var hasInvalidFolderPath: Bool {
+        !folderPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && canonicalFolder == nil
+    }
 
     private var canCreate: Bool {
         !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -315,16 +324,30 @@ private struct CreateProjectView: View {
                     showFolderBrowser = true
                 } label: {
                     HStack {
-                        Label(canonicalFolder == nil ? "Choose server folder" : "Change server folder", systemImage: "folder")
+                        Label(folderPath.isEmpty ? "Browse server folders" : "Change server folder", systemImage: "folder")
                         Spacer()
                         Image(systemName: "chevron.right")
                     }
                 }
+                .accessibilityLabel(folderPath.isEmpty ? "Browse server folders" : "Change server folder")
+
+                // Keep manual registration available when the active transport
+                // has no folder-browser capability (notably Relay). The server
+                // remains authoritative for whether the existing path exists.
+                TextField("Absolute server folder path", text: $folderPath)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.asciiCapable)
+                    .accessibilityLabel("Server folder path")
                 if let canonicalFolder {
                     Text(canonicalFolder)
                         .font(.caption.monospaced())
                         .foregroundStyle(Color.secondary)
                         .textSelection(.enabled)
+                } else if hasInvalidFolderPath {
+                    Text("Enter an absolute server path without ‘.’ or ‘..’ components.")
+                        .font(.caption)
+                        .foregroundStyle(Color.statusAlert)
                 }
             }
             if let error = controller.errorMessage {
@@ -348,7 +371,7 @@ private struct CreateProjectView: View {
         .sheet(isPresented: $showFolderBrowser) {
             NavigationStack {
                 HostFilesView(mode: .projectFolder, onSelectFolder: { path in
-                    canonicalFolder = path
+                    folderPath = path
                 })
             }
         }

--- a/ios/Mercury/Views/RootView.swift
+++ b/ios/Mercury/Views/RootView.swift
@@ -16,7 +16,9 @@ struct RootView: View {
             case .connected:
                 home
             case .failed(let message):
-                if appModel.sessions.isEmpty {
+                if case .failed(let identity?, _) = appModel.startupState {
+                    ConnectView(errorMessage: message)
+                } else if appModel.sessions.isEmpty {
                     ConnectView(errorMessage: message)
                 } else {
                     home

--- a/ios/Mercury/Views/ServerListView.swift
+++ b/ios/Mercury/Views/ServerListView.swift
@@ -1,79 +1,42 @@
 import SwiftUI
 
-/// Stateless server switcher. Every mutation is an explicit callback; this view
-/// intentionally owns no connection, credential, cache, teardown, or generation
-/// behavior so the parent can integrate those shared concerns atomically.
+/// Unified configured-server picker used by startup and Settings. Direct rows
+/// retain catalog ID-based rename/remove behavior; relay rows retain their own
+/// pairing store and approval status. Credentials and relay keys never enter
+/// this view's persistence or shared selection policy.
 struct ServerListView: View {
     let catalog: ServerCatalog
+    let relayTargets: [RelayPairedTarget]
+    let activeIdentity: StartupConnectionIdentity?
     let onSelect: (ServerCatalogEntry) -> Void
+    let onSelectRelay: (RelayPairedTarget) -> Void
     let onAdd: (_ origin: String, _ label: String) -> Void
+    let onPairRelay: () -> Void
     let onEditLabel: (_ entry: ServerCatalogEntry, _ label: String) -> Void
+    let onEditRelayLabel: (_ target: RelayPairedTarget, _ label: String) -> Void
     let onRemove: (ServerCatalogEntry) -> Void
+    let onRemoveRelay: (RelayPairedTarget) -> Void
+    /// Embedded startup mode omits NavigationStack chrome and exposes add/pair
+    /// actions as rows so it can live inside the root connection screen.
+    var embedded = false
 
     @State private var presentingAdd = false
     @State private var editingEntry: ServerCatalogEntry?
+    @State private var editingRelay: RelayPairedTarget?
+    @State private var removingRelay: RelayPairedTarget?
 
     var body: some View {
-        List {
-            Section("Servers") {
-                if catalog.entries.isEmpty {
-                    ContentUnavailableView(
-                        "No servers",
-                        systemImage: "server.rack",
-                        description: Text("Add a Hermes server to get started.")
-                    )
-                    .listRowBackground(Color.clear)
-                }
-
-                ForEach(catalog.entries) { entry in
-                    Button {
-                        onSelect(entry)
-                    } label: {
-                        HStack(spacing: 12) {
-                            Image(systemName: entry.id == catalog.activeID ? "checkmark.circle.fill" : "server.rack")
-                                .foregroundStyle(entry.id == catalog.activeID ? Color.statusHealthy : Color.secondary)
-                            VStack(alignment: .leading, spacing: 3) {
-                                Text(entry.displayLabel)
-                                    .font(.headline)
-                                    .foregroundStyle(Color.primary)
-                                Text(entry.origin)
-                                    .font(.caption.monospaced())
-                                    .foregroundStyle(Color.secondary)
-                                    .lineLimit(1)
-                            }
-                            Spacer()
+        Group {
+            if embedded {
+                listContent
+            } else {
+                listContent
+                    .navigationTitle("Servers")
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            addMenu
                         }
-                        .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(entry.id == catalog.activeID
-                        ? "\(entry.displayLabel), active server"
-                        : entry.displayLabel)
-                    .contextMenu {
-                        Button("Rename", systemImage: "pencil") { editingEntry = entry }
-                        Button("Remove", systemImage: "trash", role: .destructive) { onRemove(entry) }
-                            .disabled(entry.id == catalog.activeID)
-                    }
-                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                        Button(role: .destructive) { onRemove(entry) } label: {
-                            Label("Remove", systemImage: "trash")
-                        }
-                        .disabled(entry.id == catalog.activeID)
-                        Button { editingEntry = entry } label: {
-                            Label("Rename", systemImage: "pencil")
-                        }
-                        .tint(.accentPrimary)
-                    }
-                    .listRowBackground(Color.surfaceLow)
-                }
-            }
-        }
-        .scrollContentBackground(.hidden)
-        .navigationTitle("Servers")
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button { presentingAdd = true } label: { Image(systemName: "plus") }
-                    .accessibilityLabel("Add server")
             }
         }
         .sheet(isPresented: $presentingAdd) {
@@ -91,7 +54,190 @@ struct ServerListView: View {
                 onEditLabel(entry, label)
             }
         }
+        .sheet(item: $editingRelay) { target in
+            ServerEntrySheet(
+                title: "Rename Relay",
+                initialOrigin: target.relayOrigin,
+                initialLabel: target.label,
+                originIsEditable: false
+            ) { _, label in
+                onEditRelayLabel(target, label)
+            }
+        }
         .amoledScreen()
+    }
+
+    @ViewBuilder
+    private var listContent: some View {
+        List {
+            Section("Configured connections") {
+                if catalog.entries.isEmpty && relayTargets.isEmpty {
+                    ContentUnavailableView(
+                        "No configured connections",
+                        systemImage: "server.rack",
+                        description: Text("Add a Hermes server or pair a Mercury Relay device to get started.")
+                    )
+                    .listRowBackground(Color.clear)
+                }
+
+                ForEach(catalog.entries) { entry in
+                    directRow(entry)
+                }
+
+                ForEach(relayTargets) { target in
+                    relayRow(target)
+                }
+            }
+
+            if embedded {
+                Section("Add a connection") {
+                    Button {
+                        presentingAdd = true
+                    } label: {
+                        Label("Add server", systemImage: "plus.circle")
+                    }
+                    Button {
+                        onPairRelay()
+                    } label: {
+                        Label("Pair relay", systemImage: "qrcode.viewfinder")
+                    }
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .toolbar {
+            if embedded {
+                ToolbarItem(placement: .topBarTrailing) {
+                    addMenu
+                }
+            }
+        }
+    }
+
+    private var addMenu: some View {
+        Menu {
+            Button("Add server", systemImage: "server.rack") {
+                presentingAdd = true
+            }
+            Button("Pair relay", systemImage: "qrcode.viewfinder") {
+                onPairRelay()
+            }
+        } label: {
+            Image(systemName: "plus")
+        }
+        .accessibilityLabel("Add server or pair relay")
+    }
+
+    private func directRow(_ entry: ServerCatalogEntry) -> some View {
+        let isActive = activeIdentity == StartupConnectionIdentity(kind: .direct, id: entry.id)
+        return Button {
+            onSelect(entry)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: isActive ? "checkmark.circle.fill" : "server.rack")
+                    .foregroundStyle(isActive ? Color.statusHealthy : Color.secondary)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(entry.displayLabel)
+                        .font(.headline)
+                        .foregroundStyle(Color.primary)
+                    Text(entry.origin)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(Color.secondary)
+                        .lineLimit(1)
+                }
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isActive ? "\(entry.displayLabel), active server" : entry.displayLabel)
+        .contextMenu {
+            Button("Rename", systemImage: "pencil") { editingEntry = entry }
+            Button("Remove", systemImage: "trash", role: .destructive) { onRemove(entry) }
+                .disabled(isActive)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) { onRemove(entry) } label: {
+                Label("Remove", systemImage: "trash")
+            }
+            .disabled(isActive)
+            Button { editingEntry = entry } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+            .tint(.accentPrimary)
+        }
+        .listRowBackground(Color.surfaceLow)
+    }
+
+    private func relayRow(_ target: RelayPairedTarget) -> some View {
+        let isActive = activeIdentity == StartupConnectionIdentity(kind: .relay, id: target.id)
+        let isApproved = target.status == .approved
+        let status = isApproved ? "Mercury Relay · Ready" : "Waiting for host approval"
+        return Button {
+            guard isApproved else { return }
+            onSelectRelay(target)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: isActive ? "checkmark.circle.fill" : "qrcode.viewfinder")
+                    .foregroundStyle(isActive ? Color.statusHealthy : Color.secondary)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(target.displayLabel)
+                        .font(.headline)
+                        .foregroundStyle(Color.primary)
+                    Text(status)
+                        .font(.caption)
+                        .foregroundStyle(isApproved ? Color.secondary : Color.statusAlert)
+                    Text(target.relayOrigin)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(Color.secondary)
+                        .lineLimit(1)
+                }
+                Spacer()
+                if isApproved {
+                    Image(systemName: "chevron.right")
+                        .foregroundStyle(Color.secondary)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isApproved)
+        .accessibilityLabel(
+            isApproved
+                ? (isActive ? "\(target.displayLabel), active relay" : target.displayLabel)
+                : "\(target.displayLabel), waiting for host approval"
+        )
+        .contextMenu {
+            Button("Rename", systemImage: "pencil") { editingRelay = target }
+            Button("Remove", systemImage: "trash", role: .destructive) { removingRelay = target }
+                .disabled(isActive)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) { removingRelay = target } label: {
+                Label("Remove", systemImage: "trash")
+            }
+            .disabled(isActive)
+            Button { editingRelay = target } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+            .tint(.accentPrimary)
+        }
+        .confirmationDialog(
+            "Remove \(target.displayLabel) from this phone?",
+            isPresented: Binding(
+                get: { removingRelay?.id == target.id },
+                set: { if !$0, removingRelay?.id == target.id { removingRelay = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Remove pairing", role: .destructive) {
+                onRemoveRelay(target)
+                removingRelay = nil
+            }
+        } message: {
+            Text("The host still lists this device until you revoke it there. You can pair again with a new QR code.")
+        }
+        .listRowBackground(Color.surfaceLow)
     }
 }
 
@@ -122,7 +268,10 @@ private struct ServerEntrySheet: View {
         _label = State(initialValue: initialLabel)
     }
 
-    private var normalizedOrigin: String? { ServerOrigin.normalize(origin) }
+    private var normalizedOrigin: String? {
+        originIsEditable ? ServerOrigin.normalize(origin) : origin
+    }
+
     private var labelIsValid: Bool {
         label.trimmingCharacters(in: .whitespacesAndNewlines).count <= ServerCatalogPolicy.maxLabelCharacters
             && !label.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) })

--- a/ios/Mercury/Views/SessionListView.swift
+++ b/ios/Mercury/Views/SessionListView.swift
@@ -43,7 +43,6 @@ struct SessionListView: View {
     // UI-level pin toggle until `pinned` is surfaced on SessionRow (see
     // swipe/context actions below).
     @State private var locallyPinnedIDs = Set<String>()
-    @State private var showHostFiles = false
     @State private var showProjects = false
     @State private var showAllSessions = false
     @State private var showSettings = false
@@ -347,7 +346,8 @@ struct SessionListView: View {
                             .foregroundStyle(Color.secondary)
                     }
                     .accessibilityLabel("Profile: \(appModel.activeProfile)")
-
+                }
+                ToolbarItemGroup(placement: .topBarTrailing) {
                     Button {
                         toggleSearch()
                     } label: {
@@ -355,15 +355,6 @@ struct SessionListView: View {
                     }
                     .foregroundStyle(Color.secondary)
                     .accessibilityLabel(searchPresented ? "Close search" : "Search sessions")
-                }
-                ToolbarItemGroup(placement: .topBarTrailing) {
-                    Button {
-                        showHostFiles = true
-                    } label: {
-                        Image(systemName: "folder")
-                    }
-                    .accessibilityLabel("Host files")
-                    .foregroundStyle(Color.secondary)
 
                     Button { showSettings = true } label: {
                         Image(systemName: "gearshape")
@@ -388,9 +379,6 @@ struct SessionListView: View {
             }
             .navigationDestination(item: $incomingShareDraft) { draft in
                 ChatView.newSession(incomingShare: draft)
-            }
-            .sheet(isPresented: $showHostFiles) {
-                NavigationStack { HostFilesView() }
             }
             .sheet(isPresented: $showProjects) {
                 NavigationStack { ProjectsView(controller: projectController) }
@@ -641,6 +629,7 @@ struct SessionListView: View {
             Text(title)
             Spacer()
             Button(actionTitle, action: action)
+                .accessibilityLabel("\(actionTitle) \(title.lowercased())")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(Color.accentPrimary)
                 .textCase(nil)
@@ -717,6 +706,7 @@ struct SessionListView: View {
             get: { appModel.activeProfile },
             set: { selected in
                 guard selected != appModel.activeProfile else { return }
+                splitSelection?.wrappedValue = nil
                 Task { await appModel.switchProfile(selected) }
             }
         )

--- a/ios/Mercury/Views/SessionStatusViews.swift
+++ b/ios/Mercury/Views/SessionStatusViews.swift
@@ -1,45 +1,6 @@
 import SwiftUI
 
-/// Android SessionDetail parity: the context ring in the session toolbar and
-/// the run status pill. These explain observed activity only; whether the
-/// user may interrupt is decided by controller authority, never by these.
-struct ContextRingButton: View {
-    let percent: Double?
-    let artifactCount: Int
-    let action: () -> Void
-
-    private var fraction: Double? { percent.map { min(max($0 / 100, 0), 1) } }
-
-    private var ringColor: Color {
-        guard let fraction else { return Color.secondaryContent }
-        if fraction >= 0.9 { return Color.statusAlert }
-        if fraction >= 0.75 { return Color.statusActive }
-        return Color.accentPrimary
-    }
-
-    var body: some View {
-        Button(action: action) {
-            ZStack {
-                Circle()
-                    .stroke(Color.surfaceHighest, lineWidth: 3)
-                Circle()
-                    .trim(from: 0, to: fraction ?? 0)
-                    .stroke(ringColor, style: StrokeStyle(lineWidth: 3, lineCap: .round))
-                    .rotationEffect(.degrees(-90))
-                Text(percent.map { String(Int(min(max($0, 0), 99))) } ?? "–")
-                    .font(.system(size: 9, weight: .medium))
-                    .foregroundStyle(Color.primary)
-            }
-            .frame(width: 30, height: 30)
-        }
-        .accessibilityLabel("Open session details")
-        .accessibilityValue(
-            (percent.map { "Context \(Int($0)) percent used" } ?? "Context usage unknown")
-                + ", " + (artifactCount == 1 ? "1 artifact" : "\(artifactCount) artifacts")
-        )
-    }
-}
-
+/// Observed run activity. Interrupt authority is handled by the composer.
 struct RunStatusPill: View {
     let text: String
 

--- a/ios/Mercury/Views/SettingsView.swift
+++ b/ios/Mercury/Views/SettingsView.swift
@@ -6,8 +6,9 @@ import UIKit
 struct SettingsView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(\.dismiss) private var dismiss
-    @State private var relay = RelayAppModel()
+    @State private var relay: RelayAppModel?
     @State private var confirmRemoveRelay = false
+    @State private var showRelayPairing = false
 
     var body: some View {
         NavigationStack {
@@ -24,10 +25,26 @@ struct SettingsView: View {
                     NavigationLink {
                         ServerListView(
                             catalog: appModel.serverCatalog,
+                            relayTargets: appModel.relayTargets,
+                            activeIdentity: appModel.activeStartupIdentity,
                             onSelect: { entry in Task { await appModel.switchServer(entry) } },
-                            onAdd: { origin, label in Task { await appModel.addServer(origin: origin, label: label) } },
-                            onEditLabel: { entry, label in Task { await appModel.renameServer(entry, label: label) } },
-                            onRemove: { entry in Task { await appModel.removeServer(entry) } }
+                            onSelectRelay: { target in Task { await appModel.connectRelay(target) } },
+                            onAdd: { origin, label in
+                                Task { await appModel.addServer(origin: origin, label: label) }
+                            },
+                            onPairRelay: { showRelayPairing = true },
+                            onEditLabel: { entry, label in
+                                Task { await appModel.renameServer(entry, label: label) }
+                            },
+                            onEditRelayLabel: { target, label in
+                                Task { await appModel.renameRelay(target, label: label) }
+                            },
+                            onRemove: { entry in
+                                Task { await appModel.removeServer(entry) }
+                            },
+                            onRemoveRelay: { target in
+                                Task { await appModel.removeRelay(target) }
+                            }
                         )
                     } label: {
                         settingsRow("Servers", subtitle: "Add, switch, or remove Hermes servers", icon: "server.rack")
@@ -86,7 +103,8 @@ struct SettingsView: View {
                         Button("Remove pairing", role: .destructive) {
                             Task {
                                 appModel.disconnect()
-                                await relay.removeTarget(target)
+                                await appModel.removeRelay(target)
+                                await appModel.loadRelayTargets()
                                 dismiss()
                             }
                         }
@@ -117,6 +135,18 @@ struct SettingsView: View {
             .amoledScreen()
         }
         .interactiveDismissDisabled(true)
+        .task {
+            let model = appModel.makeRelayAppModel()
+            relay = model
+            await model.loadTargets()
+            await appModel.loadRelayTargets()
+        }
+        .sheet(isPresented: $showRelayPairing, onDismiss: {
+            relay?.cancelPairing()
+            Task { await appModel.loadRelayTargets() }
+        }) {
+            if let relay { RelayPairingView(relay: relay) }
+        }
     }
 
     private func settingsRow(_ title: String, subtitle: String, icon: String) -> some View {

--- a/ios/MercuryTests/ChatFollowUpSubmissionTests.swift
+++ b/ios/MercuryTests/ChatFollowUpSubmissionTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import XCTest
+@testable import Mercury
+
+/// Regression coverage for the iOS prompt-admission race:
+/// message.complete/error can be delivered before prompt.submit's correlated
+/// response. The terminal event must release the composer gate, while a late
+/// failed acknowledgement must not restore the admitted draft or affect the
+/// next attempt.
+final class ChatFollowUpSubmissionTests: XCTestCase {
+    private static func eventEnvelope(type: String, payload: String, sessionID: String = "rt-follow-up") -> String {
+        #"{"jsonrpc":"2.0","method":"event","params":{"session_id":"\#(sessionID)","type":"\#(type)","payload":\#(payload)}}"#
+    }
+
+    private static func errorFrame(id: Int64, code: Int64) -> String {
+        #"{"jsonrpc":"2.0","id":\#(id),"error":{"code":\#(code),"message":"request failed"}}"#
+    }
+
+    private func firstEvent(
+        from stream: AsyncStream<ChatEvent>,
+        timeoutNanoseconds: UInt64 = 2_000_000_000
+    ) async throws -> ChatEvent {
+        try await withThrowingTaskGroup(of: ChatEvent?.self) { group in
+            group.addTask {
+                var iterator = stream.makeAsyncIterator()
+                return await iterator.next()
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                throw ChatError.transport("timed out waiting for terminal event")
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next(), let event = result else {
+                throw ChatError.transport("terminal event stream ended")
+            }
+            return event
+        }
+    }
+
+    func testTerminalEventBeforeSubmitAckReleasesGateAndPermitsFollowUp() async throws {
+        let socket = ConnectionTestSocket(frames: [])
+        socket.autoRespond = { [socket] sent in
+            guard sent.contains(#""method":"prompt.submit""#) else { return nil }
+            // The fake delivers the authoritative terminal event first and the
+            // correlated RPC failure second, exactly the ordering under test.
+            socket.enqueue(.frame(Self.eventEnvelope(
+                type: "message.complete",
+                payload: #"{"text":"first response","status":"completed"}"#
+            )))
+            return Self.errorFrame(id: 1, code: -32000)
+        }
+
+        let connection = try ChatConnection(socket: socket)
+        let stream = connection.start()
+        var lifecycle = PromptSubmissionLifecycle()
+        let firstAttempt = try XCTUnwrap(
+            lifecycle.begin(draft: "first draft", hostReferenceIDs: ["host-old"])
+        )
+
+        let submitFailed = Task { () -> Bool in
+            do {
+                _ = try await connection.submitPrompt(runtimeSessionID: "rt-follow-up", text: "first draft")
+                return false
+            } catch {
+                return true
+            }
+        }
+
+        let event = try await firstEvent(from: stream)
+        guard case .messageComplete = event else {
+            return XCTFail("expected message.complete before submit acknowledgement, got \(event)")
+        }
+        let terminalEffect = lifecycle.observeTerminal()
+        XCTAssertEqual(
+            terminalEffect,
+            .releasedPending(hostReferenceIDs: ["host-old"])
+        )
+        if case .releasedPending(let referenceIDs) = terminalEffect {
+            var stagedReferenceIDs = ["host-old"]
+            stagedReferenceIDs.removeAll { referenceIDs.contains($0) }
+            XCTAssertTrue(stagedReferenceIDs.isEmpty)
+        }
+        XCTAssertEqual(lifecycle.phase, .terminalBeforeAcceptance)
+
+        let submitDidFail = await submitFailed.value
+        XCTAssertTrue(submitDidFail)
+        // The late failure is authoritative-terminal cleanup, not a draft
+        // restoration. A second attempt can therefore be admitted immediately.
+        XCTAssertEqual(
+            lifecycle.resolve(attempt: firstAttempt, accepted: false),
+            .authoritativeTerminal
+        )
+        XCTAssertEqual(lifecycle.phase, .idle)
+        XCTAssertNotNil(lifecycle.begin(draft: "second draft"))
+
+        await connection.close()
+    }
+
+    func testLateOldFailureCannotClearReplacementAttemptOrRestoreItsDraft() throws {
+        var lifecycle = PromptSubmissionLifecycle()
+        let first = try XCTUnwrap(
+            lifecycle.begin(draft: "already admitted", hostReferenceIDs: ["host-old"])
+        )
+        XCTAssertEqual(
+            lifecycle.observeTerminal(),
+            .releasedPending(hostReferenceIDs: ["host-old"])
+        )
+
+        // The user submitted a new draft after the terminal event released the
+        // gate, before the old prompt.submit failure arrived.
+        let replacement = try XCTUnwrap(
+            lifecycle.begin(draft: "new draft", hostReferenceIDs: ["host-new"])
+        )
+        XCTAssertEqual(
+            lifecycle.resolve(attempt: first, accepted: false),
+            .stale
+        )
+        XCTAssertEqual(lifecycle.phase, .awaitingAcceptance)
+
+        XCTAssertEqual(
+            lifecycle.resolve(attempt: replacement, accepted: true),
+            .accepted(hostReferenceIDs: ["host-new"])
+        )
+        XCTAssertEqual(lifecycle.phase, .idle)
+    }
+}

--- a/ios/MercuryTests/HostFilesAccessTests.swift
+++ b/ios/MercuryTests/HostFilesAccessTests.swift
@@ -1,0 +1,259 @@
+import Foundation
+import XCTest
+@testable import Mercury
+
+private final class HostFilesAccessMockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+
+    static func reset() {
+        handler = nil
+        requests = []
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requests.append(request)
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    static func body(of request: URLRequest) -> Data {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return Data() }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4_096)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let count = stream.read(buffer, maxLength: 4_096)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}
+
+private final class HostFilesAccessCredentialStore: CredentialStoring {
+    var pair: TokenPair?
+
+    init(pair: TokenPair? = nil) {
+        self.pair = pair
+    }
+
+    func tokens(for origin: String) -> TokenPair? { pair }
+    func setTokens(_ tokens: TokenPair, for origin: String) { pair = tokens }
+    func clearTokens(for origin: String) { pair = nil }
+}
+
+final class HostFilesAccessTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        HostFilesAccessMockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        HostFilesAccessMockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [HostFilesAccessMockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private func response(_ request: URLRequest, status: Int = 200) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: request.url!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private var emptyListing: Data {
+        Data(#"{"path":"/srv","parent":"/","entries":[]}"#.utf8)
+    }
+
+    func testCapabilityDistinguishesDirectAccessFromRelayAndMissingOrigin() {
+        XCTAssertEqual(
+            HostFilesAccess.capability(origin: "https://hermes.example", relayActive: false),
+            .direct
+        )
+        XCTAssertEqual(
+            HostFilesAccess.capability(origin: nil, relayActive: true),
+            .relayUnsupported
+        )
+        XCTAssertEqual(
+            HostFilesAccess.capability(origin: nil, relayActive: false),
+            .unavailable
+        )
+        XCTAssertEqual(
+            HostFilesAccess.capability(origin: "relative/path", relayActive: false),
+            .unavailable
+        )
+
+        XCTAssertThrowsError(
+            try HostFilesAccess.makeClient(origin: nil, relayActive: true, urlSession: makeSession())
+        ) { error in
+            XCTAssertEqual(error as? HostFilesAccessError, .relayUnsupported)
+        }
+        XCTAssertThrowsError(
+            try HostFilesAccess.makeClient(origin: nil, relayActive: false, urlSession: makeSession())
+        ) { error in
+            XCTAssertEqual(error as? HostFilesAccessError, .directOriginUnavailable)
+        }
+    }
+
+    func testFolderPickerUsesServerDirectoryAndParentMetadataWithoutExtraConfinement() {
+        let listing = HostFileListing(
+            path: "/opt/data/project",
+            entries: [
+                HostFileEntry(name: "README.md", path: "/opt/data/project/README.md", isDirectory: false),
+                HostFileEntry(name: "Sources", path: "/opt/data/project/Sources", isDirectory: true),
+                HostFileEntry(name: "Linked folder", path: "/srv/shared", isDirectory: true),
+            ],
+            parentPath: "/opt/data",
+            root: nil,
+            lockedRoot: nil,
+            canChangePath: true
+        )
+
+        XCTAssertTrue(HostFilesFolderPickerPolicy.canSelect(listing))
+        XCTAssertEqual(
+            HostFilesFolderPickerPolicy.directories(in: listing).map(\.path),
+            ["/opt/data/project/Sources", "/srv/shared"]
+        )
+        XCTAssertEqual(
+            HostFilesFolderPickerPolicy.parentPath(in: listing),
+            "/opt/data"
+        )
+
+        let locked = HostFileListing(
+            path: listing.path,
+            entries: [],
+            parentPath: listing.parentPath,
+            root: "/opt/data",
+            lockedRoot: "/opt/data",
+            canChangePath: false
+        )
+        XCTAssertEqual(HostFilesFolderPickerPolicy.parentPath(in: locked), "/opt/data")
+    }
+
+    func testOperationResponsesAreRejectedAfterScopeSwitchForPreviewAndMkdir() {
+        var previewState = HostFilesBrowserState()
+        _ = previewState.beginLoad(scope: "direct|default", path: nil)
+        let preview = previewState.beginPreview(path: "/srv/old.txt")
+        let newerPreview = previewState.beginPreview(path: "/srv/new.txt")
+        XCTAssertFalse(previewState.isCurrent(preview))
+        XCTAssertTrue(previewState.isCurrent(newerPreview))
+        _ = previewState.beginLoad(scope: "relay|default", path: nil)
+        XCTAssertFalse(previewState.isCurrent(newerPreview))
+
+        var createState = HostFilesBrowserState()
+        _ = createState.beginLoad(scope: "direct|default", path: "/srv")
+        let create = createState.beginCreate(parentPath: "/srv")
+        let newerCreate = createState.beginCreate(parentPath: "/srv")
+        XCTAssertFalse(createState.isCurrent(create))
+        XCTAssertTrue(createState.isCurrent(newerCreate))
+        _ = createState.beginLoad(scope: "direct|work", path: nil)
+        XCTAssertFalse(createState.isCurrent(newerCreate))
+    }
+
+    func testClientKeepsFolder403SeparateFromAuthentication401() async throws {
+        var status = 401
+        HostFilesAccessMockURLProtocol.handler = { request in
+            (self.response(request, status: status), Data(#"{"detail":"denied"}"#.utf8))
+        }
+        let client = try HostFilesClient(
+            origin: "https://hermes.example",
+            bearerToken: "access",
+            session: makeSession()
+        )
+
+        do {
+            _ = try await client.list()
+            XCTFail("Expected HTTP 401")
+        } catch let error as HermesAuthError {
+            XCTAssertEqual(error, .authRejected)
+        }
+
+        status = 403
+        do {
+            _ = try await client.list()
+            XCTFail("Expected denied-folder status")
+        } catch let error as HostFilesClientError {
+            XCTAssertEqual(error, .httpStatus(403))
+        }
+    }
+
+    func testDirectClientRefreshesStoredBearerAndPersistsRotatedPair() async throws {
+        let now = Int64(Date().timeIntervalSince1970)
+        let store = HostFilesAccessCredentialStore(
+            pair: TokenPair(
+                accessToken: Data("stale-access".utf8),
+                refreshToken: Data("refresh-secret".utf8),
+                expiresAt: now + 1,
+                provider: "nous"
+            )
+        )
+        var fileAttempts = 0
+        HostFilesAccessMockURLProtocol.handler = { request in
+            switch request.url?.path {
+            case "/api/files":
+                fileAttempts += 1
+                XCTAssertEqual(
+                    request.value(forHTTPHeaderField: "Authorization"),
+                    fileAttempts == 1 ? "Bearer stale-access" : "Bearer fresh-access"
+                )
+                if fileAttempts == 1 {
+                    return (self.response(request, status: 401), Data())
+                }
+                return (self.response(request), self.emptyListing)
+            case "/auth/native/refresh":
+                XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+                let body = try XCTUnwrap(
+                    JSONSerialization.jsonObject(with: HostFilesAccessMockURLProtocol.body(of: request)) as? [String: String]
+                )
+                XCTAssertEqual(body["refresh_token"], "refresh-secret")
+                XCTAssertEqual(body["provider"], "nous")
+                let payload = """
+                {"access_token":"fresh-access","refresh_token":"fresh-refresh","expires_at":\(now + 3600),"provider":"nous","user_id":"user-1"}
+                """
+                return (self.response(request), Data(payload.utf8))
+            default:
+                XCTFail("Unexpected request path")
+                return (self.response(request, status: 404), Data())
+            }
+        }
+
+        let client = try HostFilesAccess.makeClient(
+            origin: "https://hermes.example",
+            relayActive: false,
+            urlSession: makeSession(),
+            credentialStore: store
+        )
+        let listing = try await client.list(path: "/srv")
+
+        XCTAssertEqual(listing.path, "/srv")
+        XCTAssertEqual(fileAttempts, 2)
+        XCTAssertEqual(String(data: store.pair?.accessToken ?? Data(), encoding: .utf8), "fresh-access")
+        XCTAssertEqual(String(data: store.pair?.refreshToken ?? Data(), encoding: .utf8), "fresh-refresh")
+    }
+}

--- a/ios/MercuryTests/LoopbackHTTPTestServer.swift
+++ b/ios/MercuryTests/LoopbackHTTPTestServer.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Network
+
+/// Real HTTP redirects for URLSession tests. URLProtocol redirect handoffs
+/// cannot safely be followed by an unconditional finish callback, and omitting
+/// that callback strands a request when its delegate refuses the redirect.
+/// Bind only to loopback, use an ephemeral port, and keep all state on one queue.
+final class LoopbackHTTPTestServer: @unchecked Sendable {
+    private let listener: NWListener
+    private let response: Data
+    private let queue = DispatchQueue(label: "mercury.tests.http")
+    private var connections: [ObjectIdentifier: NWConnection] = [:]
+    private var startContinuation: CheckedContinuation<URL, Error>?
+    private var receivedRequests = 0
+
+    init(redirectTo destination: URL? = nil) throws {
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: 0)
+        listener = try NWListener(using: parameters)
+        let headers = destination.map {
+            "HTTP/1.1 302 Found\r\nLocation: \($0.absoluteString)\r\n"
+        } ?? "HTTP/1.1 200 OK\r\n"
+        response = Data((headers + "Content-Length: 0\r\nConnection: close\r\n\r\n").utf8)
+        listener.newConnectionHandler = { [weak self] connection in
+            guard let self else { connection.cancel(); return }
+            self.accept(connection)
+        }
+    }
+
+    var requestCount: Int { queue.sync { receivedRequests } }
+
+    func start() async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            queue.async {
+                self.startContinuation = continuation
+                self.listener.stateUpdateHandler = { [weak self] state in
+                    guard let self, let pending = self.startContinuation else { return }
+                    switch state {
+                    case .ready:
+                        self.startContinuation = nil
+                        if let port = self.listener.port,
+                           let url = URL(string: "http://127.0.0.1:\(port.rawValue)") {
+                            pending.resume(returning: url)
+                        } else {
+                            pending.resume(throwing: URLError(.cannotFindHost))
+                        }
+                    case .failed(let error):
+                        self.startContinuation = nil
+                        pending.resume(throwing: error)
+                    case .cancelled:
+                        self.startContinuation = nil
+                        pending.resume(throwing: CancellationError())
+                    default:
+                        break
+                    }
+                }
+                self.listener.start(queue: self.queue)
+                self.queue.asyncAfter(deadline: .now() + 5) { [weak self] in
+                    guard let self, let pending = self.startContinuation else { return }
+                    self.startContinuation = nil
+                    pending.resume(throwing: URLError(.timedOut))
+                    self.listener.cancel()
+                }
+            }
+        }
+    }
+
+    /// Call from the test's defer, including when start or the request fails.
+    func stop() {
+        queue.sync {
+            listener.cancel()
+            for connection in connections.values { connection.cancel() }
+            connections.removeAll()
+            startContinuation?.resume(throwing: CancellationError())
+            startContinuation = nil
+        }
+    }
+
+    private func accept(_ connection: NWConnection) {
+        let id = ObjectIdentifier(connection)
+        connections[id] = connection
+        connection.stateUpdateHandler = { [weak self, weak connection] state in
+            guard let self, let connection else { return }
+            switch state {
+            case .ready:
+                self.readHeaders(connection, buffer: Data())
+            case .failed, .cancelled:
+                self.connections.removeValue(forKey: id)
+            default:
+                break
+            }
+        }
+        connection.start(queue: queue)
+    }
+
+    private func readHeaders(_ connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 8_192) { [weak self] data, _, complete, error in
+            guard let self else { connection.cancel(); return }
+            var buffer = buffer
+            if let data { buffer.append(data) }
+            guard buffer.count <= 16_384, error == nil else {
+                connection.cancel()
+                return
+            }
+            if buffer.range(of: Data("\r\n\r\n".utf8)) != nil {
+                self.receivedRequests += 1
+                connection.send(content: self.response, completion: .contentProcessed { _ in
+                    connection.cancel()
+                })
+            } else if complete {
+                connection.cancel()
+            } else {
+                self.readHeaders(connection, buffer: buffer)
+            }
+        }
+    }
+}

--- a/ios/MercuryTests/NetworkingTests.swift
+++ b/ios/MercuryTests/NetworkingTests.swift
@@ -31,15 +31,9 @@ final class MockURLProtocol: URLProtocol {
         }
         do {
             let (response, data) = try handler(request)
-            // Simulate a real redirect: hand the session the new request so
-            // its redirect policy (delegate) decides whether to follow.
-            if (300...399).contains(response.statusCode),
-               let location = response.value(forHTTPHeaderField: "Location"),
-               let target = URL(string: location, relativeTo: request.url) {
-                var redirected = request
-                redirected.url = target.absoluteURL
-                client?.urlProtocol(self, wasRedirectedTo: redirected, redirectResponse: response)
-            }
+            // This stub serves responses only. Redirect transport behavior is
+            // exercised by LoopbackHTTPTestServer rather than synthesizing a
+            // redirect and also completing the original URLProtocol load.
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             client?.urlProtocol(self, didLoad: data)
             // URLProtocol does not persist Set-Cookie into HTTPCookieStorage on
@@ -113,19 +107,22 @@ final class NetworkingTests: XCTestCase {
     /// parity): a bearer token scoped to the configured origin must not be
     /// forwarded to another host. The 3xx surfaces to the caller as-is.
     func testHermesSessionRefusesCrossOriginRedirect() async throws {
-        MockURLProtocol.handler = { request in
-            if request.url?.host == "hermes.test" {
-                return self.response(
-                    302, headers: ["Location": "https://evil.test/steal"], for: request
-                )
-            }
-            return self.response(200, for: request)
-        }
-        let client = makeClient()
+        let target = try LoopbackHTTPTestServer()
+        defer { target.stop() }
+        let targetOrigin = try await target.start()
+        let source = try LoopbackHTTPTestServer(redirectTo: targetOrigin.appendingPathComponent("steal"))
+        defer { source.stop() }
+        let sourceOrigin = try await source.start()
+        XCTAssertNotEqual(sourceOrigin.port, targetOrigin.port)
+
+        let session = HermesURLSession.make(.ephemeral)
+        defer { session.invalidateAndCancel() }
+        let client = HermesHTTPClient(origin: sourceOrigin.absoluteString, session: session)
         client.bearerToken = "secret-token"
         let (_, http) = try await client.get(path: "/api/status")
         XCTAssertEqual(http.statusCode, 302)
-        XCTAssertEqual(MockURLProtocol.receivedRequests.map { $0.url?.host }, ["hermes.test"])
+        XCTAssertEqual(source.requestCount, 1)
+        XCTAssertEqual(target.requestCount, 0, "A refused redirect must never contact the other origin")
     }
 
     /// The authenticated factory is how production builds every bearer-carrying
@@ -140,23 +137,25 @@ final class NetworkingTests: XCTestCase {
         XCTAssertFalse(plain.refusesRedirects)
     }
 
-    /// Control for the test above: the mock really does redirect when the
+    /// Control for the test above: the server really does redirect when the
     /// session has no refusing delegate, so the assertion is meaningful.
     func testControlPlainSessionFollowsTheSameRedirect() async throws {
-        MockURLProtocol.handler = { request in
-            if request.url?.host == "hermes.test" {
-                return self.response(
-                    302, headers: ["Location": "https://evil.test/steal"], for: request
-                )
-            }
-            return self.response(200, for: request)
-        }
-        let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [MockURLProtocol.self]
-        let client = HermesHTTPClient(origin: "https://hermes.test", session: URLSession(configuration: config))
+        let target = try LoopbackHTTPTestServer()
+        defer { target.stop() }
+        let targetOrigin = try await target.start()
+        let source = try LoopbackHTTPTestServer(redirectTo: targetOrigin.appendingPathComponent("steal"))
+        defer { source.stop() }
+        let sourceOrigin = try await source.start()
+        XCTAssertNotEqual(sourceOrigin.port, targetOrigin.port)
+
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.invalidateAndCancel() }
+        let client = HermesHTTPClient(origin: sourceOrigin.absoluteString, session: session)
         let (_, http) = try await client.get(path: "/api/status")
         XCTAssertEqual(http.statusCode, 200)
-        XCTAssertEqual(MockURLProtocol.receivedRequests.map { $0.url?.host }, ["hermes.test", "evil.test"])
+        XCTAssertEqual(http.url?.port, targetOrigin.port)
+        XCTAssertEqual(source.requestCount, 1)
+        XCTAssertEqual(target.requestCount, 1)
     }
 
     func testBearerTokenIsSentWhenSet() async throws {

--- a/ios/MercuryTests/ProfileDiscoveryTests.swift
+++ b/ios/MercuryTests/ProfileDiscoveryTests.swift
@@ -201,7 +201,8 @@ final class ProfileDiscoveryTests: XCTestCase {
     func testStalePreviousHostProfileResponseCannotOverwriteCurrentCatalog() async {
         let oldHost = "https://old-profiles.test"
         let newHost = "https://new-profiles.test"
-        let oldClient = DeferredProfilesListing()
+        let oldRequestStarted = expectation(description: "Old host profile request started")
+        let oldClient = DeferredProfilesListing(onRequest: { oldRequestStarted.fulfill() })
         let newClient = FakeProfilesListing(names: ["default", "new-host"])
         let model = makeModel(
             session: makeSession(),
@@ -221,12 +222,7 @@ final class ProfileDiscoveryTests: XCTestCase {
         let oldProbe = Task { @MainActor in
             await model.controller.probeSelfHosted(origin: oldHost)
         }
-        var oldRequested = false
-        for _ in 0..<100 where !oldRequested {
-            oldRequested = await oldClient.requested
-            if !oldRequested { await Task.yield() }
-        }
-        XCTAssertTrue(oldRequested)
+        await fulfillment(of: [oldRequestStarted], timeout: 5)
 
         await model.controller.probeSelfHosted(origin: newHost)
         XCTAssertEqual(model.profiles, ["default", "new-host"])
@@ -239,7 +235,12 @@ final class ProfileDiscoveryTests: XCTestCase {
     }
 
     func testStaleProfileSessionRefreshCannotMixRowsAfterProfileSwitch() async {
-        let pages = DeferredSessionPages()
+        let defaultRequestStarted = expectation(description: "Default profile page requested")
+        let workRequestStarted = expectation(description: "Work profile page requested")
+        let pages = DeferredSessionPages(onRequest: { profile in
+            if profile == "default" { defaultRequestStarted.fulfill() }
+            if profile == "work" { workRequestStarted.fulfill() }
+        })
         let model = makeModel(
             session: makeSession(),
             sessionPageLoader: { _, profile, _, _ in
@@ -252,15 +253,13 @@ final class ProfileDiscoveryTests: XCTestCase {
         let oldRefresh = Task { @MainActor in
             await model.controller.refreshSessions()
         }
-        let defaultRequested = await pages.waitUntilRequested("default")
-        XCTAssertTrue(defaultRequested)
+        await fulfillment(of: [defaultRequestStarted], timeout: 5)
 
         model.setActiveProfile("work")
         let newRefresh = Task { @MainActor in
             await model.controller.refreshSessions()
         }
-        let workRequested = await pages.waitUntilRequested("work")
-        XCTAssertTrue(workRequested)
+        await fulfillment(of: [workRequestStarted], timeout: 5)
 
         await pages.release(
             "work",
@@ -353,13 +352,17 @@ private final class FakeProfilesListing: ProfilesListing {
 }
 
 private actor DeferredProfilesListing: ProfilesListing {
-    private(set) var requested = false
+    private let onRequest: @Sendable () -> Void
     private var continuation: CheckedContinuation<[String], Error>?
 
+    init(onRequest: @escaping @Sendable () -> Void) {
+        self.onRequest = onRequest
+    }
+
     func list() async throws -> [String] {
-        requested = true
         return try await withCheckedThrowingContinuation { continuation in
             self.continuation = continuation
+            onRequest()
         }
     }
 
@@ -371,21 +374,17 @@ private actor DeferredProfilesListing: ProfilesListing {
 
 private actor DeferredSessionPages {
     private var continuations: [String: CheckedContinuation<SessionPage, Error>] = [:]
-    private(set) var requests: [String] = []
+    private let onRequest: @Sendable (String) -> Void
 
-    func load(profile: String) async throws -> SessionPage {
-        requests.append(profile)
-        return try await withCheckedThrowingContinuation { continuation in
-            continuations[profile] = continuation
-        }
+    init(onRequest: @escaping @Sendable (String) -> Void) {
+        self.onRequest = onRequest
     }
 
-    func waitUntilRequested(_ profile: String) async -> Bool {
-        for _ in 0..<100 {
-            if requests.contains(profile) { return true }
-            await Task.yield()
+    func load(profile: String) async throws -> SessionPage {
+        return try await withCheckedThrowingContinuation { continuation in
+            continuations[profile] = continuation
+            onRequest(profile)
         }
-        return false
     }
 
     func release(_ profile: String, page: SessionPage) {

--- a/ios/MercuryTests/ProfileDiscoveryTests.swift
+++ b/ios/MercuryTests/ProfileDiscoveryTests.swift
@@ -1,0 +1,426 @@
+import Foundation
+import XCTest
+@testable import Mercury
+
+@MainActor
+final class ProfileDiscoveryTests: XCTestCase {
+    private let directOrigin = "https://profiles-hermes.test"
+
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: Direct discovery
+
+    func testChangingProfileClearsPreviousRowsBeforeLoadingReplacement() {
+        let model = makeModel(session: makeSession())
+        model.sessions = [SessionRow(id: "previous-profile", profile: "default")]
+        model.setCanLoadMoreSessions(true)
+        model.setIsLoadingMoreSessions(true)
+        model.setActiveProfile("work")
+        XCTAssertTrue(model.sessions.isEmpty)
+        XCTAssertFalse(model.canLoadMoreSessions)
+        XCTAssertFalse(model.isLoadingMoreSessions)
+    }
+
+    func testDirectAuthDiscoversRestNamesAndKeepsAuthenticatedConnectionOnProfileError() async {
+        MockURLProtocol.handler = { request in
+            let body: String
+            let status: Int
+            switch request.url?.path {
+            case "/api/status":
+                status = 200
+                body = #"{"version":"test","auth_required":false}"#
+            case "/api/profiles":
+                status = 200
+                body = #"{"profiles":[{"name":"default"},{"name":" work "},{"name":"work"},{"name":"../invalid"},{"name":""},{"name":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}]}"#
+            default:
+                throw URLError(.unsupportedURL)
+            }
+            return (
+                HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: status,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!,
+                Data(body.utf8)
+            )
+        }
+
+        let session = makeSession()
+        let client = ProfilesClient(
+            httpClient: HermesHTTPClient(origin: directOrigin, session: HermesURLSession.make(session.configuration))
+        )
+        let model = makeModel(
+            session: session,
+            directProfilesClientFactory: { _ in client }
+        )
+
+        await model.controller.probeSelfHosted(origin: directOrigin)
+
+        XCTAssertEqual(model.connectionPhase, .connected)
+        XCTAssertEqual(model.profiles, ["default", "work", "../invalid"])
+
+        // A later unsupported/error response is a catalog fallback, not an
+        // authentication failure and never resurrects an older host catalog.
+        let errorClient = FakeProfilesListing(error: ProfilesClientError.unsupported)
+        let errorModel = makeModel(
+            session: makeSession(),
+            directProfilesClientFactory: { _ in errorClient }
+        )
+        MockURLProtocol.handler = { request in
+            guard request.url?.path == "/api/status" else { throw URLError(.unsupportedURL) }
+            return (
+                HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                Data(#"{"version":"test","auth_required":false}"#.utf8)
+            )
+        }
+
+        await errorModel.controller.probeSelfHosted(origin: directOrigin)
+
+        XCTAssertEqual(errorModel.connectionPhase, .connected)
+        XCTAssertEqual(errorModel.profiles, ["default"])
+    }
+
+    // MARK: Relay discovery
+
+    func testBootstrapRestoresSavedRelayInsteadOfConfiguredDirectServer() async throws {
+        let catalog = ServerCatalogStore(persistence: ProfileTestCatalogPersistence(), legacyOrigin: nil)
+        _ = try await catalog.add(origin: directOrigin, label: "Direct")
+        let target = makeRelayTarget()
+        let relays = RelayTargetStore(persistence: InMemoryRelayTargetPersistence())
+        try await relays.add(target)
+        let choices = StartupConnectionChoiceStore(persistence: MemoryStartupChoicePersistence())
+        let savedChoice = StartupConnectionIdentity(kind: .relay, id: target.id)
+        try await choices.save(savedChoice)
+        let model = makeModel(
+            session: makeSession(),
+            catalogStore: catalog,
+            relayTargetStore: relays,
+            startupChoiceStore: choices,
+            relayProfilesClientFactory: { _, _ in FakeProfilesListing(names: ["default", "work"]) },
+            relaySessionsPageLoader: { _, _, _, _ in
+                SessionPage(rows: [SessionRow(id: "restored-relay")], total: 1, hasMore: false)
+            }
+        )
+
+        await model.bootstrapSavedServer()
+
+        XCTAssertEqual(model.connectionPhase, .connected)
+        XCTAssertEqual(model.activeRelayTarget?.id, target.id)
+        XCTAssertNil(model.serverOrigin)
+        XCTAssertEqual(model.startupLastSuccessfulChoice, savedChoice)
+        XCTAssertEqual(model.sessions.map(\.id), ["restored-relay"])
+        model.disconnect()
+    }
+
+    func testRelayDiscoveryUsesOfficialProfilesListAndSafeRpcAdmissionNames() async throws {
+        var requestedMethod: String?
+        var requestedParams: [String: Any]?
+        let client = ProfilesClient(rpcRequest: { method, params in
+            requestedMethod = method
+            requestedParams = params
+            return [
+                "profiles": [
+                    ["name": "default"],
+                    ["name": "work"],
+                    ["name": "work"],
+                    ["name": "../invalid"],
+                    ["name": "_invalid"],
+                    ["name": "Work"],
+                    ["name": "safe_name"],
+                ],
+            ]
+        })
+        let target = makeRelayTarget()
+        let relayStore = RelayTargetStore(persistence: InMemoryRelayTargetPersistence())
+        try await relayStore.add(target)
+        let model = makeModel(
+            session: makeSession(),
+            relayTargetStore: relayStore,
+            relayProfilesClientFactory: { _, _ in client },
+            relaySessionsPageLoader: { _, _, _, _ in
+                SessionPage(
+                    rows: [SessionRow(id: "relay-session", profile: "work")],
+                    total: 1,
+                    hasMore: false
+                )
+            }
+        )
+
+        await model.connectRelay(target)
+
+        XCTAssertEqual(requestedMethod, "profiles.list")
+        XCTAssertEqual(requestedParams?["include_sessions"] as? Bool, false)
+        XCTAssertEqual(model.connectionPhase, .connected)
+        XCTAssertEqual(model.activeRelayTarget?.id, target.id)
+        XCTAssertEqual(model.profiles, ["default", "work", "safe_name"])
+        XCTAssertEqual(model.sessions.map(\.id), ["relay-session"])
+
+        model.disconnect()
+    }
+
+    func testUnsupportedRelayProfilesDoNotDropAuthenticatedConnection() async throws {
+        let client = ProfilesClient(rpcRequest: { _, _ in
+            throw ChatMethodNotFoundError(method: "profiles.list")
+        })
+        let target = makeRelayTarget()
+        let relayStore = RelayTargetStore(persistence: InMemoryRelayTargetPersistence())
+        try await relayStore.add(target)
+        let model = makeModel(
+            session: makeSession(),
+            relayTargetStore: relayStore,
+            relayProfilesClientFactory: { _, _ in client },
+            relaySessionsPageLoader: { _, _, _, _ in
+                SessionPage(
+                    rows: [SessionRow(id: "relay-session")],
+                    total: 1,
+                    hasMore: false
+                )
+            }
+        )
+
+        await model.connectRelay(target)
+
+        XCTAssertEqual(model.connectionPhase, .connected)
+        XCTAssertEqual(model.profiles, ["default"])
+        XCTAssertEqual(model.sessions.map(\.id), ["relay-session"])
+
+        model.disconnect()
+    }
+
+    // MARK: Stale asynchronous work
+
+    func testStalePreviousHostProfileResponseCannotOverwriteCurrentCatalog() async {
+        let oldHost = "https://old-profiles.test"
+        let newHost = "https://new-profiles.test"
+        let oldClient = DeferredProfilesListing()
+        let newClient = FakeProfilesListing(names: ["default", "new-host"])
+        let model = makeModel(
+            session: makeSession(),
+            directProfilesClientFactory: { origin in
+                if origin == oldHost { return oldClient }
+                return newClient
+            }
+        )
+        MockURLProtocol.handler = { request in
+            guard request.url?.path == "/api/status" else { throw URLError(.unsupportedURL) }
+            return (
+                HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                Data(#"{"version":"test","auth_required":false}"#.utf8)
+            )
+        }
+
+        let oldProbe = Task { @MainActor in
+            await model.controller.probeSelfHosted(origin: oldHost)
+        }
+        var oldRequested = false
+        for _ in 0..<100 where !oldRequested {
+            oldRequested = await oldClient.requested
+            if !oldRequested { await Task.yield() }
+        }
+        XCTAssertTrue(oldRequested)
+
+        await model.controller.probeSelfHosted(origin: newHost)
+        XCTAssertEqual(model.profiles, ["default", "new-host"])
+
+        await oldClient.release(["default", "old-host"])
+        await oldProbe.value
+
+        XCTAssertEqual(model.connectionPhase, .connected)
+        XCTAssertEqual(model.profiles, ["default", "new-host"])
+    }
+
+    func testStaleProfileSessionRefreshCannotMixRowsAfterProfileSwitch() async {
+        let pages = DeferredSessionPages()
+        let model = makeModel(
+            session: makeSession(),
+            sessionPageLoader: { _, profile, _, _ in
+                try await pages.load(profile: profile)
+            }
+        )
+        model.setServerOrigin(directOrigin)
+        model.setPhase(.connected)
+
+        let oldRefresh = Task { @MainActor in
+            await model.controller.refreshSessions()
+        }
+        let defaultRequested = await pages.waitUntilRequested("default")
+        XCTAssertTrue(defaultRequested)
+
+        model.setActiveProfile("work")
+        let newRefresh = Task { @MainActor in
+            await model.controller.refreshSessions()
+        }
+        let workRequested = await pages.waitUntilRequested("work")
+        XCTAssertTrue(workRequested)
+
+        await pages.release(
+            "work",
+            page: SessionPage(
+                rows: [SessionRow(id: "work-row", profile: "work")],
+                total: 1,
+                hasMore: false
+            )
+        )
+        await newRefresh.value
+
+        await pages.release(
+            "default",
+            page: SessionPage(
+                rows: [SessionRow(id: "default-row", profile: "default")],
+                total: 1,
+                hasMore: false
+            )
+        )
+        await oldRefresh.value
+
+        XCTAssertEqual(model.sessions.map(\.id), ["work-row"])
+        XCTAssertEqual(model.sessions.first?.profile, "work")
+    }
+
+    // MARK: Test seams
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private func makeModel(
+        session: URLSession,
+        catalogStore: ServerCatalogStore = ServerCatalogStore(persistence: ProfileTestCatalogPersistence(), legacyOrigin: nil),
+        relayTargetStore: RelayTargetStore = RelayTargetStore(persistence: InMemoryRelayTargetPersistence()),
+        startupChoiceStore: StartupConnectionChoiceStore = StartupConnectionChoiceStore(persistence: MemoryStartupChoicePersistence()),
+        directProfilesClientFactory: (@MainActor (String) -> any ProfilesListing)? = nil,
+        relayProfilesClientFactory: (@MainActor (RelayPairedTarget, String) async throws -> any ProfilesListing)? = nil,
+        relaySessionsPageLoader: (@MainActor (RelayPairedTarget, String, Int, Int) async throws -> SessionPage)? = nil,
+        sessionPageLoader: (@MainActor (String, String, Int, Int) async throws -> SessionPage)? = nil
+    ) -> AppModel {
+        let model = AppModel(
+            serverCatalogStore: catalogStore,
+            offlineCacheStore: OfflineCacheStore(
+                backend: ProfileTestCacheBackend(),
+                cipher: ProfileTestCacheCipher()
+            ),
+            relayTargetStore: relayTargetStore,
+            startupChoiceStore: startupChoiceStore
+        )
+        let controller = ConnectionController(
+            appModel: model,
+            urlSession: session,
+            credentialStore: ProfileTestCredentialStore(),
+            directProfilesClientFactory: directProfilesClientFactory,
+            relayProfilesClientFactory: relayProfilesClientFactory,
+            relaySessionsPageLoader: relaySessionsPageLoader,
+            sessionPageLoader: sessionPageLoader
+        )
+        model.injectController(controller)
+        return model
+    }
+
+    private func makeRelayTarget() -> RelayPairedTarget {
+        RelayPairedTarget(
+            id: UUID(),
+            label: "test relay",
+            relayOrigin: "https://relay.test",
+            installationID: Data(repeating: 0x01, count: 32),
+            hostPublicKey: Data(repeating: 0x02, count: 32),
+            deviceID: RelayBase64.urlSafeEncode(Data(repeating: 0x03, count: 16)),
+            deviceStaticPrivateKey: Data(repeating: 0x04, count: 32),
+            fingerprint: String(repeating: "a", count: 16),
+            status: .approved,
+            createdAtEpochSeconds: 1,
+            lastUsedEpochSeconds: nil
+        )
+    }
+}
+
+private final class FakeProfilesListing: ProfilesListing {
+    private let result: Result<[String], Error>
+
+    init(names: [String]) { result = .success(names) }
+    init(error: Error) { result = .failure(error) }
+
+    func list() async throws -> [String] { try result.get() }
+}
+
+private actor DeferredProfilesListing: ProfilesListing {
+    private(set) var requested = false
+    private var continuation: CheckedContinuation<[String], Error>?
+
+    func list() async throws -> [String] {
+        requested = true
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func release(_ names: [String]) {
+        continuation?.resume(returning: names)
+        continuation = nil
+    }
+}
+
+private actor DeferredSessionPages {
+    private var continuations: [String: CheckedContinuation<SessionPage, Error>] = [:]
+    private(set) var requests: [String] = []
+
+    func load(profile: String) async throws -> SessionPage {
+        requests.append(profile)
+        return try await withCheckedThrowingContinuation { continuation in
+            continuations[profile] = continuation
+        }
+    }
+
+    func waitUntilRequested(_ profile: String) async -> Bool {
+        for _ in 0..<100 {
+            if requests.contains(profile) { return true }
+            await Task.yield()
+        }
+        return false
+    }
+
+    func release(_ profile: String, page: SessionPage) {
+        continuations.removeValue(forKey: profile)?.resume(returning: page)
+    }
+}
+
+private final class ProfileTestCredentialStore: CredentialStoring, @unchecked Sendable {
+    private var values: [String: TokenPair] = [:]
+
+    func tokens(for origin: String) -> TokenPair? { values[origin] }
+    func setTokens(_ tokens: TokenPair, for origin: String) { values[origin] = tokens }
+    func clearTokens(for origin: String) { values.removeValue(forKey: origin) }
+}
+
+private final class ProfileTestCatalogPersistence: ServerCatalogPersisting, @unchecked Sendable {
+    private var data: Data?
+
+    func readCatalogData() throws -> Data? { data }
+    func writeCatalogData(_ data: Data) throws { self.data = data }
+}
+
+private final class ProfileTestCacheBackend: OfflineCacheBacking, @unchecked Sendable {
+    private var rows: [String: Data] = [:]
+    private var enabled = false
+
+    func listRowKeys(limit: Int) throws -> [String] { Array(rows.keys.sorted().prefix(limit)) }
+    func readRow(key: String) throws -> Data? { rows[key] }
+    func writeRow(_ data: Data, key: String) throws { rows[key] = data }
+    func deleteRow(key: String) throws { rows.removeValue(forKey: key) }
+    func readTranscriptCachingEnabled() -> Bool { enabled }
+    func writeTranscriptCachingEnabled(_ enabled: Bool) throws { self.enabled = enabled }
+}
+
+private struct ProfileTestCacheCipher: OfflineCacheCrypting {
+    func seal(_ plaintext: Data, authenticating associatedData: Data) throws -> Data { plaintext }
+    func open(_ ciphertext: Data, authenticating associatedData: Data) throws -> Data { ciphertext }
+}

--- a/ios/MercuryTests/StartupConnectionTests.swift
+++ b/ios/MercuryTests/StartupConnectionTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import XCTest
+@testable import Mercury
+
+final class StartupConnectionTests: XCTestCase {
+    func testChoiceStoreRoundTripsTypedDirectAndRelayIdentity() async throws {
+        let persistence = MemoryStartupChoicePersistence()
+        let store = StartupConnectionChoiceStore(persistence: persistence)
+        let direct = StartupConnectionIdentity(kind: .direct, id: UUID(uuidString: "00000000-0000-0000-0000-000000000101")!)
+        let relay = StartupConnectionIdentity(kind: .relay, id: UUID(uuidString: "00000000-0000-0000-0000-000000000202")!)
+
+        try await store.save(direct)
+        let restoredDirect = try await store.load()
+        XCTAssertEqual(restoredDirect, direct)
+
+        try await store.save(relay)
+        let restoredRelay = try await store.load()
+        XCTAssertEqual(restoredRelay, relay)
+    }
+
+    func testChoiceStoreContainsNoOriginOrRelayKeyMaterial() async throws {
+        let persistence = MemoryStartupChoicePersistence()
+        let store = StartupConnectionChoiceStore(persistence: persistence)
+        let choice = StartupConnectionIdentity(
+            kind: .direct,
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000303")!
+        )
+
+        try await store.save(choice)
+
+        let raw = try XCTUnwrap(persistence.data)
+        XCTAssertFalse(raw.contains(Data("https://hermes.example".utf8)))
+        XCTAssertFalse(raw.contains(Data("private-key".utf8)))
+        XCTAssertFalse(raw.contains(Data("relay-token".utf8)))
+        XCTAssertTrue(raw.contains(Data("direct".utf8)))
+    }
+
+    func testValidSavedChoiceRestoresOnlyThatConfiguredTarget() {
+        let direct = StartupConnectionCandidate(
+            identity: StartupConnectionIdentity(
+                kind: .direct,
+                id: UUID(uuidString: "00000000-0000-0000-0000-000000000401")!
+            ),
+            isUsable: true
+        )
+        let relay = StartupConnectionCandidate(
+            identity: StartupConnectionIdentity(
+                kind: .relay,
+                id: UUID(uuidString: "00000000-0000-0000-0000-000000000402")!
+            ),
+            isUsable: true
+        )
+
+        let decision = StartupConnectionDecisionPolicy.decide(
+            candidates: [direct, relay],
+            lastSuccessful: relay.identity
+        )
+
+        XCTAssertEqual(decision.action, .autoConnect)
+        XCTAssertEqual(decision.selected, relay.identity)
+        XCTAssertFalse(decision.savedChoiceUnavailable)
+    }
+
+    func testUnavailableSavedChoiceShowsPickerInsteadOfSilentlyConnectingAnotherHost() {
+        let available = StartupConnectionCandidate(
+            identity: StartupConnectionIdentity(
+                kind: .direct,
+                id: UUID(uuidString: "00000000-0000-0000-0000-000000000501")!
+            ),
+            isUsable: true
+        )
+        let removed = StartupConnectionIdentity(
+            kind: .relay,
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000599")!
+        )
+
+        let decision = StartupConnectionDecisionPolicy.decide(
+            candidates: [available],
+            lastSuccessful: removed
+        )
+
+        XCTAssertEqual(decision.action, .chooseTarget)
+        XCTAssertNil(decision.selected)
+        XCTAssertTrue(decision.savedChoiceUnavailable)
+    }
+
+    func testPendingRelayIsVisibleButNeverSelectedForAutostart() {
+        let pending = StartupConnectionCandidate(
+            identity: StartupConnectionIdentity(
+                kind: .relay,
+                id: UUID(uuidString: "00000000-0000-0000-0000-000000000601")!
+            ),
+            isUsable: false
+        )
+
+        let decision = StartupConnectionDecisionPolicy.decide(
+            candidates: [pending],
+            lastSuccessful: nil
+        )
+
+        XCTAssertEqual(decision.action, .chooseTarget)
+        XCTAssertNil(decision.selected)
+    }
+
+    func testMultipleConfiguredTargetsIncludingPendingRelayShowPicker() {
+        let direct = StartupConnectionCandidate(
+            identity: StartupConnectionIdentity(
+                kind: .direct,
+                id: UUID(uuidString: "00000000-0000-0000-0000-000000000701")!
+            ),
+            isUsable: true
+        )
+        let pending = StartupConnectionCandidate(
+            identity: StartupConnectionIdentity(
+                kind: .relay,
+                id: UUID(uuidString: "00000000-0000-0000-0000-000000000702")!
+            ),
+            isUsable: false
+        )
+
+        let decision = StartupConnectionDecisionPolicy.decide(
+            candidates: [direct, pending],
+            lastSuccessful: nil
+        )
+
+        XCTAssertEqual(decision.action, .chooseTarget)
+        XCTAssertNil(decision.selected)
+        XCTAssertFalse(decision.savedChoiceUnavailable)
+    }
+
+    func testNoSavedChoiceWithOneUsableTargetAutoConnects() {
+        let direct = StartupConnectionCandidate(
+            identity: StartupConnectionIdentity(
+                kind: .direct,
+                id: UUID(uuidString: "00000000-0000-0000-0000-000000000703")!
+            ),
+            isUsable: true
+        )
+
+        let decision = StartupConnectionDecisionPolicy.decide(
+            candidates: [direct],
+            lastSuccessful: nil
+        )
+
+        XCTAssertEqual(decision.action, .autoConnect)
+        XCTAssertEqual(decision.selected, direct.identity)
+    }
+
+    func testNoTargetsUsesFirstRunOnboarding() {
+        let decision = StartupConnectionDecisionPolicy.decide(candidates: [], lastSuccessful: nil)
+
+        XCTAssertEqual(decision.action, .onboarding)
+        XCTAssertNil(decision.selected)
+    }
+}
+
+final class MemoryStartupChoicePersistence: StartupConnectionChoicePersisting, @unchecked Sendable {
+    var data: Data?
+
+    func readStartupChoiceData() throws -> Data? { data }
+    func writeStartupChoiceData(_ data: Data) throws { self.data = data }
+    func clearStartupChoiceData() { data = nil }
+}

--- a/ios/MercuryUITests/StartupConnectionUITests.swift
+++ b/ios/MercuryUITests/StartupConnectionUITests.swift
@@ -1,0 +1,55 @@
+import XCTest
+
+final class StartupConnectionUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    private func launch(_ fixture: String) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitest-reset-local-state", fixture]
+        app.launch()
+        return app
+    }
+
+    func testFirstRunWithoutTargetsShowsAddressOnboarding() {
+        let app = launch("-uitest-startup-empty")
+
+        XCTAssertTrue(app.staticTexts["Connect to Hermes"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.textFields.firstMatch.exists)
+        XCTAssertTrue(app.staticTexts["Server address"].exists)
+        XCTAssertTrue(app.buttons["Continue"].exists)
+        XCTAssertFalse(app.buttons["Continue"].isEnabled)
+        capture("startup-first-run", app: app)
+    }
+
+    func testMultipleConfiguredTargetsShowUnifiedPickerWithoutAutoconnect() {
+        let app = launch("-uitest-startup-multiple")
+
+        XCTAssertTrue(app.staticTexts["Choose a connection"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Direct test server"].exists)
+        XCTAssertTrue(app.staticTexts["Pending relay test"].exists)
+        XCTAssertTrue(app.staticTexts["Waiting for host approval"].exists)
+        XCTAssertFalse(app.staticTexts["Mercury"].exists)
+        capture("startup-connection-picker", app: app)
+    }
+
+    func testFailedLastChoiceOffersRetryAndExplicitChooseAnother() {
+        let app = launch("-uitest-startup-failed")
+
+        XCTAssertTrue(app.staticTexts["Could not connect to the last server."].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Retry"].exists)
+        XCTAssertTrue(app.buttons["Choose another"].exists)
+
+        app.buttons["Choose another"].tap()
+        XCTAssertTrue(app.staticTexts["Choose a connection"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Direct test server"].exists)
+    }
+
+    private func capture(_ name: String, app: XCUIApplication) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/ios/MercuryUITests/StartupFlowEndToEndUITests.swift
+++ b/ios/MercuryUITests/StartupFlowEndToEndUITests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import XCTest
+
+/// Bounded startup/UI regression coverage against the opt-in fake Hermes
+/// scenario. The ordinary UI-test scheme stays hermetic when the scenario is
+/// not requested.
+///
+/// Run the harness with a fake backend started as:
+///   FAKE_HERMES_SCENARIO=ios-startup python3 tools/fake-hermes/fake_hermes.py 8787
+/// and the UI tests as:
+///   FAKE_HERMES_SCENARIO=ios-startup FAKE_HERMES_ORIGIN=http://127.0.0.1:8787 xcodebuild …
+final class StartupFlowEndToEndUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testHomeChromeShowsProfilesLeftSearchAndSettingsRightWithoutHostFiles() throws {
+        let app = try launchConnectedApp()
+
+        let profile = app.buttons["Profile: default"]
+        let search = app.buttons["Search sessions"]
+        let settings = app.buttons["Settings"]
+        XCTAssertTrue(profile.waitForExistence(timeout: 30), app.debugDescription)
+        XCTAssertTrue(search.waitForExistence(timeout: 10), app.debugDescription)
+        XCTAssertTrue(settings.waitForExistence(timeout: 10), app.debugDescription)
+        XCTAssertLessThan(profile.frame.midX, search.frame.midX, "profile must stay on the leading side")
+        XCTAssertLessThan(search.frame.midX, settings.frame.midX, "search must precede settings on the trailing side")
+        XCTAssertGreaterThan(search.frame.midX, app.navigationBars["Mercury"].frame.midX)
+        capture("startup-home-toolbar", app: app)
+
+        profile.tap()
+        let defaultChoice = app.descendants(matching: .any).matching(
+            NSPredicate(format: "label == %@", "default")
+        ).firstMatch
+        let workChoice = app.descendants(matching: .any).matching(
+            NSPredicate(format: "label == %@", "work")
+        ).firstMatch
+        XCTAssertTrue(defaultChoice.waitForExistence(timeout: 10), app.debugDescription)
+        XCTAssertTrue(workChoice.waitForExistence(timeout: 10), app.debugDescription)
+        capture("startup-profiles", app: app)
+        workChoice.tap()
+        XCTAssertTrue(app.staticTexts["Work Session"].waitForExistence(timeout: 30), app.debugDescription)
+
+        let hostFiles = app.descendants(matching: .any).matching(
+            NSPredicate(format: "label CONTAINS[c] %@", "Host files")
+        ).firstMatch
+        XCTAssertFalse(hostFiles.exists, "the home toolbar must not expose Host files")
+
+        settings.tap()
+        let servers = app.staticTexts["Servers"]
+        XCTAssertTrue(servers.waitForExistence(timeout: 10), app.debugDescription)
+        servers.tap()
+        XCTAssertTrue(app.navigationBars["Servers"].waitForExistence(timeout: 10), app.debugDescription)
+        capture("startup-settings-servers", app: app)
+        let settingsBack = app.navigationBars["Servers"].buttons["Settings"]
+        XCTAssertTrue(settingsBack.waitForExistence(timeout: 5), "Servers must retain native Back navigation")
+        settingsBack.tap()
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 5))
+    }
+
+    func testProjectsAddBrowseCreateSelectFolderAndExposeBack() throws {
+        let app = try launchConnectedApp()
+        let viewAll = app.buttons["View all projects"]
+        XCTAssertTrue(viewAll.waitForExistence(timeout: 30), app.debugDescription)
+        viewAll.tap()
+
+        let projectsNavigationBar = app.navigationBars["Projects"]
+        XCTAssertTrue(projectsNavigationBar.waitForExistence(timeout: 20), app.debugDescription)
+        let createProject = app.buttons["Create project"]
+        XCTAssertTrue(createProject.waitForExistence(timeout: 10), app.debugDescription)
+        createProject.tap()
+
+        XCTAssertTrue(app.navigationBars["New Project"].waitForExistence(timeout: 10), app.debugDescription)
+        let projectSuffix = String(UUID().uuidString.prefix(8)).lowercased()
+        let projectName = "Startup UI Project \(projectSuffix)"
+        let folderName = "ios-startup-\(projectSuffix)"
+
+        let name = app.textFields["Name"]
+        XCTAssertTrue(name.waitForExistence(timeout: 10), app.debugDescription)
+        name.tap()
+        name.typeText(projectName)
+
+        let chooseFolder = app.buttons["Browse server folders"]
+        XCTAssertTrue(chooseFolder.waitForExistence(timeout: 10), app.debugDescription)
+        chooseFolder.tap()
+
+        XCTAssertTrue(app.navigationBars["Host Files"].waitForExistence(timeout: 20), app.debugDescription)
+        let filesBack = app.navigationBars["Host Files"].buttons["Back"]
+        XCTAssertTrue(filesBack.waitForExistence(timeout: 10), app.debugDescription)
+        XCTAssertLessThan(filesBack.frame.midX, app.navigationBars["Host Files"].frame.midX)
+        capture("startup-host-files", app: app)
+        filesBack.tap()
+        XCTAssertTrue(app.navigationBars["New Project"].waitForExistence(timeout: 10), app.debugDescription)
+        chooseFolder.tap()
+        let workspace = app.buttons["workspace"]
+        XCTAssertTrue(workspace.waitForExistence(timeout: 20), app.debugDescription)
+        workspace.tap()
+
+        let createFolder = app.buttons["Create folder"]
+        XCTAssertTrue(createFolder.waitForExistence(timeout: 10), app.debugDescription)
+        createFolder.tap()
+        let folderNameField = app.textFields["Folder name"]
+        XCTAssertTrue(folderNameField.waitForExistence(timeout: 10), app.debugDescription)
+        folderNameField.typeText(folderName)
+        app.alerts["Create Folder"].buttons["Create"].tap()
+
+        let selectedPath = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS %@", folderName)
+        ).firstMatch
+        XCTAssertTrue(selectedPath.waitForExistence(timeout: 20), app.debugDescription)
+        capture("startup-created-folder", app: app)
+        let chooseThisFolder = app.buttons["Choose this folder"]
+        XCTAssertTrue(chooseThisFolder.waitForExistence(timeout: 10), app.debugDescription)
+        chooseThisFolder.tap()
+
+        XCTAssertTrue(app.navigationBars["New Project"].waitForExistence(timeout: 10), app.debugDescription)
+        let create = app.navigationBars["New Project"].buttons["Create"]
+        XCTAssertTrue(create.waitForExistence(timeout: 10), app.debugDescription)
+        XCTAssertTrue(create.isEnabled, app.debugDescription)
+        create.tap()
+
+        XCTAssertTrue(projectsNavigationBar.waitForExistence(timeout: 20), app.debugDescription)
+        XCTAssertTrue(app.staticTexts[projectName].waitForExistence(timeout: 20), app.debugDescription)
+        let back = app.buttons["Back"]
+        XCTAssertTrue(back.waitForExistence(timeout: 10), app.debugDescription)
+        XCTAssertLessThan(back.frame.midX, projectsNavigationBar.frame.midX, "Projects Back must be top-left")
+        back.tap()
+        XCTAssertTrue(app.navigationBars["Mercury"].waitForExistence(timeout: 20), app.debugDescription)
+    }
+
+    func testExistingSessionAcceptsTwoConsecutiveTurnsWithoutReopen() throws {
+        let app = try launchConnectedApp()
+        let session = app.staticTexts["E2E Session"]
+        XCTAssertTrue(session.waitForExistence(timeout: 30), app.debugDescription)
+        session.tap()
+
+        let suffix = UUID().uuidString
+        send("first startup turn \(suffix)", expect: "First startup response", in: app)
+        send("second startup turn \(suffix)", expect: "Second startup response", in: app)
+        let context = app.buttons.matching(identifier: "Open session details")
+        XCTAssertTrue(context.firstMatch.waitForExistence(timeout: 5))
+        XCTAssertEqual(context.count, 1, "Only the composer context control should remain")
+        XCTAssertFalse(app.navigationBars.buttons["Open session details"].exists)
+        capture("startup-two-turn-chat", app: app)
+    }
+
+    func testDelayedFirstAckDoesNotBlockSecondTurnOrRestoreFirstDraft() throws {
+        let app = try launchConnectedApp(requireDelayedPromptAck: true)
+        let session = app.staticTexts["E2E Session"]
+        XCTAssertTrue(session.waitForExistence(timeout: 30), app.debugDescription)
+        session.tap()
+
+        let composer = app.textFields["Message Hermes"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 30), app.debugDescription)
+        let suffix = UUID().uuidString
+        let firstDraft = "first delayed turn \(suffix)"
+        let secondDraft = "second delayed turn \(suffix)"
+        composer.tap()
+        composer.typeText(firstDraft)
+        let send = app.buttons["Send message"]
+        XCTAssertTrue(send.waitForExistence(timeout: 10), app.debugDescription)
+        send.tap()
+
+        // The startup fake releases message.complete before prompt.submit's
+        // first response. Sending immediately after the final reply keeps the
+        // first request's ACK outstanding while the second request is made.
+        let first = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS %@", "First startup response: \(firstDraft)")
+        ).firstMatch
+        XCTAssertTrue(first.waitForExistence(timeout: 30), app.debugDescription)
+
+        composer.tap()
+        composer.typeText(secondDraft)
+        XCTAssertTrue(send.isEnabled, "the late first ACK must not keep the second send disabled")
+        send.tap()
+
+        let second = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS %@", "Second startup response: \(secondDraft)")
+        ).firstMatch
+        XCTAssertTrue(second.waitForExistence(timeout: 30), app.debugDescription)
+        let draft = (composer.value as? String) ?? ""
+        XCTAssertFalse(draft.contains(firstDraft), "a late first response restored the accepted draft")
+        XCTAssertFalse(app.staticTexts["Send failed — check the connection and try again."].exists)
+        capture("startup-delayed-ack-chat", app: app)
+    }
+
+    @discardableResult
+    private func launchConnectedApp(requireDelayedPromptAck: Bool = false) throws -> XCUIApplication {
+        guard let origin = ProcessInfo.processInfo.environment["FAKE_HERMES_ORIGIN"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !origin.isEmpty else {
+            throw XCTSkip("FAKE_HERMES_ORIGIN not set; startup fake UI tests not requested")
+        }
+        let environment = ProcessInfo.processInfo.environment
+        let scenario = environment["FAKE_HERMES_SCENARIO"]?.lowercased()
+        guard scenario == "ios-startup"
+                || scenario == "startup"
+                || scenario == "startup-flow"
+                || scenario == "startup_flow"
+                || environment["FAKE_HERMES_STARTUP"] == "1" else {
+            throw XCTSkip("Set FAKE_HERMES_SCENARIO=ios-startup to run startup fake UI tests")
+        }
+        if requireDelayedPromptAck {
+            guard environment["FAKE_HERMES_DELAY_FIRST_PROMPT_ACK"] == "1" else {
+                throw XCTSkip("Set FAKE_HERMES_DELAY_FIRST_PROMPT_ACK=1 for the delayed-ACK UI regression")
+            }
+        }
+
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitest-reset-local-state", "-uitest-probe", origin]
+        app.launch()
+
+        // Cookies are deliberately preserved between app launches. A prior
+        // test's still-valid fixture login may go straight to the home list.
+        if app.staticTexts["E2E Session"].waitForExistence(timeout: 3) { return app }
+        let passwordButton = app.buttons["Sign in with username and password"]
+        XCTAssertTrue(passwordButton.waitForExistence(timeout: 30), app.debugDescription)
+        passwordButton.tap()
+        let username = app.textFields["Username"]
+        XCTAssertTrue(username.waitForExistence(timeout: 10), app.debugDescription)
+        username.tap()
+        username.typeText("admin")
+        let password = app.secureTextFields["Password"]
+        XCTAssertTrue(password.waitForExistence(timeout: 10), app.debugDescription)
+        password.tap()
+        password.typeText("e2epass")
+        app.buttons["Sign in"].tap()
+
+        XCTAssertTrue(app.staticTexts["E2E Session"].waitForExistence(timeout: 30), app.debugDescription)
+        return app
+    }
+
+    private func send(_ text: String, expect response: String, in app: XCUIApplication) {
+        let composer = app.textFields["Message Hermes"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 30), app.debugDescription)
+        composer.tap()
+        composer.typeText(text)
+        let send = app.buttons["Send message"]
+        XCTAssertTrue(send.waitForExistence(timeout: 10), app.debugDescription)
+        send.tap()
+
+        let assistant = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS %@", "\(response): \(text)")
+        ).firstMatch
+        XCTAssertTrue(assistant.waitForExistence(timeout: 30), app.debugDescription)
+    }
+
+    private func capture(_ name: String, app: XCUIApplication) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -59,6 +59,17 @@ Version numbers come from `project.yml` (`MARKETING_VERSION`,
 
 ## Notes
 
+- Startup restores the last successfully used direct server or relay. With no
+  saved choice, one usable configured connection starts automatically; multiple
+  configured connections show a picker. A failed or unavailable saved choice
+  never silently switches to another host. Settings → Servers lists both kinds.
+- Project folders can be browsed and created over a direct connection, within
+  the host's managed-files permissions. The current Relay contract does not
+  expose folder browsing or creation; an existing host folder can instead be
+  entered by path for project registration, with validation by the host.
+- These native startup/toolbar changes are iOS-scoped. Android's corresponding
+  native UI changes are deferred rather than changing its navigation as part of
+  the reported iOS fixes. Shared profile-name policy is consumed by both clients.
 - Native UI, networking, and secure storage use Apple frameworks; the shared
   KMP core uses `cryptography-kotlin`'s CryptoKit provider for Relay primitives.
 - Minimum deployment target: iOS 17.0.

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/connection/StartupConnectionPolicy.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/connection/StartupConnectionPolicy.kt
@@ -1,0 +1,100 @@
+package com.unsupportedpastels.mercury.core.connection
+
+/** The two persisted startup connection namespaces. */
+enum class StartupConnectionKind {
+    DIRECT,
+    RELAY,
+}
+
+/**
+ * Secret-free configured target projection used by startup selection.
+ *
+ * The id is an app-local catalog/pairing identifier. Origins, cookies, tokens,
+ * and relay key material deliberately never enter this policy.
+ */
+data class StartupConnectionTarget(
+    val kind: StartupConnectionKind,
+    val id: String,
+    val usable: Boolean,
+)
+
+/** A typed, secret-free last-successful identity. */
+data class StartupConnectionChoice(
+    val kind: StartupConnectionKind,
+    val id: String,
+)
+
+enum class StartupConnectionAction {
+    ONBOARDING,
+    AUTO_CONNECT,
+    SHOW_PICKER,
+}
+
+data class StartupConnectionDecision(
+    val action: StartupConnectionAction,
+    val selected: StartupConnectionChoice?,
+    val savedChoiceUnavailable: Boolean,
+)
+
+/**
+ * Pure startup selection policy shared by Android and iOS.
+ *
+ * Rules:
+ * - no configured rows means first-run onboarding;
+ * - a valid saved successful identity is the only automatic choice;
+ * - without a saved identity, exactly one usable target may autostart;
+ * - pending/unusable relay rows are never selected for autostart;
+ * - a missing, removed, or pending saved identity opens the picker instead of
+ *   silently falling back to another host.
+ */
+object StartupConnectionPolicy {
+    fun decide(
+        targets: List<StartupConnectionTarget>,
+        lastSuccessful: StartupConnectionChoice?,
+    ): StartupConnectionDecision {
+        val uniqueTargets = targets
+            .asSequence()
+            .filter { it.id.isNotBlank() }
+            .distinctBy { it.kind to it.id }
+            .toList()
+        val usable = uniqueTargets.filter { it.usable }
+
+        if (lastSuccessful != null) {
+            val matching = usable.firstOrNull {
+                it.kind == lastSuccessful.kind && it.id == lastSuccessful.id
+            }
+            if (matching != null) {
+                return StartupConnectionDecision(
+                    action = StartupConnectionAction.AUTO_CONNECT,
+                    selected = lastSuccessful,
+                    savedChoiceUnavailable = false,
+                )
+            }
+            return StartupConnectionDecision(
+                action = StartupConnectionAction.SHOW_PICKER,
+                selected = null,
+                savedChoiceUnavailable = true,
+            )
+        }
+
+        return when {
+            uniqueTargets.isEmpty() -> StartupConnectionDecision(
+                action = StartupConnectionAction.ONBOARDING,
+                selected = null,
+                savedChoiceUnavailable = false,
+            )
+            uniqueTargets.size == 1 && usable.size == 1 -> StartupConnectionDecision(
+                action = StartupConnectionAction.AUTO_CONNECT,
+                selected = usable.single().let {
+                    StartupConnectionChoice(kind = it.kind, id = it.id)
+                },
+                savedChoiceUnavailable = false,
+            )
+            else -> StartupConnectionDecision(
+                action = StartupConnectionAction.SHOW_PICKER,
+                selected = null,
+                savedChoiceUnavailable = false,
+            )
+        }
+    }
+}

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/profiles/ProfileCatalogPolicy.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/profiles/ProfileCatalogPolicy.kt
@@ -1,0 +1,43 @@
+package com.unsupportedpastels.mercury.core.profiles
+
+/**
+ * Pure profile-name bounds shared by the native clients.
+ *
+ * Hermes exposes the same catalog through two official transports with
+ * intentionally different legacy decoder behavior. REST trims names and
+ * accepts any nonblank value up to 64 UTF-16 code units, while the gateway
+ * JSON-RPC adapter admits only the existing lowercase ASCII profile grammar.
+ * Keep the modes explicit so one transport cannot silently tighten or loosen
+ * the other.
+ */
+object ProfileCatalogPolicy {
+    const val maxProfileCharacters = 64
+    const val maxRestProfiles = 32
+    const val maxRpcProfiles = 64
+
+    /** REST `/api/profiles` semantics: trim, bound, deduplicate, then cap. */
+    fun sanitizeRestNames(names: List<String>): List<String> =
+        names.asSequence()
+            .map(String::trim)
+            .filter { it.isNotEmpty() && it.length <= maxProfileCharacters }
+            .distinct()
+            .take(maxRestProfiles)
+            .toList()
+
+    /** `profiles.list` JSON-RPC semantics: exact lowercase ASCII grammar. */
+    fun sanitizeRpcNames(names: List<String>): List<String> =
+        names.asSequence()
+            .filter(::isValidRpcName)
+            .distinct()
+            .take(maxRpcProfiles)
+            .toList()
+
+    fun isValidRpcName(name: String): Boolean {
+        if (name.length !in 1..maxProfileCharacters) return false
+        if (!isAsciiLowerOrDigit(name.first())) return false
+        return name.drop(1).all { isAsciiLowerOrDigit(it) || it == '_' || it == '-' }
+    }
+
+    private fun isAsciiLowerOrDigit(value: Char): Boolean =
+        value in 'a'..'z' || value in '0'..'9'
+}

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/PromptSubmissionPolicy.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/PromptSubmissionPolicy.kt
@@ -1,0 +1,43 @@
+package com.unsupportedpastels.mercury.core.transcript
+
+/**
+ * Deterministic decisions for the client-side prompt admission lifecycle.
+ *
+ * Hermes can publish an authoritative terminal event before the correlated
+ * prompt.submit response reaches the client. Once that terminal event is
+ * observed, the composer admission gate may be released, but a later failed
+ * acknowledgement must not restore the already-admitted draft. The native
+ * clients own attempt identity and lifecycle storage; this object owns only
+ * the cross-platform decision table.
+ */
+enum class PromptSubmissionDecision {
+    /** The event authoritatively ended an awaiting submission; release the gate. */
+    RELEASE_PENDING,
+
+    /** The acknowledgement accepted the prompt; keep the draft cleared. */
+    ACCEPTED,
+
+    /** The acknowledgement failed before any authoritative terminal event. */
+    RESTORE_DRAFT,
+
+    /** A stale/late callback has no state or draft effect. */
+    IGNORE,
+}
+
+object PromptSubmissionPolicy {
+    fun onTerminalEvent(awaitingAcceptance: Boolean): PromptSubmissionDecision =
+        if (awaitingAcceptance) {
+            PromptSubmissionDecision.RELEASE_PENDING
+        } else {
+            PromptSubmissionDecision.IGNORE
+        }
+
+    fun onAcknowledgement(
+        authoritativeTerminal: Boolean,
+        accepted: Boolean,
+    ): PromptSubmissionDecision = when {
+        accepted -> PromptSubmissionDecision.ACCEPTED
+        authoritativeTerminal -> PromptSubmissionDecision.IGNORE
+        else -> PromptSubmissionDecision.RESTORE_DRAFT
+    }
+}

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/connection/StartupConnectionPolicyTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/connection/StartupConnectionPolicyTest.kt
@@ -1,0 +1,114 @@
+package com.unsupportedpastels.mercury.core.connection
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class StartupConnectionPolicyTest {
+    private fun target(
+        kind: StartupConnectionKind,
+        id: String,
+        usable: Boolean = true,
+    ) = StartupConnectionTarget(kind = kind, id = id, usable = usable)
+
+    private fun choice(kind: StartupConnectionKind, id: String) =
+        StartupConnectionChoice(kind = kind, id = id)
+
+    @Test
+    fun noConfiguredTargetsShowsOnboarding() {
+        val decision = StartupConnectionPolicy.decide(emptyList(), null)
+
+        assertEquals(StartupConnectionAction.ONBOARDING, decision.action)
+        assertNull(decision.selected)
+        assertFalse(decision.savedChoiceUnavailable)
+    }
+
+    @Test
+    fun oneUsableTargetWithoutSavedChoiceAutoConnects() {
+        val target = target(StartupConnectionKind.DIRECT, "direct-1")
+
+        val decision = StartupConnectionPolicy.decide(listOf(target), null)
+
+        assertEquals(StartupConnectionAction.AUTO_CONNECT, decision.action)
+        assertEquals(StartupConnectionChoice(StartupConnectionKind.DIRECT, "direct-1"), decision.selected)
+        assertFalse(decision.savedChoiceUnavailable)
+    }
+
+    @Test
+    fun multipleUsableTargetsShowPicker() {
+        val targets = listOf(
+            target(StartupConnectionKind.DIRECT, "direct-1"),
+            target(StartupConnectionKind.RELAY, "relay-1"),
+        )
+
+        val decision = StartupConnectionPolicy.decide(targets, null)
+
+        assertEquals(StartupConnectionAction.SHOW_PICKER, decision.action)
+        assertNull(decision.selected)
+        assertFalse(decision.savedChoiceUnavailable)
+    }
+
+    @Test
+    fun validSavedChoiceConnectsOnlyThatChoice() {
+        val saved = choice(StartupConnectionKind.RELAY, "relay-1")
+        val targets = listOf(
+            target(StartupConnectionKind.DIRECT, "direct-1"),
+            target(StartupConnectionKind.RELAY, "relay-1"),
+        )
+
+        val decision = StartupConnectionPolicy.decide(targets, saved)
+
+        assertEquals(StartupConnectionAction.AUTO_CONNECT, decision.action)
+        assertEquals(saved, decision.selected)
+        assertFalse(decision.savedChoiceUnavailable)
+    }
+
+    @Test
+    fun unavailableSavedChoiceNeverFallsBackToAnotherTarget() {
+        val saved = choice(StartupConnectionKind.DIRECT, "removed-direct")
+        val targets = listOf(target(StartupConnectionKind.RELAY, "other-relay"))
+
+        val decision = StartupConnectionPolicy.decide(targets, saved)
+
+        assertEquals(StartupConnectionAction.SHOW_PICKER, decision.action)
+        assertNull(decision.selected)
+        assertTrue(decision.savedChoiceUnavailable)
+    }
+
+    @Test
+    fun pendingRelayIsVisibleToPickerButNeverUsableForAutostart() {
+        val pending = target(StartupConnectionKind.RELAY, "pending-relay", usable = false)
+
+        val decision = StartupConnectionPolicy.decide(listOf(pending), null)
+
+        assertEquals(StartupConnectionAction.SHOW_PICKER, decision.action)
+        assertNull(decision.selected)
+        assertFalse(decision.savedChoiceUnavailable)
+    }
+
+    @Test
+    fun savedPendingRelayDoesNotAutoConnect() {
+        val saved = choice(StartupConnectionKind.RELAY, "pending-relay")
+        val pending = target(StartupConnectionKind.RELAY, "pending-relay", usable = false)
+
+        val decision = StartupConnectionPolicy.decide(listOf(pending), saved)
+
+        assertEquals(StartupConnectionAction.SHOW_PICKER, decision.action)
+        assertNull(decision.selected)
+        assertTrue(decision.savedChoiceUnavailable)
+    }
+
+    @Test
+    fun multipleConfiguredTargetsIncludingPendingRelayShowPicker() {
+        val direct = target(StartupConnectionKind.DIRECT, "direct-1")
+        val pending = target(StartupConnectionKind.RELAY, "pending-relay", usable = false)
+
+        val decision = StartupConnectionPolicy.decide(listOf(direct, pending), null)
+
+        assertEquals(StartupConnectionAction.SHOW_PICKER, decision.action)
+        assertNull(decision.selected)
+        assertFalse(decision.savedChoiceUnavailable)
+    }
+}

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/profiles/ProfileCatalogPolicyTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/profiles/ProfileCatalogPolicyTest.kt
@@ -1,0 +1,57 @@
+package com.unsupportedpastels.mercury.core.profiles
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProfileCatalogPolicyTest {
+    private val policy = ProfileCatalogPolicy
+
+    @Test
+    fun restNamesPreserveTrimmedLegacySemanticsWithBoundsAndOrder() {
+        val names = policy.sanitizeRestNames(
+            listOf(" default ", "work", "work", "", "   ", "../invalid", "A profile")
+        )
+
+        assertEquals(listOf("default", "work", "../invalid", "A profile"), names)
+    }
+
+    @Test
+    fun restNamesCapAfterFilteringAndDeduplication() {
+        val names = policy.sanitizeRestNames(
+            (0 until policy.maxRestProfiles + 2).map { "profile-$it" } + "profile-0"
+        )
+
+        assertEquals(policy.maxRestProfiles, names.size)
+        assertEquals("profile-0", names.first())
+        assertEquals("profile-${policy.maxRestProfiles - 1}", names.last())
+    }
+
+    @Test
+    fun rpcNamesUseExactLowercaseProfileGrammar() {
+        val names = policy.sanitizeRpcNames(
+            listOf("default", "work", "work", "Work", "../invalid", "has space", "ok_name", "ok-name")
+        )
+
+        assertEquals(listOf("default", "work", "ok_name", "ok-name"), names)
+        assertTrue(policy.isValidRpcName("a"))
+        assertTrue(policy.isValidRpcName("a0_b-c"))
+        assertFalse(policy.isValidRpcName("_leading"))
+        assertFalse(policy.isValidRpcName("-leading"))
+        assertFalse(policy.isValidRpcName("A"))
+        assertFalse(policy.isValidRpcName("a.b"))
+        assertFalse(policy.isValidRpcName("a b"))
+    }
+
+    @Test
+    fun rpcNamesCapWithoutChangingAdmissionOrder() {
+        val names = policy.sanitizeRpcNames(
+            (0 until policy.maxRpcProfiles + 2).map { "p$it" } + "p0"
+        )
+
+        assertEquals(policy.maxRpcProfiles, names.size)
+        assertEquals("p0", names.first())
+        assertEquals("p${policy.maxRpcProfiles - 1}", names.last())
+    }
+}

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/PromptSubmissionPolicyTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/PromptSubmissionPolicyTest.kt
@@ -1,0 +1,55 @@
+package com.unsupportedpastels.mercury.core.transcript
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PromptSubmissionPolicyTest {
+    @Test
+    fun terminalWhileAwaitingAcceptanceReleasesPendingGate() {
+        assertEquals(
+            PromptSubmissionDecision.RELEASE_PENDING,
+            PromptSubmissionPolicy.onTerminalEvent(awaitingAcceptance = true),
+        )
+    }
+
+    @Test
+    fun terminalWithoutAwaitingSubmissionHasNoEffect() {
+        assertEquals(
+            PromptSubmissionDecision.IGNORE,
+            PromptSubmissionPolicy.onTerminalEvent(awaitingAcceptance = false),
+        )
+    }
+
+    @Test
+    fun acceptedAcknowledgementKeepsDraftClearedEvenAfterTerminal() {
+        assertEquals(
+            PromptSubmissionDecision.ACCEPTED,
+            PromptSubmissionPolicy.onAcknowledgement(
+                authoritativeTerminal = true,
+                accepted = true,
+            ),
+        )
+    }
+
+    @Test
+    fun failedAcknowledgementBeforeTerminalRestoresDraft() {
+        assertEquals(
+            PromptSubmissionDecision.RESTORE_DRAFT,
+            PromptSubmissionPolicy.onAcknowledgement(
+                authoritativeTerminal = false,
+                accepted = false,
+            ),
+        )
+    }
+
+    @Test
+    fun failedAcknowledgementAfterTerminalDoesNotRestoreDraft() {
+        assertEquals(
+            PromptSubmissionDecision.IGNORE,
+            PromptSubmissionPolicy.onAcknowledgement(
+                authoritativeTerminal = true,
+                accepted = false,
+            ),
+        )
+    }
+}

--- a/tools/fake-hermes/fake_hermes.py
+++ b/tools/fake-hermes/fake_hermes.py
@@ -45,15 +45,286 @@ WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 VIDEO_FIXTURE_FILE = os.environ.get("MERCURY_E2E_VIDEO_FILE")
 VIDEO_MANAGED_PATH = "/tmp/mercury-test-video.mp4"
 
+# The normal fake deliberately keeps the old interrupt-sentinel behavior. The
+# startup scenario is opt-in so existing sentinel/video tests remain unchanged.
+FAKE_HERMES_SCENARIO = os.environ.get("FAKE_HERMES_SCENARIO", "default")
+STARTUP_SCENARIO_NAMES = {"ios-startup", "startup", "startup-flow", "startup_flow"}
+DELAY_FIRST_PROMPT_ACK_ENV = "FAKE_HERMES_DELAY_FIRST_PROMPT_ACK"
+DELAY_FIRST_PROMPT_ACK_SECONDS_ENV = "FAKE_HERMES_DELAY_FIRST_PROMPT_ACK_SECONDS"
+DELAY_FIRST_PROMPT_ERROR_ENV = "FAKE_HERMES_DELAY_FIRST_PROMPT_ERROR"
+STARTUP_DELAYED_ACK_SECONDS = 0.75
+SYNTHETIC_FILESYSTEM_ROOT = "/srv/mercury-e2e"
+SYNTHETIC_WORKSPACE_PATH = SYNTHETIC_FILESYSTEM_ROOT + "/workspace"
+SYNTHETIC_PROFILES = ("default", "work")
+WORK_DURABLE_SESSION_ID = "work-e2e-session-1"
+WORK_SESSION_TITLE = "Work Session"
+STARTUP_RESPONSE_TEXTS = ("First startup response", "Second startup response")
 
-def transcript_messages():
-    if not VIDEO_FIXTURE_FILE:
-        return []
-    return [{"role": "assistant", "content": "Video playback fixture\nMEDIA: " + VIDEO_MANAGED_PATH}]
 
-_lock = threading.Lock()
+# These are deliberately in-memory objects. The startup contract never maps a
+# requested path to the host filesystem and only exposes entries registered here.
+_lock = threading.RLock()
 SESSION_TOKENS = set()      # cookie/bearer values minted by password-login
 WS_TICKETS = {}             # ticket -> expiry epoch seconds (single-use)
+SYNTHETIC_DIRECTORIES = {}
+SYNTHETIC_FILES = {}
+SYNTHETIC_PROJECTS = {}
+SYNTHETIC_ACTIVE_PROJECTS = {}
+SYNTHETIC_TRANSCRIPTS = {}
+
+
+def startup_scenario_enabled():
+    value = os.environ.get("FAKE_HERMES_SCENARIO", FAKE_HERMES_SCENARIO)
+    return value.strip().lower() in STARTUP_SCENARIO_NAMES or os.environ.get("FAKE_HERMES_STARTUP") == "1"
+
+
+def startup_delayed_ack_enabled():
+    """Opt in to the prompt-completion-before-ACK race used by one UI test."""
+    return startup_scenario_enabled() and os.environ.get(DELAY_FIRST_PROMPT_ACK_ENV) == "1"
+
+
+def startup_delayed_ack_seconds():
+    """Return a bounded delay so a malformed test env cannot hang the server."""
+    raw = os.environ.get(DELAY_FIRST_PROMPT_ACK_SECONDS_ENV)
+    try:
+        requested = float(raw) if raw is not None else STARTUP_DELAYED_ACK_SECONDS
+    except (TypeError, ValueError):
+        requested = STARTUP_DELAYED_ACK_SECONDS
+    if not 0.05 <= requested <= 2.0:
+        return STARTUP_DELAYED_ACK_SECONDS
+    return requested
+
+
+def startup_delayed_ack_is_error():
+    """Optionally deliver a fixed late RPC error instead of the ACK."""
+    return startup_delayed_ack_enabled() and os.environ.get(DELAY_FIRST_PROMPT_ERROR_ENV) == "1"
+
+
+def _reset_synthetic_state_locked():
+    global SYNTHETIC_DIRECTORIES, SYNTHETIC_FILES
+    global SYNTHETIC_PROJECTS, SYNTHETIC_ACTIVE_PROJECTS, SYNTHETIC_TRANSCRIPTS
+    SYNTHETIC_DIRECTORIES = {
+        SYNTHETIC_FILESYSTEM_ROOT: {SYNTHETIC_WORKSPACE_PATH},
+        SYNTHETIC_WORKSPACE_PATH: {SYNTHETIC_WORKSPACE_PATH + "/existing"},
+        SYNTHETIC_WORKSPACE_PATH + "/existing": set(),
+    }
+    SYNTHETIC_FILES = {
+        SYNTHETIC_WORKSPACE_PATH + "/README.md": {
+            "content": b"# Mercury startup fixture\n",
+            "mime_type": "text/markdown",
+        },
+    }
+    SYNTHETIC_PROJECTS = {
+        "default": {
+            "existing-project": {
+                "id": "existing-project",
+                "label": "Existing Project",
+                "path": SYNTHETIC_WORKSPACE_PATH,
+                "session_ids": [DURABLE_SESSION_ID],
+            },
+        },
+        "work": {
+            "work-project": {
+                "id": "work-project",
+                "label": "Work Project",
+                "path": SYNTHETIC_WORKSPACE_PATH,
+                "session_ids": [WORK_DURABLE_SESSION_ID],
+            },
+        },
+    }
+    SYNTHETIC_ACTIVE_PROJECTS = {
+        profile: next(iter(projects), None)
+        for profile, projects in SYNTHETIC_PROJECTS.items()
+    }
+    SYNTHETIC_TRANSCRIPTS = {
+        ("default", DURABLE_SESSION_ID): [],
+        ("work", WORK_DURABLE_SESSION_ID): [],
+    }
+
+
+def reset_synthetic_state():
+    """Reset only the opt-in scenario's in-memory state for isolated tests."""
+    with _lock:
+        _reset_synthetic_state_locked()
+
+
+def _synthetic_profile(value):
+    profile = "default" if value is None else str(value).strip()
+    return profile if profile in SYNTHETIC_PROFILES else None
+
+
+def _safe_synthetic_path(path):
+    if not isinstance(path, str) or not path or len(path) > 1_024:
+        return None
+    if path != SYNTHETIC_FILESYSTEM_ROOT and not path.startswith(SYNTHETIC_FILESYSTEM_ROOT + "/"):
+        return None
+    components = path.split("/")
+    if any(not component or component in (".", "..") for component in components[1:]):
+        return None
+    if any("\\\\" in component or any(ord(char) < 32 for char in component) for component in components):
+        return None
+    return path
+
+
+def _synthetic_session_row(profile, session_id):
+    if profile == "work":
+        title = WORK_SESSION_TITLE
+    else:
+        title = DURABLE_SESSION_TITLE
+    with _lock:
+        transcript = list(SYNTHETIC_TRANSCRIPTS.get((profile, session_id), []))
+    preview = next((row.get("content", "") for row in reversed(transcript) if row.get("role") == "assistant"), "")
+    return {
+        "id": session_id,
+        "session_key": session_id,
+        "title": title,
+        "preview": preview,
+        "last_active": time.time(),
+        "message_count": len(transcript),
+        "model": "fake-model",
+        "billing_provider": "fake",
+        "profile": profile,
+        "cwd": SYNTHETIC_WORKSPACE_PATH,
+        "pinned": False,
+        "archived": False,
+    }
+
+
+def _synthetic_project_row(profile, project):
+    session_ids = project["session_ids"]
+    sessions = [_synthetic_session_row(profile, session_id) for session_id in session_ids]
+    return {
+        "id": project["id"],
+        "label": project["label"],
+        "path": project["path"],
+        "primary_path": project["path"],
+        "is_auto": False,
+        "is_no_project": False,
+        "session_count": len(sessions),
+        "preview_sessions": sessions[:3],
+    }
+
+
+def _synthetic_listing(path=None):
+    requested = SYNTHETIC_FILESYSTEM_ROOT if path is None else _safe_synthetic_path(path)
+    with _lock:
+        if requested not in SYNTHETIC_DIRECTORIES:
+            raise KeyError(requested)
+        children = sorted(SYNTHETIC_DIRECTORIES[requested] | {
+            file_path for file_path in SYNTHETIC_FILES if file_path.rsplit("/", 1)[0] == requested
+        })
+        entries = []
+        for child in children:
+            if child in SYNTHETIC_DIRECTORIES:
+                entries.append({
+                    "name": child.rsplit("/", 1)[-1],
+                    "path": child,
+                    "is_directory": True,
+                })
+            else:
+                file_info = SYNTHETIC_FILES[child]
+                entries.append({
+                    "name": child.rsplit("/", 1)[-1],
+                    "path": child,
+                    "is_directory": False,
+                    "size": len(file_info["content"]),
+                    "mime_type": file_info["mime_type"],
+                })
+        parent = None if requested == SYNTHETIC_FILESYSTEM_ROOT else requested.rsplit("/", 1)[0]
+        return {
+            "path": requested,
+            "parent": parent,
+            "entries": entries,
+            "root": SYNTHETIC_FILESYSTEM_ROOT,
+            "locked_root": SYNTHETIC_FILESYSTEM_ROOT,
+            "can_change_path": True,
+        }
+
+
+def _record_synthetic_turn(profile, session_id, prompt, response):
+    with _lock:
+        transcript = SYNTHETIC_TRANSCRIPTS.setdefault((profile, session_id), [])
+        transcript.extend([
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": response, "status": "completed"},
+        ])
+
+
+def transcript_messages(profile="default", session_id=DURABLE_SESSION_ID):
+    messages = []
+    if VIDEO_FIXTURE_FILE:
+        messages.append({"role": "assistant", "content": "Video playback fixture\nMEDIA: " + VIDEO_MANAGED_PATH})
+    if startup_scenario_enabled():
+        with _lock:
+            messages.extend(dict(row) for row in SYNTHETIC_TRANSCRIPTS.get((profile, session_id), []))
+    return messages
+
+
+def _synthetic_project_tree(profile):
+    with _lock:
+        projects = list(SYNTHETIC_PROJECTS.get(profile, {}).values())
+        active_id = SYNTHETIC_ACTIVE_PROJECTS.get(profile)
+        scoped_ids = [session_id for project in projects for session_id in project["session_ids"]]
+    return {
+        "projects": [_synthetic_project_row(profile, project) for project in projects],
+        "active_id": active_id,
+        "scoped_session_ids": scoped_ids,
+    }
+
+
+def _synthetic_create_project(params):
+    profile = _synthetic_profile(params.get("profile"))
+    name = params.get("name")
+    folders = params.get("folders")
+    primary_path = params.get("primary_path")
+    if profile is None:
+        return None, "profile not found"
+    if not isinstance(name, str) or not name.strip() or len(name.strip()) > 160:
+        return None, "project name is invalid"
+    if any(ord(char) < 32 for char in name):
+        return None, "project name is invalid"
+    if not isinstance(folders, list) or not folders:
+        return None, "project requires a folder"
+    canonical_folders = []
+    with _lock:
+        for folder in folders:
+            canonical = _safe_synthetic_path(folder)
+            if canonical is None or canonical not in SYNTHETIC_DIRECTORIES:
+                return None, "folder not found"
+            if canonical not in canonical_folders:
+                canonical_folders.append(canonical)
+        primary = _safe_synthetic_path(primary_path)
+        if primary is None or primary not in canonical_folders:
+            return None, "primary folder is invalid"
+        projects = SYNTHETIC_PROJECTS.setdefault(profile, {})
+        base_id = "".join(char.lower() if char.isalnum() else "-" for char in name.strip()).strip("-") or "project"
+        project_id = base_id[:128]
+        suffix = 2
+        while project_id in projects:
+            project_id = f"{base_id[:120]}-{suffix}"
+            suffix += 1
+        project = {
+            "id": project_id,
+            "label": name.strip(),
+            "path": primary,
+            "session_ids": [],
+        }
+        projects[project_id] = project
+        if params.get("use") is True:
+            SYNTHETIC_ACTIVE_PROJECTS[profile] = project_id
+    return _synthetic_project_row(profile, project), None
+
+
+def _synthetic_project_sessions(profile, project_id):
+    with _lock:
+        project = SYNTHETIC_PROJECTS.get(profile, {}).get(project_id)
+    if project is None:
+        return None
+    row = _synthetic_project_row(profile, project)
+    return {"project": row, "sessions": row["preview_sessions"]}
+
+
+_reset_synthetic_state_locked()
 
 log_lock = threading.Lock()
 
@@ -190,35 +461,100 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_json({"user_id": "e2e-user", "provider": "basic"})
         elif path == "/api/profiles":
             if self.require_auth():
-                self.send_json({"profiles": [{"name": "default"}]})
+                names = SYNTHETIC_PROFILES if startup_scenario_enabled() else ("default",)
+                self.send_json({"profiles": [{"name": name} for name in names]})
         elif path == "/api/profiles/sessions":
             if self.require_auth():
-                self.send_json({
-                    "sessions": [{
-                        "id": DURABLE_SESSION_ID,
-                        "session_key": DURABLE_SESSION_ID,
-                        "title": DURABLE_SESSION_TITLE,
-                        "preview": "",
-                        "last_active": time.time(),
-                        "message_count": 0,
-                        "model": "fake-model",
-                        "billing_provider": "fake",
-                        "profile": "default",
-                        "cwd": "/tmp/e2e",
-                        "pinned": False,
-                        "archived": False,
-                    }],
-                    "total": 1,
-                    "limit": int(query.get("limit", ["20"])[0]),
-                    "offset": int(query.get("offset", ["0"])[0]),
-                })
+                requested_profile = query.get("profile", [None])[0]
+                if startup_scenario_enabled():
+                    profile = _synthetic_profile(requested_profile)
+                    if profile is None:
+                        self.send_json({"error": "profile not found"}, status=404)
+                        return
+                    session_id = WORK_DURABLE_SESSION_ID if profile == "work" else DURABLE_SESSION_ID
+                    rows = [_synthetic_session_row(profile, session_id)]
+                    self.send_json({
+                        "sessions": rows,
+                        "total": len(rows),
+                        "limit": int(query.get("limit", ["20"])[0]),
+                        "offset": int(query.get("offset", ["0"])[0]),
+                    })
+                else:
+                    self.send_json({
+                        "sessions": [{
+                            "id": DURABLE_SESSION_ID,
+                            "session_key": DURABLE_SESSION_ID,
+                            "title": DURABLE_SESSION_TITLE,
+                            "preview": "",
+                            "last_active": time.time(),
+                            "message_count": 0,
+                            "model": "fake-model",
+                            "billing_provider": "fake",
+                            "profile": "default",
+                            "cwd": "/tmp/e2e",
+                            "pinned": False,
+                            "archived": False,
+                        }],
+                        "total": 1,
+                        "limit": int(query.get("limit", ["20"])[0]),
+                        "offset": int(query.get("offset", ["0"])[0]),
+                    })
         elif path.startswith("/api/sessions/") and path.endswith("/messages"):
             if self.require_auth():
-                messages = transcript_messages()
+                session_id = path.split("/")[3]
+                profile = _synthetic_profile(query.get("profile", [None])[0]) or "default"
+                messages = transcript_messages(profile, session_id)
                 self.send_json({
-                    "session_id": path.split("/")[3],
+                    "session_id": session_id,
                     "messages": messages,
                     "pagination": {"limit": 100, "offset": 0, "returned": len(messages)},
+                })
+        elif path == "/api/sessions/search":
+            if not startup_scenario_enabled():
+                self.send_json({"error": "not found"}, status=404)
+            elif self.require_auth():
+                profile = _synthetic_profile(query.get("profile", [None])[0])
+                needle = (query.get("q", [""])[0] or "").strip().lower()
+                if profile is None:
+                    self.send_json({"error": "profile not found"}, status=404)
+                    return
+                session_id = WORK_DURABLE_SESSION_ID if profile == "work" else DURABLE_SESSION_ID
+                row = _synthetic_session_row(profile, session_id)
+                if needle and any(needle in str(row[field]).lower() for field in ("id", "title", "preview")):
+                    results = [{
+                        "session_id": row["id"],
+                        "title": row["title"],
+                        "snippet": row["preview"],
+                        "role": "session",
+                    }]
+                else:
+                    results = []
+                self.send_json({"results": results})
+        elif path == "/api/files":
+            if not startup_scenario_enabled():
+                self.send_json({"error": "not found"}, status=404)
+            elif self.require_auth():
+                try:
+                    self.send_json(_synthetic_listing((query.get("path") or [None])[0]))
+                except (KeyError, TypeError):
+                    self.send_json({"error": "folder not found"}, status=404)
+        elif path == "/api/files/read":
+            if not startup_scenario_enabled():
+                self.send_json({"error": "not found"}, status=404)
+            elif self.require_auth():
+                requested = _safe_synthetic_path((query.get("path") or [None])[0])
+                with _lock:
+                    file_info = SYNTHETIC_FILES.get(requested)
+                if file_info is None:
+                    self.send_json({"error": "file not found"}, status=404)
+                    return
+                encoded = base64.b64encode(file_info["content"]).decode("ascii")
+                self.send_json({
+                    "name": requested.rsplit("/", 1)[-1],
+                    "path": requested,
+                    "mime_type": file_info["mime_type"],
+                    "size": len(file_info["content"]),
+                    "data_url": f"data:{file_info['mime_type']};base64,{encoded}",
                 })
         elif path == "/api/files/download":
             if not self.require_auth():
@@ -294,6 +630,26 @@ class Handler(BaseHTTPRequestHandler):
         elif path == "/api/auth/ws-ticket":
             if self.require_auth():
                 self.send_json({"ticket": mint_ws_ticket(), "ttl_seconds": 60})
+        elif path == "/api/files/mkdir":
+            if not startup_scenario_enabled():
+                self.send_json({"error": "not found"}, status=404)
+            elif self.require_auth():
+                body = self.read_body_json()
+                requested = _safe_synthetic_path(body.get("path"))
+                if requested is None or requested == SYNTHETIC_FILESYSTEM_ROOT:
+                    self.send_json({"error": "invalid folder path"}, status=400)
+                    return
+                parent = requested.rsplit("/", 1)[0]
+                with _lock:
+                    if parent not in SYNTHETIC_DIRECTORIES:
+                        self.send_json({"error": "parent folder not found"}, status=404)
+                        return
+                    if requested in SYNTHETIC_DIRECTORIES or requested in SYNTHETIC_FILES:
+                        self.send_json({"error": "folder already exists"}, status=409)
+                        return
+                    SYNTHETIC_DIRECTORIES[parent].add(requested)
+                    SYNTHETIC_DIRECTORIES[requested] = set()
+                self.send_json({"ok": True, "path": requested})
         else:
             self.send_json({"error": "not found"}, status=404)
 
@@ -361,6 +717,11 @@ class WsSession:
         self.interrupt_event = threading.Event()
         self.prompt_thread = None
         self.closed = False
+        self.profile = "default"
+        self.durable_session_id = DURABLE_SESSION_ID
+        self.startup_turn_count = 0
+        self.follow_up_received = threading.Event()
+        self.first_response_settled = threading.Event()
 
     # -- framing ------------------------------------------------------------
 
@@ -454,6 +815,72 @@ class WsSession:
             },
         })
 
+    def _handle_startup_rpc(self, request_id, method, params):
+        if method == "profiles.list":
+            self.respond(request_id, {"profiles": [{"name": name} for name in SYNTHETIC_PROFILES]})
+            return True
+        if method == "session.active_list":
+            self.respond(request_id, {"sessions": []})
+            return True
+        if method == "projects.tree":
+            profile = _synthetic_profile(params.get("profile"))
+            if profile is None:
+                self.respond_error(request_id, -32602, "profile not found")
+            else:
+                self.respond(request_id, _synthetic_project_tree(profile))
+            return True
+        if method == "projects.for_cwd":
+            profile = _synthetic_profile(params.get("profile"))
+            requested = _safe_synthetic_path(params.get("cwd"))
+            if profile is None or requested not in SYNTHETIC_DIRECTORIES:
+                self.respond_error(request_id, -32602, "host folder not found")
+            else:
+                self.respond(request_id, {"cwd": requested})
+            return True
+        if method == "projects.create":
+            project, error = _synthetic_create_project(params)
+            if project is None:
+                self.respond_error(request_id, -32602, error or "project creation failed")
+            else:
+                self.respond(request_id, {"project": project})
+            return True
+        if method == "projects.project_sessions":
+            profile = _synthetic_profile(params.get("profile"))
+            project_id = params.get("project_id")
+            result = _synthetic_project_sessions(profile, project_id) if profile and isinstance(project_id, str) else None
+            if result is None:
+                self.respond_error(request_id, -32602, "project not found")
+            else:
+                self.respond(request_id, result)
+            return True
+        if method == "projects.set_active":
+            profile = _synthetic_profile(params.get("profile"))
+            project_id = params.get("id")
+            with _lock:
+                known = profile is not None and project_id in SYNTHETIC_PROJECTS.get(profile, {})
+                if known:
+                    SYNTHETIC_ACTIVE_PROJECTS[profile] = project_id
+            if not known:
+                self.respond_error(request_id, -32602, "project not found")
+            else:
+                self.respond(request_id, {"active_id": project_id})
+            return True
+        if method == "projects.delete":
+            profile = _synthetic_profile(params.get("profile"))
+            project_id = params.get("id")
+            with _lock:
+                known = profile is not None and project_id in SYNTHETIC_PROJECTS.get(profile, {})
+                if known:
+                    del SYNTHETIC_PROJECTS[profile][project_id]
+                    if SYNTHETIC_ACTIVE_PROJECTS.get(profile) == project_id:
+                        SYNTHETIC_ACTIVE_PROJECTS[profile] = next(iter(SYNTHETIC_PROJECTS[profile]), None)
+            if not known:
+                self.respond_error(request_id, -32602, "project not found")
+            else:
+                self.respond(request_id, {})
+            return True
+        return False
+
     def handle_rpc(self, text):
         try:
             message = json.loads(text)
@@ -467,18 +894,33 @@ class WsSession:
         if request_id is None or not isinstance(method, str):
             return
 
+        if startup_scenario_enabled() and self._handle_startup_rpc(request_id, method, params):
+            return
+
         if method == "session.create":
+            requested_profile = _synthetic_profile(params.get("profile")) if startup_scenario_enabled() else "default"
+            self.profile = requested_profile or "default"
+            self.durable_session_id = params.get("session_id") or (
+                WORK_DURABLE_SESSION_ID if self.profile == "work" else DURABLE_SESSION_ID
+            )
             self.respond(request_id, {
                 "session_id": RUNTIME_SESSION_ID,
-                "stored_session_id": DURABLE_SESSION_ID,
+                "stored_session_id": self.durable_session_id,
             })
         elif method == "session.resume":
             requested = params.get("session_id") or DURABLE_SESSION_ID
+            if startup_scenario_enabled():
+                requested_profile = _synthetic_profile(params.get("profile"))
+                if requested_profile is None:
+                    self.respond_error(request_id, -32602, "profile not found")
+                    return
+                self.profile = requested_profile
+                self.durable_session_id = requested
             self.respond(request_id, {
                 "session_id": RUNTIME_SESSION_ID,
                 "session_key": requested,
                 "resumed": True,
-                "messages": transcript_messages(),
+                "messages": transcript_messages(self.profile, self.durable_session_id),
                 "running": False,
                 "info": {
                     "model": "fake-model",
@@ -487,12 +929,36 @@ class WsSession:
                 },
             })
         elif method == "prompt.submit":
-            self.respond(request_id, {"status": "streaming"})
             self.interrupt_event.clear()
-            self.prompt_thread = threading.Thread(
-                target=self.stream_prompt_events, daemon=True,
-            )
-            self.prompt_thread.start()
+            if startup_scenario_enabled():
+                self.startup_turn_count += 1
+                if self.startup_turn_count == 2:
+                    self.follow_up_received.set()
+                prompt = params.get("text") if isinstance(params.get("text"), str) else ""
+                self.prompt_thread = threading.Thread(
+                    target=self.stream_startup_prompt_events,
+                    args=(self.startup_turn_count, prompt, self.profile, self.durable_session_id),
+                    daemon=True,
+                )
+                if self.startup_turn_count == 1 and startup_delayed_ack_enabled():
+                    # Deliberately exercise the real race: completion events are
+                    # written before the first prompt.submit response, while the
+                    # reader loop remains free to accept the next prompt.
+                    self.prompt_thread.start()
+                    threading.Thread(
+                        target=self.send_delayed_startup_ack,
+                        args=(request_id,),
+                        daemon=True,
+                    ).start()
+                else:
+                    self.respond(request_id, {"status": "streaming"})
+                    self.prompt_thread.start()
+            else:
+                self.respond(request_id, {"status": "streaming"})
+                self.prompt_thread = threading.Thread(
+                    target=self.stream_prompt_events, daemon=True,
+                )
+                self.prompt_thread.start()
         elif method == "session.interrupt":
             self.respond(request_id, {"status": "ok"})
             self.interrupt_event.set()
@@ -526,6 +992,41 @@ class WsSession:
             self.respond(request_id, {"processes": []})
         else:
             self.respond_error(request_id, -32601, f"Method not found: {method}")
+
+    def send_delayed_startup_ack(self, request_id):
+        try:
+            # Hold until the next request, rather than assuming a UI driver
+            # can type within a subsecond window. A broken client times out.
+            self.follow_up_received.wait(timeout=30)
+            time.sleep(startup_delayed_ack_seconds())
+            if self.closed:
+                return
+            if startup_delayed_ack_is_error():
+                self.respond_error(request_id, -32001, "synthetic delayed prompt rejection")
+            else:
+                self.respond(request_id, {"status": "streaming"})
+            self.first_response_settled.set()
+        except (ConnectionError, OSError) as error:
+            log(f"WS delayed prompt response aborted: {error}")
+
+    def stream_startup_prompt_events(self, turn_number, prompt, profile, session_id):
+        try:
+            if turn_number == 2 and startup_delayed_ack_enabled():
+                self.first_response_settled.wait(timeout=5)
+            response = STARTUP_RESPONSE_TEXTS[min(turn_number - 1, len(STARTUP_RESPONSE_TEXTS) - 1)] + ": " + prompt
+            self.push_event("message.start", {})
+            time.sleep(0.02)
+            self.push_event("message.delta", {"text": response})
+            time.sleep(0.02)
+            if self.closed:
+                return
+            self.push_event("message.complete", {
+                "text": response,
+                "status": "completed",
+            })
+            _record_synthetic_turn(profile, session_id, prompt, response)
+        except (ConnectionError, OSError) as error:
+            log(f"WS prompt stream aborted: {error}")
 
     def stream_prompt_events(self):
         try:

--- a/tools/fake-hermes/test_fake_hermes.py
+++ b/tools/fake-hermes/test_fake_hermes.py
@@ -1,8 +1,11 @@
-import unittest
+import base64
 import json
 from pathlib import Path
+import os
+import socket
 import tempfile
 import threading
+import unittest
 from unittest.mock import patch
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
@@ -54,6 +57,341 @@ class VideoFixtureTest(unittest.TestCase):
                     server.shutdown()
                     server.server_close()
                     worker.join(timeout=2)
+
+
+class FakeHermesServer:
+    def __init__(self):
+        self.server = fake_hermes.ThreadingHTTPServer(("127.0.0.1", 0), fake_hermes.Handler)
+        self.worker = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    @property
+    def origin(self):
+        return f"http://127.0.0.1:{self.server.server_port}"
+
+    def __enter__(self):
+        self.worker.start()
+        return self
+
+    def __exit__(self, *_):
+        self.server.shutdown()
+        self.server.server_close()
+        self.worker.join(timeout=2)
+
+
+def _json_request(origin, method, path, token=None, body=None):
+    headers = {}
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+        body = json.dumps(body).encode("utf-8")
+    request = Request(origin + path, method=method, headers=headers, data=body)
+    with urlopen(request, timeout=2) as response:
+        return response.status, json.load(response)
+
+
+def _read_exact(sock, count):
+    chunks = bytearray()
+    while len(chunks) < count:
+        chunk = sock.recv(count - len(chunks))
+        if not chunk:
+            raise ConnectionError("websocket peer closed")
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def _open_websocket(origin, ticket):
+    url = origin.removeprefix("http://")
+    host, port = url.rsplit(":", 1)
+    sock = socket.create_connection((host, int(port)), timeout=2)
+    key = base64.b64encode(os.urandom(16)).decode("ascii")
+    request = (
+        f"GET /api/ws?ticket={ticket} HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n"
+    ).encode("ascii")
+    sock.sendall(request)
+    response = bytearray()
+    while b"\r\n\r\n" not in response:
+        response.extend(sock.recv(4096))
+    if not response.startswith(b"HTTP/1.1 101"):
+        raise AssertionError(response.decode("ascii", errors="replace"))
+    return sock
+
+
+def _send_websocket_json(sock, value):
+    payload = json.dumps(value, separators=(",", ":")).encode("utf-8")
+    mask = os.urandom(4)
+    length = len(payload)
+    if length < 126:
+        header = bytes((0x81, 0x80 | length))
+    elif length < 65536:
+        header = bytes((0x81, 0xFE)) + length.to_bytes(2, "big")
+    else:
+        header = bytes((0x81, 0xFF)) + length.to_bytes(8, "big")
+    masked = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    sock.sendall(header + mask + masked)
+
+
+def _receive_websocket_json(sock):
+    first, second = _read_exact(sock, 2)
+    opcode = first & 0x0F
+    length = second & 0x7F
+    if length == 126:
+        length = int.from_bytes(_read_exact(sock, 2), "big")
+    elif length == 127:
+        length = int.from_bytes(_read_exact(sock, 8), "big")
+    payload = _read_exact(sock, length) if length else b""
+    if opcode == 0x8:
+        raise ConnectionError("websocket closed")
+    if opcode != 0x1:
+        return _receive_websocket_json(sock)
+    return json.loads(payload.decode("utf-8"))
+
+
+def _rpc(sock, request_id, method, params=None):
+    _send_websocket_json(sock, {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": params or {},
+    })
+    while True:
+        message = _receive_websocket_json(sock)
+        if message.get("id") == request_id:
+            if "error" in message:
+                raise AssertionError(message["error"])
+            return message["result"]
+
+
+def _prompt_completion(sock, request_id, text):
+    _send_websocket_json(sock, {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "prompt.submit",
+        "params": {"session_id": fake_hermes.RUNTIME_SESSION_ID, "text": text},
+    })
+    response = None
+    completion = None
+    while response is None or completion is None:
+        message = _receive_websocket_json(sock)
+        if message.get("id") == request_id:
+            response = message.get("result")
+        params = message.get("params")
+        if message.get("method") == "event" and isinstance(params, dict):
+            if params.get("type") == "message.complete":
+                completion = params.get("payload")
+    return response, completion
+
+
+def _startup_chat_socket(origin):
+    token = fake_hermes.mint_session_token()
+    _, ticket_payload = _json_request(origin, "POST", "/api/auth/ws-ticket", token=token)
+    sock = _open_websocket(origin, ticket_payload["ticket"])
+    _rpc(sock, 1, "session.resume", {
+        "session_id": fake_hermes.DURABLE_SESSION_ID,
+        "profile": "default",
+        "close_on_disconnect": False,
+    })
+    return sock
+
+
+def _event_type(message):
+    params = message.get("params")
+    return params.get("type") if isinstance(params, dict) else None
+
+
+def _run_delayed_prompt_race(sock):
+    _send_websocket_json(sock, {
+        "jsonrpc": "2.0",
+        "id": 5,
+        "method": "prompt.submit",
+        "params": {"session_id": fake_hermes.RUNTIME_SESSION_ID, "text": "first startup turn"},
+    })
+    before_first_ack = []
+    while True:
+        message = _receive_websocket_json(sock)
+        before_first_ack.append(message)
+        if message.get("id") == 5:
+            raise AssertionError("first prompt ACK arrived before its completion event")
+        if _event_type(message) == "message.complete":
+            break
+
+    # The second request is intentionally sent while request id 5 is still
+    # outstanding. The server's read loop must accept it before the delayed
+    # first response is released.
+    _send_websocket_json(sock, {
+        "jsonrpc": "2.0",
+        "id": 6,
+        "method": "prompt.submit",
+        "params": {"session_id": fake_hermes.RUNTIME_SESSION_ID, "text": "second startup turn"},
+    })
+    after_second_prompt = []
+    first_response = None
+    second_response = None
+    second_completion = None
+    while first_response is None or second_completion is None:
+        message = _receive_websocket_json(sock)
+        after_second_prompt.append(message)
+        if message.get("id") == 5:
+            first_response = message
+        elif message.get("id") == 6:
+            second_response = message
+        elif _event_type(message) == "message.complete":
+            payload = message.get("params", {}).get("payload", {})
+            if payload.get("text") == fake_hermes.STARTUP_RESPONSE_TEXTS[1] + ": second startup turn":
+                second_completion = payload
+    return before_first_ack, after_second_prompt, first_response, second_response, second_completion
+
+
+class StartupScenarioTest(unittest.TestCase):
+    def setUp(self):
+        self.scenario = patch.object(fake_hermes, "FAKE_HERMES_SCENARIO", "ios-startup")
+        self.scenario.start()
+        fake_hermes.reset_synthetic_state()
+
+    def tearDown(self):
+        fake_hermes.reset_synthetic_state()
+        self.scenario.stop()
+
+    def test_profiles_and_synthetic_filesystem_are_bounded(self):
+        with FakeHermesServer() as server:
+            token = fake_hermes.mint_session_token()
+            status, payload = _json_request(server.origin, "GET", "/api/profiles", token=token)
+            self.assertEqual(status, 200)
+            self.assertEqual([row["name"] for row in payload["profiles"]], ["default", "work"])
+
+            status, listing = _json_request(server.origin, "GET", "/api/files", token=token)
+            self.assertEqual(status, 200)
+            self.assertEqual(listing["path"], fake_hermes.SYNTHETIC_FILESYSTEM_ROOT)
+            workspace = next(row for row in listing["entries"] if row["name"] == "workspace")
+            self.assertTrue(workspace["is_directory"])
+
+            folder = fake_hermes.SYNTHETIC_WORKSPACE_PATH + "/ios-startup-folder"
+            status, created = _json_request(
+                server.origin,
+                "POST",
+                "/api/files/mkdir",
+                token=token,
+                body={"path": folder},
+            )
+            self.assertEqual(status, 200)
+            self.assertEqual(created, {"ok": True, "path": folder})
+            status, child = _json_request(
+                server.origin,
+                "GET",
+                "/api/files?path=" + folder,
+                token=token,
+            )
+            self.assertEqual(status, 200)
+            self.assertEqual(child["path"], folder)
+            self.assertEqual(child["parent"], fake_hermes.SYNTHETIC_WORKSPACE_PATH)
+            self.assertEqual(child["entries"], [])
+
+            for path in ("/etc", fake_hermes.SYNTHETIC_WORKSPACE_PATH + "/../escape"):
+                with self.assertRaises(HTTPError) as failure:
+                    urlopen(Request(
+                        server.origin + "/api/files?path=" + path,
+                        headers={"Authorization": "Bearer " + token},
+                    ), timeout=2)
+                self.assertEqual(failure.exception.code, 404)
+
+    def test_rpc_profiles_projects_and_two_turn_completion(self):
+        with FakeHermesServer() as server:
+            token = fake_hermes.mint_session_token()
+            _, ticket_payload = _json_request(
+                server.origin,
+                "POST",
+                "/api/auth/ws-ticket",
+                token=token,
+            )
+            sock = _open_websocket(server.origin, ticket_payload["ticket"])
+            try:
+                profiles = _rpc(sock, 1, "profiles.list", {"include_sessions": False})
+                self.assertEqual([row["name"] for row in profiles["profiles"]], ["default", "work"])
+
+                tree = _rpc(sock, 2, "projects.tree", {
+                    "profile": "default",
+                    "preview_limit": 3,
+                    "session_limit": 500,
+                })
+                self.assertIn("projects", tree)
+                self.assertEqual(tree["projects"][0]["label"], "Existing Project")
+
+                folder = fake_hermes.SYNTHETIC_WORKSPACE_PATH + "/ios-startup-folder"
+                _json_request(
+                    server.origin,
+                    "POST",
+                    "/api/files/mkdir",
+                    token=token,
+                    body={"path": folder},
+                )
+                created = _rpc(sock, 3, "projects.create", {
+                    "name": "UI Startup Project",
+                    "folders": [folder],
+                    "primary_path": folder,
+                    "use": True,
+                    "profile": "default",
+                })
+                self.assertEqual(created["project"]["label"], "UI Startup Project")
+                self.assertEqual(created["project"]["path"], folder)
+
+                resumed = _rpc(sock, 4, "session.resume", {
+                    "session_id": fake_hermes.DURABLE_SESSION_ID,
+                    "profile": "default",
+                    "close_on_disconnect": False,
+                })
+                self.assertEqual(resumed["session_id"], fake_hermes.RUNTIME_SESSION_ID)
+
+                first_response, first = _prompt_completion(sock, 5, "first startup turn")
+                second_response, second = _prompt_completion(sock, 6, "second startup turn")
+                self.assertEqual(first_response["status"], "streaming")
+                self.assertEqual(second_response["status"], "streaming")
+                self.assertEqual(first["status"], "completed")
+                self.assertEqual(second["status"], "completed")
+                self.assertEqual(first["text"], "First startup response: first startup turn")
+                self.assertEqual(second["text"], "Second startup response: second startup turn")
+                self.assertNotIn("Operation interrupted", second["text"])
+            finally:
+                sock.close()
+
+    def test_opt_in_delayed_first_ack_accepts_second_prompt_before_ack(self):
+        with patch.dict(os.environ, {
+            fake_hermes.DELAY_FIRST_PROMPT_ACK_ENV: "1",
+            fake_hermes.DELAY_FIRST_PROMPT_ERROR_ENV: "0",
+        }, clear=False):
+            with FakeHermesServer() as server:
+                sock = _startup_chat_socket(server.origin)
+                try:
+                    before, after, first, second, second_completion = _run_delayed_prompt_race(sock)
+                    self.assertFalse(any(message.get("id") == 5 for message in before))
+                    self.assertEqual((first or {}).get("result", {}).get("status"), "streaming")
+                    self.assertEqual((second or {}).get("result", {}).get("status"), "streaming")
+                    self.assertEqual((second_completion or {}).get("status"), "completed")
+                    self.assertTrue((second_completion or {}).get("text", "").startswith("Second startup response: "))
+                    self.assertTrue(any(_event_type(message) == "message.complete" for message in before))
+                    self.assertTrue(any(message.get("id") == 5 for message in after))
+                finally:
+                    sock.close()
+
+    def test_opt_in_delayed_first_error_is_after_completion_and_second_prompt(self):
+        with patch.dict(os.environ, {
+            fake_hermes.DELAY_FIRST_PROMPT_ACK_ENV: "1",
+            fake_hermes.DELAY_FIRST_PROMPT_ERROR_ENV: "1",
+        }, clear=False):
+            with FakeHermesServer() as server:
+                sock = _startup_chat_socket(server.origin)
+                try:
+                    before, _, first, second, second_completion = _run_delayed_prompt_race(sock)
+                    self.assertFalse(any(message.get("id") == 5 for message in before))
+                    self.assertEqual((first or {}).get("error", {}).get("code"), -32001)
+                    self.assertEqual((second or {}).get("result", {}).get("status"), "streaming")
+                    self.assertTrue((second_completion or {}).get("text", "").startswith("Second startup response: "))
+                finally:
+                    sock.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Restore the last successfully used direct server or relay at startup. With no saved choice, connect automatically only when a single configured connection is usable; otherwise show a combined direct/relay picker. Failed or unavailable saved choices never silently fall back to another host.
- Show configured relays alongside direct servers in Settings, and populate the profile picker from the connected host instead of leaving it at `default`. Fence asynchronous catalog/session responses by connection and profile.
- Remove the home Host Files shortcut, move Search beside Settings, add Back to the Host Files picker, and keep only the composer's context circle.
- Wire managed-file requests through the existing authenticated refresh path, distinguish authentication rejection from folder-access denial, and support direct folder browsing, creation, and selection. Existing host paths can also be entered for project registration.
- Fix follow-up submission when a terminal event arrives before the `prompt.submit` acknowledgement. Release the composer gate and accepted references without letting a late callback restore the old draft or alter a newer attempt.

The changes are rebased onto `0c74a0c`. The chat fix follows the newly extracted `ChatSessionState`, `ChatComposerActions`, and `ChatEventApplier` structure and preserves the upstream batch-clarification work.

## PR follow-up fixes

- Replace the unsafe synthetic URLProtocol redirect handoff with a loopback HTTP fixture. The refusal test and plain-session control now exercise real redirects; production redirect blocking is unchanged. The networking suite passed five consecutive runs (55 executions), followed by the full 629-test iOS suite.
- Replace fixed `Task.yield()` polling loops in the two iOS profile race tests with expectations fired after the fake request continuation is registered. The original stale-response assertions and deliberate reply ordering remain intact.
- Address the Android terminal-before-ACK review finding: release pending admission on terminal evidence, acknowledge draft/attachment state once, and fence late callbacks by attempt identity and operation generation. Include a regression for recreated lifecycle owners so an old callback cannot settle a new attempt.
- Update `AGENTS.md` to allow coordinated Mercury-owned client/plugin/router capabilities without modifying the actual Hermes API. Encryption, host authorization, direct-mode independence, and capability/version compatibility remain required.

## Hermes compatibility

Uses the existing official interfaces: `/api/profiles`, `profiles.list` with `include_sessions=false`, managed-files REST endpoints, and the existing session JSON-RPC contract. No Hermes fork, new server route, or relay filesystem bridge is introduced.

**Relay limitation:** the current transport contract does not expose folder browsing or directory creation. Relay users receive an accurate explanation instead of a misleading sign-in error and can register an existing absolute host folder path, validated by the host. Browsing/creating folders requires a direct connection.

The last-successful preference contains only a transport discriminator and local UUID. Direct catalogs/credentials and relay pairing/key state remain separate. Shared runtimes are not closed as part of these UI changes.

## Cross-platform

The native startup/navigation changes are iOS-scoped; equivalent Android native startup/toolbar changes remain explicitly deferred. The terminal-before-acknowledgement fix now lands on both Android and iOS, consuming the same shared admission policy with native, per-session attempt ownership. Profile-name policy is also shared through `shared/mercury-core` and consumed by both clients, preserving their existing REST/RPC decoding behavior. Startup selection and prompt-admission decisions live in the shared core; native lifecycle and UI remain platform-owned.

## Verification

On the rebased tree:

- [x] `./gradlew testDebugUnitTest lintDebug assembleDebug`
- [x] `./gradlew :shared:mercury-core:check`
- [x] XcodeGen generation and `Mercury` simulator build/test on iPhone 17 Pro: **629 tests passed**.
- [x] Real SwiftUI follow-up regression against the synthetic backend: hold the first acknowledgement until a second prompt arrives, then deliver a late first error; the second response completes without restoring the old draft.
- [x] Compared the Mac build inputs with the working tree; only XcodeGen's expected plist expansion differed, with source values preserved.
- [x] Whitespace checks and publication scan: no real private host identifiers or secret-scanner findings in the proposed files. Added prompts, responses, paths, and credentials are synthetic test fixtures only.

Before the rebase, seven simulator UI checks passed covering startup states, profile selection, toolbar placement, Settings navigation, folder creation/selection/Back, ordinary consecutive turns, and the delayed-acknowledgement race. After the rebase, the full unit gate and the critical moved chat UI path were rerun; the other six UI checks were not rerun.

Android screenshot references and adaptive Android UI were not changed. The rebased artifact has not been deployed to a physical device.

## Screenshots

Sanitized local simulator captures were inspected for the startup picker, home toolbar, profile menu, folder picker, and chat controls. Screenshot/build artifacts are kept outside the repository; no screenshot references were changed.
