### PR TITLE
fix: keep host-confirmed background children live after a reopen

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -152,6 +152,9 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
+/** How often a chat re-asks the gateway registry about unresolved delegated children. */
+private const val BACKGROUND_REGISTRY_POLL_MILLIS = 30_000L
+
 class HermesConnectionViewModel(
     settingsStates: Flow<ServerSettingsState>,
     private val client: HermesConnectionClient,
@@ -5325,16 +5328,33 @@ class HermesConnectionViewModel(
         }
         if (mutableSnapshots.value.chatSessions[durableSessionId]?.backgroundTasks?.rows?.isNotEmpty() == true) {
             viewModelScope.launch {
-                try {
-                    val status = session.loadDelegationStatus()
-                    if (isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration) &&
-                        liveControllers[durableSessionId]?.session === session) {
-                        updateChat(durableSessionId) {
-                            it.copy(backgroundTasks = it.backgroundTasks.reconcile(status, runtimeSessionId, previousRuntimeSessionId))
+                // A reopened app's only child evidence is a recovered snapshot with no
+                // fresh event to observe. The gateway's subagent registry is the
+                // authoritative liveness signal, so keep asking it while unresolved
+                // children remain; each "running" report counts as activity for one
+                // window without pretending to be a worker event.
+                var previousRuntime = previousRuntimeSessionId
+                while (true) {
+                    if (!isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration) ||
+                        liveControllers[durableSessionId]?.session !== session) return@launch
+                    try {
+                        val status = session.loadDelegationStatus()
+                        if (isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration) &&
+                            liveControllers[durableSessionId]?.session === session) {
+                            updateChat(durableSessionId) {
+                                it.copy(backgroundTasks = it.backgroundTasks.reconcile(
+                                    status, runtimeSessionId, previousRuntime, System.currentTimeMillis()))
+                            }
+                            previousRuntime = runtimeSessionId
                         }
-                    }
-                } catch (cancelled: CancellationException) { throw cancelled }
-                catch (_: Exception) { /* Retain last known rows; absence is not success. */ }
+                    } catch (cancelled: CancellationException) { throw cancelled }
+                    catch (_: HermesChatMethodNotFoundException) { return@launch }
+                    catch (_: Exception) { /* Retain last known rows; absence is not success. */ }
+                    val unresolved = mutableSnapshots.value.chatSessions[durableSessionId]?.backgroundTasks?.rows
+                        ?.any { !it.terminal && it.identityKnown } == true
+                    if (!unresolved) return@launch
+                    delay(BACKGROUND_REGISTRY_POLL_MILLIS)
+                }
             }
         }
         val eventJob = viewModelScope.launch(start = CoroutineStart.LAZY) {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/BackgroundTasks.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/BackgroundTasks.kt
@@ -24,6 +24,7 @@ data class BackgroundTaskRow(
     val observedAtMillis: Long,
     val available: Boolean = true,
     val identityKnown: Boolean = true,
+    val registryConfirmedAtMillis: Long = 0L,
 ) {
     val terminal: Boolean get() = shared().terminal
     fun recentlyActive(now: Long): Boolean = shared().recentlyActive(now)
@@ -32,7 +33,7 @@ data class BackgroundTaskRow(
     fun dismissalKey(): String = shared().dismissalKey()
     fun timeLabel(now: Long): String = shared().timeLabel(now)
     internal fun shared() = com.unsupportedpastels.mercury.core.relay.BackgroundTaskRow(
-        runtimeId.value, id, goal, action, status, observedAtMillis, available, identityKnown)
+        runtimeId.value, id, goal, action, status, observedAtMillis, available, identityKnown, registryConfirmedAtMillis)
 }
 
 data class BackgroundTasks(
@@ -58,9 +59,10 @@ data class BackgroundTasks(
         status: com.unsupportedpastels.hermesandroid.app.DelegationStatus,
         runtime: RuntimeSessionId,
         previousRuntime: RuntimeSessionId = runtime,
+        now: Long = 0L,
     ): BackgroundTasks = shared().reconcile(status.active.map {
         com.unsupportedpastels.mercury.core.relay.BackgroundTaskRegistryEntry(it.subagentId, it.status)
-    }, runtime.value, previousRuntime.value).native()
+    }, runtime.value, previousRuntime.value, now).native()
     fun reduce(event: HermesChatEvent, expectedRuntime: RuntimeSessionId, now: Long): BackgroundTasks {
         if (event !is BackgroundTaskEvent) return this
         val current = shared()
@@ -70,7 +72,7 @@ data class BackgroundTasks(
     companion object {
         internal fun fromShared(state: com.unsupportedpastels.mercury.core.relay.BackgroundTasks) = BackgroundTasks(
             state.rows.map { BackgroundTaskRow(RuntimeSessionId(it.runtimeId), it.id, it.goal,
-                it.action, it.status, it.observedAtMillis, it.available, it.identityKnown) },
+                it.action, it.status, it.observedAtMillis, it.available, it.identityKnown, it.registryConfirmedAtMillis) },
             state.processedEventIds,
         )
     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetailScreen.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetailScreen.kt
@@ -319,7 +319,9 @@ internal fun SessionDetailScreen(
         streamingAnswer = streaming?.text?.isNotBlank() == true,
         streamingReasoning = streaming?.reasoningText?.isNotBlank() == true,
         inProgressTodo = summary.inProgress.firstOrNull()?.label,
-        activeChildCount = if (connectionLost || connectionBusy || chat.progress.restored) 0
+        // Child evidence is live run state too: a reopen's history refresh sets
+        // `restored`, which must not hide children the host still reports running.
+        activeChildCount = if (connectionLost || connectionBusy) 0
             else chat.backgroundTasks.presentation(visibleBackground, activityNow).activeCount,
     )))
 

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/ComposerActivityIntegrationTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/ComposerActivityIntegrationTest.kt
@@ -95,6 +95,20 @@ class ComposerActivityIntegrationTest {
         compose.onAllNodes(SemanticsMatcher.keyIsDefined(androidx.compose.ui.semantics.SemanticsProperties.ProgressBarRangeInfo)
             and hasAnyAncestor(hasTestTag("Session activity sheet"))).assertCountEquals(1)
     }
+    @Test fun restoredHistoryNeverHidesHostConfirmedBackgroundChildren() {
+        // Cold reopen mid-delegation: the parent turn already finished (resume running=false),
+        // the history refresh labeled progress restored, and the only child evidence is a
+        // recovered snapshot the gateway registry just confirmed as running.
+        show(ChatSessionSnapshot(
+            progress = DurableProgress(hasMilestoneSnapshot = true, restored = true),
+            messages = listOf(ChatMessage(ChatMessageRole.User, "Write 4 poems. Use subagents."),
+                ChatMessage(ChatMessageRole.Assistant, "Four subagents are each writing a poem.")),
+            backgroundTasks = BackgroundTasks(listOf(BackgroundTaskRow(RuntimeSessionId("runtime"), "sa-0", "Write a poem",
+                null, BackgroundTaskStatus.Active, observedAtMillis = 0L, registryConfirmedAtMillis = System.currentTimeMillis())))))
+        compose.onNodeWithContentDescription("Activity: 1 background task").assertIsDisplayed()
+        compose.onNodeWithTag("Composer activity line").performClick()
+        compose.onNodeWithText("Active · host reports running").assertIsDisplayed()
+    }
     @Test fun completedTurnHasAnswerAndDisclosureWithoutLiveLine() {
         show(ChatSessionSnapshot(messages = listOf(ChatMessage(ChatMessageRole.User, "Question"),
             ChatMessage(ChatMessageRole.Assistant, "Intermediate"), ChatMessage(ChatMessageRole.Tool, "Tool output"),

--- a/ios/Mercury/MercuryKit/Chat/BackgroundTasks.swift
+++ b/ios/Mercury/MercuryKit/Chat/BackgroundTasks.swift
@@ -61,11 +61,14 @@ struct BackgroundTaskRow: Sendable, Equatable, Identifiable {
     var observedAtMillis: Int64
     var available = true
     var identityKnown = true
+    /// Last time the gateway's subagent registry reported this child running.
+    var registryConfirmedAtMillis: Int64 = 0
     var id: String { runtime + "/" + childID }
     var core: MercuryCore.BackgroundTaskRow {
         MercuryCore.BackgroundTaskRow(runtimeId: runtime, id: childID, goal: goal,
             action: action, status: status.core, observedAtMillis: observedAtMillis,
-            available: available, identityKnown: identityKnown)
+            available: available, identityKnown: identityKnown,
+            registryConfirmedAtMillis: registryConfirmedAtMillis)
     }
     var terminal: Bool { core.terminal }
     func recentlyActive(now: Int64) -> Bool { core.recentlyActive(now: now) }
@@ -96,7 +99,8 @@ struct BackgroundTasks: @unchecked Sendable, Equatable {
             BackgroundTaskRow(runtime: row.runtimeId, childID: row.id, goal: row.goal,
                 action: row.action, status: BackgroundTaskStatus(row.status),
                 observedAtMillis: row.observedAtMillis, available: row.available,
-                identityKnown: row.identityKnown)
+                identityKnown: row.identityKnown,
+                registryConfirmedAtMillis: row.registryConfirmedAtMillis)
         }
     }
     static func == (lhs: Self, rhs: Self) -> Bool { lhs.core == rhs.core }
@@ -125,10 +129,16 @@ struct BackgroundTasks: @unchecked Sendable, Equatable {
         )
     }
     mutating func markUnavailable() { core = core.unavailable() }
-    mutating func reconcile(_ statuses: [String: String], runtime: String) {
+    /// `now` stamps a "running" registry answer as confirmed liveness for one
+    /// activity window; it never touches the worker-observed timestamp.
+    mutating func reconcile(_ statuses: [String: String], runtime: String, now: Int64 = 0) {
         core = core.reconcile(active: statuses.map {
             MercuryCore.BackgroundTaskRegistryEntry(subagentId: $0.key, status: $0.value)
-        }, runtime: runtime, previousRuntime: runtime)
+        }, runtime: runtime, previousRuntime: runtime, now: now)
+    }
+    /// Unresolved children with a known identity: the rows worth asking the host about.
+    var hasUnresolvedIdentifiedChildren: Bool {
+        rows.contains { !$0.terminal && $0.identityKnown }
     }
     mutating func recover(snapshot: MercuryCore.RelayLeaseSnapshot, durableID: String,
                           profile: String, runtime: String?) {

--- a/ios/Mercury/MercuryKit/Relay/RelayTaskOwner.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayTaskOwner.swift
@@ -59,7 +59,7 @@ final class RelayTaskOwner: @unchecked Sendable {
         guard self.generation == generation, let binding = bindings[runtime],
               binding.live, binding.durableId == durable, binding.profile == profile else { return nil }
         var state = tasks[durable] ?? BackgroundTasks()
-        state.reconcile(statuses, runtime: runtime)
+        state.reconcile(statuses, runtime: runtime, now: Int64(Date().timeIntervalSince1970 * 1000))
         tasks[durable] = state
         return state
     }

--- a/ios/Mercury/Views/ChatConnectionCoordinator.swift
+++ b/ios/Mercury/Views/ChatConnectionCoordinator.swift
@@ -200,6 +200,7 @@ extension ChatView {
                 return false
             }
             state.connection = candidate
+            state.connectionOwnershipToken = ownershipToken
             let childScope = backgroundTaskScope
             if let relay = candidate.relaySocket,
                let tasks = await relay.retainedTasks(durable: state.durableID ?? sessionID, runtime: state.runtimeSessionID) {
@@ -211,26 +212,7 @@ extension ChatView {
                 appModel.backgroundTasksBySession[childScope] = tasks
             }
             state.eventTask?.cancel()
-            if !backgroundTasks.rows.isEmpty, let childRuntime = state.runtimeSessionID {
-                Task {
-                    if let statuses = try? await candidate.backgroundTaskStatuses(),
-                       state.connectionOwnership.isCurrent(ownershipToken), state.connection === candidate,
-                       backgroundTaskScope == childScope {
-                        if let relay = candidate.relaySocket {
-                            let tasks = await relay.reconcileRetainedTasks(durable: state.durableID ?? sessionID,
-                                                                          runtime: childRuntime, statuses: statuses)
-                            guard state.connectionOwnership.isCurrent(ownershipToken), state.connection === candidate,
-                                  backgroundTaskScope == childScope, state.runtimeSessionID == childRuntime,
-                                  let tasks else { return }
-                            appModel.backgroundTasksBySession[childScope] = tasks
-                        } else {
-                            var tasks = backgroundTasks
-                            tasks.reconcile(statuses, runtime: childRuntime)
-                            appModel.backgroundTasksBySession[childScope] = tasks
-                        }
-                    }
-                }
-            }
+            startBackgroundRegistryPolling()
             state.eventTask = Task { [weak candidate] in
                 guard let candidate else { return }
                 for await event in stream {

--- a/ios/Mercury/Views/ChatEventApplier.swift
+++ b/ios/Mercury/Views/ChatEventApplier.swift
@@ -16,11 +16,13 @@ extension ChatView {
                     guard state.connection === candidate, backgroundTaskScope == scope,
                           state.runtimeSessionID == runtimeSessionID, let tasks else { return }
                     appModel.backgroundTasksBySession[scope] = tasks
+                    startBackgroundRegistryPollingIfIdle()
                 }
             } else {
                 var tasks = backgroundTasks
                 tasks.apply(event, runtime: runtimeSessionID, now: Int64(Date().timeIntervalSince1970 * 1000))
                 appModel.backgroundTasksBySession[backgroundTaskScope] = tasks
+                startBackgroundRegistryPollingIfIdle()
             }
             return
         }

--- a/ios/Mercury/Views/ChatProgressRecovery.swift
+++ b/ios/Mercury/Views/ChatProgressRecovery.swift
@@ -55,6 +55,62 @@ extension ChatView {
         }
     }
 
+    /// How often a chat re-asks the gateway registry about unresolved children.
+    static let backgroundRegistryPollInterval: Duration = .seconds(30)
+
+    /// A reopened app's only child evidence is a recovered snapshot with no
+    /// fresh event to observe, and a child inside a long tool call emits
+    /// nothing. The gateway's `delegation.status` registry is the authoritative
+    /// liveness signal, so keep asking it while unresolved children remain.
+    /// Each "running" answer counts as activity for one window without being
+    /// mistaken for a worker event. Registry silence never invents rows.
+    @MainActor
+    func startBackgroundRegistryPolling() {
+        state.backgroundRegistryTask?.cancel()
+        state.backgroundRegistryPolling = false
+        guard backgroundTasks.hasUnresolvedIdentifiedChildren, let childRuntime = state.runtimeSessionID,
+              let candidate = state.connection, let ownershipToken = state.connectionOwnershipToken,
+              state.connectionOwnership.isCurrent(ownershipToken) else { return }
+        let scope = backgroundTaskScope
+        state.backgroundRegistryGeneration &+= 1
+        let generation = state.backgroundRegistryGeneration
+        state.backgroundRegistryPolling = true
+        state.backgroundRegistryTask = Task { @MainActor [weak candidate] in
+            defer { if state.backgroundRegistryGeneration == generation { state.backgroundRegistryPolling = false } }
+            while !Task.isCancelled {
+                guard let candidate, state.connectionOwnership.isCurrent(ownershipToken), state.connection === candidate,
+                      backgroundTaskScope == scope, state.runtimeSessionID == childRuntime else { return }
+                guard let statuses = try? await candidate.backgroundTaskStatuses() else {
+                    // Retain last known rows; an unanswered registry is not success or failure.
+                    return
+                }
+                guard !Task.isCancelled, state.connectionOwnership.isCurrent(ownershipToken), state.connection === candidate,
+                      backgroundTaskScope == scope, state.runtimeSessionID == childRuntime else { return }
+                if let relay = candidate.relaySocket {
+                    let tasks = await relay.reconcileRetainedTasks(durable: state.durableID ?? sessionID,
+                                                                  runtime: childRuntime, statuses: statuses)
+                    guard !Task.isCancelled, state.connectionOwnership.isCurrent(ownershipToken),
+                          state.connection === candidate, backgroundTaskScope == scope,
+                          state.runtimeSessionID == childRuntime, let tasks else { return }
+                    appModel.backgroundTasksBySession[scope] = tasks
+                } else {
+                    var tasks = backgroundTasks
+                    tasks.reconcile(statuses, runtime: childRuntime, now: Int64(Date().timeIntervalSince1970 * 1000))
+                    appModel.backgroundTasksBySession[scope] = tasks
+                }
+                guard backgroundTasks.hasUnresolvedIdentifiedChildren else { return }
+                try? await Task.sleep(for: Self.backgroundRegistryPollInterval)
+            }
+        }
+    }
+
+    /// Fresh child evidence on a chat that is not already asking the registry.
+    @MainActor
+    func startBackgroundRegistryPollingIfIdle() {
+        guard !state.backgroundRegistryPolling else { return }
+        startBackgroundRegistryPolling()
+    }
+
     func visibleBackgroundTasks(now: Int64) -> BackgroundTasks {
         BackgroundTasks(rows: backgroundTasks.rows.filter {
             !($0.isDismissible(now: now) && state.dismissedBackgroundEvidence.contains($0.dismissalKey))

--- a/ios/Mercury/Views/ChatSessionLoader.swift
+++ b/ios/Mercury/Views/ChatSessionLoader.swift
@@ -159,6 +159,10 @@ extension ChatView {
         }
         if state.connection == nil {
             retryConnectionNow(automatic: true)
+        } else if !state.closedByUs {
+            // The socket survived the background; ask the registry now rather
+            // than waiting out the poll interval for children's liveness.
+            startBackgroundRegistryPolling()
         }
     }
 

--- a/ios/Mercury/Views/ChatSessionState.swift
+++ b/ios/Mercury/Views/ChatSessionState.swift
@@ -138,6 +138,12 @@ final class ChatSessionState {
     /// once the gateway persists the new runtime session.
     var durableID: String?
     var eventTask: Task<Void, Never>?
+    /// Periodic `delegation.status` reconciliation while unresolved children remain.
+    var backgroundRegistryTask: Task<Void, Never>?
+    var backgroundRegistryPolling = false
+    var backgroundRegistryGeneration: UInt64 = 0
+    /// Token of the published live connection, for observers started after connect.
+    var connectionOwnershipToken: ChatConnectionOwnership.Token?
     var pendingRequest: ApprovalSheet.Request?
     /// Batch clarify: qids already answered for the pending request.
     var clarifyAnsweredIDs: Set<String> = []

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -249,6 +249,8 @@ struct ChatView: View {
             state.readAloud?.stop()
             state.eventTask?.cancel()
             state.eventTask = nil
+            state.backgroundRegistryTask?.cancel()
+            state.backgroundRegistryTask = nil
             let closingConnection = state.connection
             markBackgroundTasksUnavailable()
             state.connectionOwnership.invalidate()

--- a/ios/MercuryTests/BackgroundTasksTests.swift
+++ b/ios/MercuryTests/BackgroundTasksTests.swift
@@ -1,9 +1,10 @@
 import XCTest
+import MercuryCore
 @testable import Mercury
 
 final class BackgroundTasksTests: XCTestCase {
     func testGlobalRegistryAbsenceNeverMeansSuccessOrOwnership() {
-        var tasks = BackgroundTasks()
+        var tasks = Mercury.BackgroundTasks()
         tasks.apply(event("subagent.start"), runtime: "runtime", now: 1000)
         tasks.markUnavailable()
         let stale = tasks
@@ -13,19 +14,19 @@ final class BackgroundTasksTests: XCTestCase {
         XCTAssertEqual(tasks, stale)
     }
     func testFailureAndStopAreDistinctExplicitTerminals() {
-        for (wire, expected) in [("failed", BackgroundTaskStatus.failed), ("timeout", .failed), ("interrupted", .stopped)] {
-            var tasks = BackgroundTasks()
+        for (wire, expected) in [("failed", Mercury.BackgroundTaskStatus.failed), ("timeout", .failed), ("interrupted", .stopped)] {
+            var tasks = Mercury.BackgroundTasks()
             tasks.apply(event("subagent.complete", status: wire), runtime: "runtime", now: 1000)
             XCTAssertEqual(tasks.rows.first?.status, expected)
         }
     }
-    private func event(_ type: String, status: String? = nil, session: String = "runtime") -> ChatEvent {
+    private func event(_ type: String, status: String? = nil, session: String = "runtime") -> Mercury.ChatEvent {
         var payload: [String: Any] = ["subagent_id": "child", "goal": "Review tests"]
         if let status { payload["status"] = status }
         return .backgroundTask(sessionID: session, evidence: BackgroundTaskEvidence.decode(type: type, payload: payload)!)
     }
     func testParentCompletionAndNewPromptPreserveChild() {
-        var tasks = BackgroundTasks()
+        var tasks = Mercury.BackgroundTasks()
         tasks.apply(event("subagent.start"), runtime: "runtime", now: 1000)
         let started = tasks
         tasks.apply(.messageStart(sessionID: "runtime", text: nil), runtime: "runtime", now: 2000)
@@ -34,7 +35,7 @@ final class BackgroundTasksTests: XCTestCase {
         XCTAssertEqual(tasks.activeCount(now: 3000), 1)
     }
     func testStaleIdentityAndExplicitTerminal() {
-        var tasks = BackgroundTasks()
+        var tasks = Mercury.BackgroundTasks()
         tasks.apply(event("subagent.start"), runtime: "runtime", now: 1000)
         tasks.apply(event("subagent.complete", status: "completed", session: "old"), runtime: "runtime", now: 2000)
         XCTAssertEqual(tasks.activeCount(now: 2000), 1)
@@ -43,8 +44,40 @@ final class BackgroundTasksTests: XCTestCase {
         tasks.apply(event("subagent.tool"), runtime: "runtime", now: 4000)
         XCTAssertEqual(tasks.rows.first?.status, .finished)
     }
+    func testRecoveredSnapshotCountsActiveOnlyWhileHostRegistryConfirmsRunning() throws {
+        // Cold reopen mid-delegation: the relay snapshot proves the child existed; the
+        // gateway registry answering "running" is the only fresh liveness evidence.
+        let snapshot = MercuryCore.RelayLeaseSnapshot(
+            leaseId: "lease", lastSeq: 8, gap: false, reset: false,
+            bindings: [MercuryCore.RelayLeaseBinding(runtimeId: "runtime", durableId: "durable", profile: "default", live: true)],
+            tasks: ["""
+                {"jsonrpc":"2.0","method":"event","params":{"session_id":"runtime","type":"subagent.start",
+                "payload":{"subagent_id":"child","goal":"Write a poem","status":"running"},"recovery_revision":1,
+                "recovery_binding":{"runtime_session_id":"runtime","durable_session_id":"durable","profile":"default","live":true}}}
+                """],
+            truncated: false, routingToken: nil)
+        var tasks = Mercury.BackgroundTasks()
+        tasks.recover(snapshot: snapshot, durableID: "durable", profile: "default", runtime: "runtime")
+        XCTAssertEqual(tasks.rows.first?.status, .active)
+        XCTAssertEqual(tasks.activeCount(now: 50_000), 0, "recovered evidence alone never claims a running child")
+        XCTAssertTrue(tasks.hasUnresolvedIdentifiedChildren)
+        tasks.reconcile(["child": "running"], runtime: "runtime", now: 50_000)
+        XCTAssertEqual(tasks.activeCount(now: 50_001), 1)
+        XCTAssertEqual(tasks.rows.first?.observedAtMillis, 0, "registry polling is not worker activity")
+        XCTAssertEqual(tasks.rows.first?.registryConfirmedAtMillis, 50_000)
+        XCTAssertEqual(tasks.rows.first?.label(now: 50_001), "Active · host reports running")
+        XCTAssertEqual(tasks.activeCount(now: 170_000), 0, "one confirmation is one activity window")
+        tasks.apply(event("subagent.tool"), runtime: "runtime", now: 80_000)
+        XCTAssertEqual(tasks.activeCount(now: 190_000), 1, "a live child event refreshes activity")
+        tasks.reconcile(["child": "completed"], runtime: "runtime", now: 300_000)
+        XCTAssertEqual(tasks.activeCount(now: 300_001), 0)
+        XCTAssertFalse(try XCTUnwrap(tasks.rows.first).terminal, "a non-running registry status is not terminal evidence")
+        tasks.markUnavailable()
+        tasks.reconcile(["child": "running"], runtime: "runtime", now: 400_000)
+        XCTAssertEqual(tasks.activeCount(now: 400_001), 1, "a live registry answer restores availability")
+    }
     func testUnavailableNeverClaimsRunningAndPreservesObservationTime() {
-        var tasks = BackgroundTasks()
+        var tasks = Mercury.BackgroundTasks()
         tasks.apply(event("subagent.start"), runtime: "runtime", now: 1000)
         tasks.markUnavailable()
         XCTAssertEqual(tasks.activeCount(now: 2000), 0)

--- a/ios/MercuryTests/RelayTransportTests.swift
+++ b/ios/MercuryTests/RelayTransportTests.swift
@@ -435,6 +435,73 @@ final class RelayTransportTests: XCTestCase {
         XCTAssertEqual(observed.visible, ["B"])
     }
 
+    func testColdReopenRecoveredChildBecomesActiveViaRegistryAndLiveEvents() async throws {
+        // Parent turn already finished on the host (resume running=false); the relay
+        // snapshot carries the child's start, the registry says it still runs, and a
+        // live subagent.tool frame arrives after the reattach.
+        let (device, hostSocket) = InMemoryRelayTransport.pair()
+        let pool = RelayConnectionPool(socketFactory: FakeRelaySocketFactory(sockets: [device]))
+        let host = Task {
+            let admitted = try await admit(socket: hostSocket)
+            let binding: [String: Any] = ["runtime_session_id": "A", "durable_session_id": "durable-A",
+                                          "profile": "default", "live": true]
+            try await sendFrame(["jsonrpc": "2.0", "method": "relay.lease.attached", "params": [
+                "recovery_version": 1, "lease_id": "reopen", "last_seq": 0,
+                "resume_cursor": 0, "replay_gap": false, "recovery_reset": false,
+                "bindings": [binding],
+                "task_snapshot": [["jsonrpc": "2.0", "method": "event", "params": [
+                    "session_id": "A", "type": "subagent.start", "recovery_revision": 1,
+                    "payload": ["subagent_id": "child-A", "goal": "Write a poem", "status": "running"],
+                    "recovery_binding": binding]]]
+            ]], socket: hostSocket, channel: admitted.channel)
+            try await sendFrame(["jsonrpc": "2.0", "method": "relay.lease.replay_complete",
+                                 "params": ["lease_id": "reopen", "last_seq": 0]],
+                                socket: hostSocket, channel: admitted.channel)
+            let request = try await readFrame(socket: hostSocket, channel: admitted.channel,
+                                              reassembler: admitted.reassembler)
+            func send(_ seq: Int, _ frame: [String: Any]) async throws {
+                let text = String(decoding: try JSONSerialization.data(withJSONObject: frame), as: UTF8.self)
+                try await sendFrame(["jsonrpc": "2.0", "method": "relay.lease.frame", "params": [
+                    "lease_id": "reopen", "seq": seq, "replay": false, "frame": text
+                ]], socket: hostSocket, channel: admitted.channel)
+            }
+            try await send(1, ["jsonrpc": "2.0", "id": try XCTUnwrap(request["id"]), "result": ["ok": true]])
+            let second = try await readFrame(socket: hostSocket, channel: admitted.channel,
+                                             reassembler: admitted.reassembler)
+            try await send(2, ["jsonrpc": "2.0", "method": "event", "params": [
+                "session_id": "A", "type": "subagent.tool",
+                "payload": ["subagent_id": "child-A", "tool_name": "execute_code", "tool_preview": "python poem.py"]]])
+            try await send(3, ["jsonrpc": "2.0", "id": try XCTUnwrap(second["id"]), "result": ["ok": true]])
+        }
+        let connection = try await pool.acquire(target: makeTarget(), profile: "default")
+        _ = connection.start(replayBuffered: false)
+        _ = try await connection.relayRequest("relay.sessions.list", params: [:])
+        let relay = try XCTUnwrap(connection.relaySocket)
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        let recoveredTasks = await relay.retainedTasks(durable: "durable-A", runtime: "A")
+        let recovered = try XCTUnwrap(recoveredTasks)
+        XCTAssertEqual(recovered.rows.map(\.childID), ["child-A"])
+        XCTAssertEqual(recovered.rows.first?.status, .active)
+        XCTAssertEqual(recovered.activeCount(now: now), 0, "a recovered snapshot alone is not live evidence")
+        XCTAssertTrue(recovered.hasUnresolvedIdentifiedChildren)
+        let confirmedTasks = await relay.reconcileRetainedTasks(durable: "durable-A", runtime: "A",
+                                                                statuses: ["child-A": "running"])
+        let confirmed = try XCTUnwrap(confirmedTasks)
+        XCTAssertEqual(confirmed.activeCount(now: now + 1), 1, "the host registry confirming the child counts as live")
+        XCTAssertEqual(confirmed.rows.first?.observedAtMillis, 0, "registry polling is not worker activity")
+        // The live tool frame rides the second request's turn on the host side.
+        _ = try await connection.relayRequest("relay.sessions.list", params: [:])
+        let observedTasks = await relay.retainedTasks(durable: "durable-A", runtime: "A")
+        let observed = try XCTUnwrap(observedTasks)
+        XCTAssertEqual(observed.rows.first?.action, "python poem.py")
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(observed.rows.first?.observedAtMillis), now)
+        XCTAssertEqual(observed.rows.first?.registryConfirmedAtMillis, confirmed.rows.first?.registryConfirmedAtMillis)
+        XCTAssertEqual(observed.activeCount(now: now + 1), 1)
+        try await host.value
+        await connection.close()
+        await hostSocket.close()
+    }
+
     func testAutomaticRecoveryAfterResetDoesNotResumeUntilExplicitRetry() async throws {
         let (device, hostSocket) = InMemoryRelayTransport.pair()
         let pool = RelayConnectionPool(socketFactory: FakeRelaySocketFactory(sockets: [device]))

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -16,7 +16,7 @@ settings:
     # number, which App Store validation requires. Bump MARKETING_VERSION with
     # each release alongside versionName.
     MARKETING_VERSION: "0.2.5"
-    CURRENT_PROJECT_VERSION: 2
+    CURRENT_PROJECT_VERSION: 3
 
 targets:
   MercuryShareKit:

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/relay/BackgroundTasks.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/relay/BackgroundTasks.kt
@@ -28,9 +28,22 @@ data class BackgroundTaskRow(
     val observedAtMillis: Long,
     val available: Boolean = true,
     val identityKnown: Boolean = true,
+    /**
+     * When the gateway's own subagent registry last reported this child as
+     * running. Registry polling is not worker activity (it never moves
+     * [observedAtMillis]), but it is authoritative liveness: a reopened app
+     * whose only child evidence is a recovered snapshot has no fresh event to
+     * observe, and the host saying "still running" must count as active.
+     */
+    val registryConfirmedAtMillis: Long = 0L,
 ) {
     val terminal: Boolean get() = status in setOf(BackgroundTaskStatus.Finished, BackgroundTaskStatus.Failed, BackgroundTaskStatus.Stopped)
-    fun recentlyActive(now: Long): Boolean = identityKnown && available && status == BackgroundTaskStatus.Active && now - observedAtMillis < 120_000
+    fun recentlyActive(now: Long): Boolean = identityKnown && available && status == BackgroundTaskStatus.Active &&
+        (observedRecently(now) || registryConfirmedRecently(now))
+    fun observedRecently(now: Long): Boolean =
+        observedAtMillis > 0L && now - observedAtMillis < ACTIVITY_WINDOW_MILLIS
+    fun registryConfirmedRecently(now: Long): Boolean =
+        registryConfirmedAtMillis > 0L && now - registryConfirmedAtMillis < ACTIVITY_WINDOW_MILLIS
     fun label(now: Long): String = when {
         terminal -> when (status) {
             BackgroundTaskStatus.Finished -> "Finished"
@@ -45,6 +58,7 @@ data class BackgroundTaskRow(
         !available -> "Last known · updates unavailable"
         status == BackgroundTaskStatus.Unknown -> "Status unavailable"
         !recentlyActive(now) -> "Last known active · no recent activity"
+        !observedRecently(now) -> "Active · host reports running"
         else -> "Active · observed activity"
     }
 
@@ -54,6 +68,11 @@ data class BackgroundTaskRow(
     fun dismissalKey(): String = BackgroundTaskPresentationPolicy.dismissalKey(this)
 
     fun timeLabel(now: Long): String = BackgroundTaskPresentationPolicy.timeLabel(this, now)
+
+    companion object {
+        /** How long one observation (a child event or a registry confirmation) counts as live. */
+        const val ACTIVITY_WINDOW_MILLIS = 120_000L
+    }
 }
 
 /** Shared summary and dismissal policy for unresolved child-task evidence. */
@@ -171,21 +190,24 @@ data class BackgroundTasks(
      * [previousRuntime] is opt-in proof from the caller that this is a rebind of the SAME
      * durable session and origin/controller generation, not a different session's runtime.
      * Only exact previously observed, still-active IDs may move to the replacement binding.
-     * Registry polling is not child activity and must not refresh observedAtMillis.
+     * Registry polling is not child activity and must not refresh observedAtMillis; a
+     * "running" report is recorded separately as registry-confirmed liveness at [now].
      */
     fun reconcile(
         active: List<BackgroundTaskRegistryEntry>,
         runtime: String,
         previousRuntime: String = runtime,
+        now: Long = 0L,
     ): BackgroundTasks = copy(rows = rows.map { row ->
         val observed = active.singleOrNull { it.subagentId == row.id }
         val running = observed?.status == "running" || observed?.status == "active"
+        val confirmedAt = if (running) maxOf(now, row.registryConfirmedAtMillis) else row.registryConfirmedAtMillis
         when {
             !row.identityKnown || row.terminal || observed == null -> row
-            row.runtimeId == runtime -> row.copy(available = running)
+            row.runtimeId == runtime -> row.copy(available = running, registryConfirmedAtMillis = confirmedAt)
             row.runtimeId == previousRuntime && running && rows.none {
                 it.runtimeId == runtime && it.id == row.id && it.identityKnown
-            } -> row.copy(runtimeId = runtime, available = true)
+            } -> row.copy(runtimeId = runtime, available = true, registryConfirmedAtMillis = confirmedAt)
             else -> row
         }
     })
@@ -215,7 +237,8 @@ data class BackgroundTasks(
             if (event.historical) {
                 if (event.kind == BackgroundTaskEventKind.Complete) 0L else old?.observedAtMillis ?: 0L
             } else now,
-            available = !event.historical, identityKnown = childId != null)
+            available = !event.historical, identityKnown = childId != null,
+            registryConfirmedAtMillis = old?.registryConfirmedAtMillis ?: 0L)
         if (index < 0 && rows.size >= 64) return this // never evict unresolved work to invent a complete list
         return copy(
             rows = if (index < 0) rows + row else rows.toMutableList().also { it[index] = row },

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/relay/RelayTaskRecoveryTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/relay/RelayTaskRecoveryTest.kt
@@ -46,4 +46,38 @@ class RelayTaskRecoveryTest {
         assertFalse(result.rows.single().available)
         assertEquals(100L, result.rows.single().observedAtMillis)
     }
+
+    @Test fun recoveredLiveEvidenceCountsActiveOnlyWhileTheHostRegistryConfirmsRunning() {
+        // Cold reopen mid-delegation: the snapshot proves the child existed, not that it
+        // still runs. The gateway's registry answering "running" is authoritative liveness.
+        val recovered = BackgroundTasks().recoverRelayTasks(
+            snapshot(live = true, kind = "subagent.start", status = "running"), "session", "default", "old-runtime")
+        assertEquals(BackgroundTaskStatus.Active, recovered.rows.single().status)
+        assertFalse(recovered.rows.single().available)
+        assertEquals(0, recovered.activeCount(50_000))
+        val confirmed = recovered.reconcile(listOf(BackgroundTaskRegistryEntry("child", "running")), "old-runtime", now = 50_000)
+        assertEquals(1, confirmed.activeCount(50_001))
+        assertEquals(0L, confirmed.rows.single().observedAtMillis, "registry polling never counts as worker activity")
+        assertEquals("Active · host reports running", confirmed.rows.single().label(50_001))
+        assertEquals(0, confirmed.activeCount(50_000 + BackgroundTaskRow.ACTIVITY_WINDOW_MILLIS), "one confirmation is one window")
+        val later = confirmed.reconcile(listOf(BackgroundTaskRegistryEntry("child", "running")), "old-runtime", now = 200_000)
+        assertEquals(1, later.activeCount(200_001))
+        val gone = later.reconcile(listOf(BackgroundTaskRegistryEntry("child", "completed")), "old-runtime", now = 300_000)
+        assertEquals(0, gone.activeCount(300_001), "a non-running registry status is not active and not terminal")
+        assertFalse(gone.rows.single().terminal)
+        assertEquals(confirmed, confirmed.reconcile(emptyList(), "old-runtime", now = 60_000), "registry silence changes nothing")
+    }
+
+    @Test fun liveChildEventAfterRegistryConfirmationKeepsTheConfirmationAndRefreshesActivity() {
+        val recovered = BackgroundTasks().recoverRelayTasks(
+            snapshot(live = true, kind = "subagent.start", status = "running"), "session", "default", "old-runtime")
+            .reconcile(listOf(BackgroundTaskRegistryEntry("child", "running")), "old-runtime", now = 50_000)
+        val observed = recovered.reduce(
+            BackgroundTaskEvent("old-runtime", BackgroundTaskEventKind.Tool, "child", null, "execute_code", eventId = "lease:9"),
+            "old-runtime", 80_000)
+        assertEquals(80_000L, observed.rows.single().observedAtMillis)
+        assertEquals(50_000L, observed.rows.single().registryConfirmedAtMillis)
+        assertEquals(1, observed.activeCount(190_000))
+        assertEquals(0, observed.unavailable().activeCount(80_001), "a dead connection still hides confirmed children")
+    }
 }


### PR DESCRIPTION
## Summary

Stacked on #69. Reopening the app while a `delegate_task` batch is still running showed the chat as finished history with no activity line (iPhone screenshot from the poems session, `20260909_031442_6f2c36`). The gateway ends the parent turn within seconds of an async delegation, so `session.resume` truthfully reports `running=false`; the only evidence a reopened app has is the relay's recovered child snapshot plus the `delegation.status` registry.

Recovered rows were imported unavailable with no observation time, and a registry "running" answer only flipped availability, so `activeCount` stayed 0 and the composer line hid the still-working subagents. Android additionally zeroed the child count whenever history was marked `restored` (same class of bug #69 fixed for `isSending`).

- **shared core**: a registry "running" report is recorded as `registryConfirmedAtMillis` and counts as liveness for one activity window without touching the worker-observed timestamp. Row label reads "Active · host reports running". Registry silence and non-running statuses still change nothing and are never terminal.
- **iOS**: poll `delegation.status` every 30s while unresolved identified children remain (started on connect, on a live child event, and on foreground catch-up).
- **Android**: same polling loop; the composer line no longer drops the background count on `restored`.
- iOS build number bumped to 3 (installed on the iPhone 17 Pro in place).

## Hermes compatibility

Uses only released gateway interfaces already consumed by both apps: `delegation.status` (registry read) and the relay-retained `subagent.*` events. No server, plugin, or worker change. Relay recovery semantics are untouched; direct mode only gains the same registry poll.

## Cross-platform

Shared decision lives in `shared/mercury-core` (`BackgroundTasks.reconcile` / `recentlyActive`). Both platforms get the polling loop and the same label. Android UI gate change in `SessionDetailScreen`; iOS in `ChatProgressRecovery`.

## Verification

- [x] `./gradlew :app:testDebugUnitTest :shared:mercury-core:testAndroidHostTest` — 1037 + 283 passed, 0 failures
- [x] `./gradlew :app:lintDebug` — clean
- [x] iOS `MercuryTests` on the iPhone 17 Pro simulator — 665 passed, 0 failures
- [x] Signed device build installed in place on the iPhone 17 Pro (0.2.5 build 3), launched, inventory shows one bundle
- [ ] `./gradlew validateDebugScreenshotTest` (no reference changes)
- [x] No credentials, transcripts, or build output added

New regression tests: core `RelayTaskRecoveryTest` (recover → registry confirm → window expiry → live event), Android `ComposerActivityIntegrationTest.restoredHistoryNeverHidesHostConfirmedBackgroundChildren`, iOS `BackgroundTasksTests.testRecoveredSnapshotCountsActiveOnlyWhileHostRegistryConfirmsRunning`, and `RelayTransportTests.testColdReopenRecoveredChildBecomesActiveViaRegistryAndLiveEvents` (relay reattach with snapshot, registry confirm, then a live `subagent.tool` frame).

Known limit: a child inside a very long silent tool call is kept alive only by the 30s registry poll, which is the only liveness signal the gateway offers.

## Screenshots

Not applicable beyond the reported screenshot; the visible change is the "N background tasks" composer line reappearing after a reopen.