### PR TITLE
test(android): fix concurrent authentication request recording

### DIFF
--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
@@ -27,6 +27,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import java.util.concurrent.ConcurrentLinkedQueue
 import com.unsupportedpastels.hermesandroid.app.DurableSessionId
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessage
 import com.unsupportedpastels.hermesandroid.gateway.ChatMessageRole
@@ -938,9 +939,21 @@ class HermesConnectionClientTest {
 
     @Test
     fun authenticatedConnectionVerifiesBearerAndLoadsDurableSessions() = runTest {
-        val requestedPaths = mutableListOf<String>()
+        verifyAuthenticatedConnectionRequests(firstPath = "/api/auth/me")
+        verifyAuthenticatedConnectionRequests(firstPath = "/api/profiles/sessions")
+    }
+
+    private suspend fun verifyAuthenticatedConnectionRequests(firstPath: String) {
+        val requestedPaths = ConcurrentLinkedQueue<String>()
+        val firstRecorded = CompletableDeferred<Unit>()
         val engine = MockEngine { request ->
-            requestedPaths += request.url.encodedPath
+            // Both requests are independent. Exercise either arrival order
+            // without relying on dispatcher timing or concurrent ArrayList writes.
+            if (request.url.encodedPath != firstPath) {
+                withTimeout(5_000) { firstRecorded.await() }
+            }
+            requestedPaths.add(request.url.encodedPath)
+            if (request.url.encodedPath == firstPath) firstRecorded.complete(Unit)
             assertEquals("Bearer opaque-access", request.headers[HttpHeaders.Authorization])
             if (request.url.encodedPath == "/api/profiles/sessions") {
                 assertEquals("20", request.url.parameters["limit"])
@@ -965,14 +978,20 @@ class HermesConnectionClientTest {
                 else -> error("Unexpected request: ${request.url}")
             }
         }
-        val client = HttpHermesConnectionClient(HttpClient(engine))
+        val httpClient = HttpClient(engine)
+        val authenticated = try {
+            HttpHermesConnectionClient(httpClient).authenticate(
+                ServerOrigin.parse("https://hermes.example"),
+                accessToken = "opaque-access",
+            )
+        } finally {
+            httpClient.close()
+        }
 
-        val authenticated = client.authenticate(
-            ServerOrigin.parse("https://hermes.example"),
-            accessToken = "opaque-access",
+        assertEquals(
+            mapOf("/api/auth/me" to 1, "/api/profiles/sessions" to 1),
+            requestedPaths.groupingBy { it }.eachCount(),
         )
-
-        assertEquals(listOf("/api/auth/me", "/api/profiles/sessions"), requestedPaths)
         assertEquals("user", authenticated.userId)
         assertEquals(
             listOf(


### PR DESCRIPTION
## Summary

Fix the flaky authentication request recorder exposed by post-merge Android CI.

- Record concurrent MockEngine calls with `ConcurrentLinkedQueue`, avoiding lost ArrayList writes.
- Assert that identity and session-list requests each occur exactly once, without assuming arrival order.
- Use deferred barriers to exercise both valid arrival orders deterministically.
- Preserve bearer-header, profile-query, authenticated-user, and durable-session assertions, and close each test client.

Production authentication remains concurrent and unchanged.

## Hermes compatibility

Test-only change. No production code, API contracts, credentials, or transport behavior changes.

## Cross-platform

Android test harness only; no user-visible platform behavior changes or iOS changes are needed.

## Verification

- [x] Observed RED with the old ordered assertion when session-list arrival was deliberately first.
- [x] All 52 `HermesConnectionClientTest` cases passed after the fix.
- [x] All 965 Android unit tests passed, with zero failures/errors/skips.
- [x] `./gradlew testDebugUnitTest lintDebug assembleDebug :shared:mercury-core:check validateDebugScreenshotTest`
- [x] `git diff --check`

No screenshot references changed. Test inputs are synthetic; no real credentials or private deployment data added.
