### PR TITLE
fix: keep Home background rows live and legible; harden registry polling

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -5307,6 +5307,53 @@ class HermesConnectionViewModel(
         }
     }
 
+    private fun hasUnresolvedIdentifiedChildren(durableSessionId: DurableSessionId): Boolean =
+        mutableSnapshots.value.chatSessions[durableSessionId]?.backgroundTasks?.rows
+            ?.any { !it.terminal && it.identityKnown } == true
+
+    /**
+     * A reopened app's only child evidence is a recovered snapshot with no fresh
+     * event to observe, and a child inside a long tool call emits nothing. The
+     * gateway's subagent registry is the authoritative liveness signal, so keep
+     * asking it while unresolved children remain; each "running" report counts
+     * as activity for one window without pretending to be a worker event.
+     * Idempotent per controller: a running poll is never duplicated.
+     */
+    private fun startBackgroundRegistryPolling(
+        controller: PerSessionController,
+        session: HermesChatSession,
+        durableSessionId: DurableSessionId,
+        runtimeSessionId: RuntimeSessionId,
+        origin: ServerOrigin,
+        originGeneration: Long,
+        operationGeneration: Long,
+        previousRuntimeSessionId: RuntimeSessionId = runtimeSessionId,
+    ) {
+        if (controller.registryJob?.isActive == true) return
+        controller.registryJob = viewModelScope.launch {
+            var previousRuntime = previousRuntimeSessionId
+            while (true) {
+                if (!isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration) ||
+                    liveControllers[durableSessionId]?.session !== session) return@launch
+                try {
+                    val status = session.loadDelegationStatus()
+                    if (isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration) &&
+                        liveControllers[durableSessionId]?.session === session) {
+                        updateChat(durableSessionId) {
+                            it.copy(backgroundTasks = it.backgroundTasks.reconcile(
+                                status, runtimeSessionId, previousRuntime, System.currentTimeMillis()))
+                        }
+                        previousRuntime = runtimeSessionId
+                    }
+                } catch (cancelled: CancellationException) { throw cancelled }
+                catch (_: HermesChatMethodNotFoundException) { return@launch }
+                catch (_: Exception) { /* Retain last known rows; absence is not success. */ }
+                if (!hasUnresolvedIdentifiedChildren(durableSessionId)) return@launch
+                delay(BACKGROUND_REGISTRY_POLL_MILLIS)
+            }
+        }
+    }
+
     private fun collectEvents(
         session: HermesChatSession,
         durableSessionId: DurableSessionId,
@@ -5327,35 +5374,10 @@ class HermesConnectionViewModel(
             }
         }
         if (mutableSnapshots.value.chatSessions[durableSessionId]?.backgroundTasks?.rows?.isNotEmpty() == true) {
-            viewModelScope.launch {
-                // A reopened app's only child evidence is a recovered snapshot with no
-                // fresh event to observe. The gateway's subagent registry is the
-                // authoritative liveness signal, so keep asking it while unresolved
-                // children remain; each "running" report counts as activity for one
-                // window without pretending to be a worker event.
-                var previousRuntime = previousRuntimeSessionId
-                while (true) {
-                    if (!isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration) ||
-                        liveControllers[durableSessionId]?.session !== session) return@launch
-                    try {
-                        val status = session.loadDelegationStatus()
-                        if (isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration) &&
-                            liveControllers[durableSessionId]?.session === session) {
-                            updateChat(durableSessionId) {
-                                it.copy(backgroundTasks = it.backgroundTasks.reconcile(
-                                    status, runtimeSessionId, previousRuntime, System.currentTimeMillis()))
-                            }
-                            previousRuntime = runtimeSessionId
-                        }
-                    } catch (cancelled: CancellationException) { throw cancelled }
-                    catch (_: HermesChatMethodNotFoundException) { return@launch }
-                    catch (_: Exception) { /* Retain last known rows; absence is not success. */ }
-                    val unresolved = mutableSnapshots.value.chatSessions[durableSessionId]?.backgroundTasks?.rows
-                        ?.any { !it.terminal && it.identityKnown } == true
-                    if (!unresolved) return@launch
-                    delay(BACKGROUND_REGISTRY_POLL_MILLIS)
-                }
-            }
+            startBackgroundRegistryPolling(
+                controller, session, durableSessionId, runtimeSessionId,
+                origin, originGeneration, operationGeneration, previousRuntimeSessionId,
+            )
         }
         val eventJob = viewModelScope.launch(start = CoroutineStart.LAZY) {
             session.events.catch { error ->
@@ -5379,6 +5401,15 @@ class HermesConnectionViewModel(
                             it.copy(backgroundTasks = it.backgroundTasks.reduce(event, runtimeSessionId, System.currentTimeMillis()))
                         }
                         session.acknowledgeRelayEvent(event.eventId)
+                        // A chat that connected with no retained rows has no poll yet;
+                        // the first live child must start one or a child inside a long
+                        // silent tool call would vanish after its activity window.
+                        if (hasUnresolvedIdentifiedChildren(durableSessionId)) {
+                            startBackgroundRegistryPolling(
+                                controller, session, durableSessionId, runtimeSessionId,
+                                origin, originGeneration, operationGeneration,
+                            )
+                        }
                     }
                     is HermesChatEvent.MessageStart,
                     is HermesChatEvent.MessageDelta,
@@ -7004,6 +7035,7 @@ class HermesConnectionViewModel(
         clearSlashCompletion(durableSessionId)
         val controller = liveControllers[durableSessionId] ?: return
         controller.eventJob?.cancel()
+        controller.registryJob?.cancel()
         removeActiveRuntime(controller.runtimeSessionId)
         detachController(durableSessionId, controller.session, closeSession = true)
     }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/PerSessionController.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/PerSessionController.kt
@@ -31,6 +31,8 @@ internal data class PerSessionController(
     val runtimeSessionId: RuntimeSessionId,
     var operationGeneration: Long,
     var eventJob: Job? = null,
+    /** Registry liveness polling for unresolved delegated children of this runtime. */
+    var registryJob: Job? = null,
     var recoveryState: ChatRecoveryState? = null,
 )
 
@@ -277,7 +279,7 @@ internal class PerSessionControllerRegistry {
         slashCompletionJobs.values.forEach(Job::cancel)
         slashCompletionJobs.clear()
         slashCompletionGenerations.clear()
-        detached.forEach { it.eventJob?.cancel() }
+        detached.forEach { it.eventJob?.cancel(); it.registryJob?.cancel() }
         activeTurnIds.clear()
         lastPublishedActiveTurnCount = 0
         return detached

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
@@ -2299,6 +2299,34 @@ class HermesConnectionViewModelTest {
     }
 
     @Test
+    fun firstLiveChildEventStartsRegistryPollingAndKeepsSilentChildConfirmed() = runTest(dispatcher) {
+        val origin = ServerOrigin.parse("https://hermes.example")
+        // Connected with no retained rows: only the live child event can start polling.
+        val session = TerminalToolChatSession(withBackgroundTask = true, registryReportsRunning = 2)
+        val client = AuthenticatingHermesConnectionClient()
+        val viewModel = HermesConnectionViewModel(
+            settingsStates = MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin)),
+            client = client, tokenStore = FixedTokenStore(),
+            chatConnector = HermesChatConnector { _, _ -> session },
+        )
+        runCurrent()
+        client.probeResponse.complete(authRequiredInfo())
+        runCurrent()
+        client.authenticationResponse.complete(AuthenticatedHermesConnection("user", emptyList()))
+        advanceUntilIdle()
+        val id = viewModel.createNewSession()
+        viewModel.sendMessage(id, "research")
+        advanceUntilIdle()
+
+        // Two "running" answers then an unsupported method: the poll ran after the
+        // first child event, kept going on the interval, and stopped cleanly.
+        assertEquals(3, session.delegationStatusCalls)
+        val row = viewModel.snapshots.value.chatSessions.getValue(id).backgroundTasks.rows.single()
+        assertEquals("own-child", row.id)
+        assertTrue(row.registryConfirmedAtMillis > 0L)
+    }
+
+    @Test
     fun duplicateSendCannotReplacePendingDraftCreateOrItsCanonicalAlias() = runTest(dispatcher) {
         val origin = ServerOrigin.parse("https://hermes.example")
         val first = BlockingCreateProjectDraftChatSession("stale-canonical")
@@ -4692,10 +4720,24 @@ private class CanonicalProjectDraftChatSession(
     }
 }
 
-private class TerminalToolChatSession(private val withBackgroundTask: Boolean = false) : HermesChatSession {
+private class TerminalToolChatSession(
+    private val withBackgroundTask: Boolean = false,
+    /** How many registry polls report the child running before the method disappears. */
+    private val registryReportsRunning: Int = 0,
+) : HermesChatSession {
     private val channel = Channel<HermesChatEvent>(Channel.UNLIMITED)
     private val runtimeSessionId = RuntimeSessionId("runtime-terminal-tools")
     override val events = channel.receiveAsFlow()
+    var delegationStatusCalls = 0
+        private set
+
+    override suspend fun loadDelegationStatus(): DelegationStatus {
+        delegationStatusCalls += 1
+        if (delegationStatusCalls > registryReportsRunning) {
+            throw com.unsupportedpastels.hermesandroid.gateway.HermesChatMethodNotFoundException("delegation.status")
+        }
+        return DelegationStatus(active = listOf(DelegatedSubagent("own-child", "Review tests", "running")))
+    }
 
     override suspend fun resume(
         durableSessionId: DurableSessionId,

--- a/ios/Mercury/AppModel.swift
+++ b/ios/Mercury/AppModel.swift
@@ -295,6 +295,37 @@ final class AppModel {
         self.offlineCacheStore = offlineCacheStore
         self.relayTargetStore = relayTargetStore
         self.startupChoiceStore = startupChoiceStore
+        Task { [weak self] in
+            await RelayConnectionPool.shared.setTaskSink { target, profile, durable, tasks in
+                Task { @MainActor in
+                    self?.observeRelayBackgroundTasks(target: target, profile: profile,
+                                                      durable: durable, tasks: tasks)
+                }
+            }
+        }
+    }
+
+    // MARK: - Background tasks
+
+    /// One key per (transport, profile, durable session) for `backgroundTasksBySession`.
+    static func backgroundTaskScope(relayTarget: RelayPairedTarget?, serverOrigin: String?,
+                                    profile: String, durable: String) -> String {
+        let origin = relayTarget.map { "relay:\($0.relayOrigin)|\($0.id)" }
+            ?? "direct:\(serverOrigin ?? "unconfigured")"
+        return "\(origin)|\(profile)|\(durable)"
+    }
+
+    /// A pooled relay reader applied child evidence for a durable session,
+    /// whether or not that chat is open. Home reads this dictionary, so the
+    /// copy must follow the owner or a completion would strand a stale row.
+    func observeRelayBackgroundTasks(target: RelayPairedTarget, profile: String,
+                                     durable: String, tasks: BackgroundTasks) {
+        guard activeRelayTarget?.id == target.id else { return }
+        let scope = Self.backgroundTaskScope(relayTarget: target, serverOrigin: nil,
+                                             profile: profile, durable: durable)
+        if backgroundTasksBySession[scope] != tasks {
+            backgroundTasksBySession[scope] = tasks
+        }
     }
 
     /// The currently live, successfully selected identity. It is derived from

--- a/ios/Mercury/MercuryKit/Chat/BackgroundTasks.swift
+++ b/ios/Mercury/MercuryKit/Chat/BackgroundTasks.swift
@@ -123,6 +123,16 @@ struct BackgroundTasks: @unchecked Sendable, Equatable {
             headline: decision.headline
         )
     }
+    /// Rows a host-wide "running" surface may show; see the shared policy.
+    static func runningRows(_ rows: [BackgroundTaskRow], now: Int64) -> [BackgroundTaskRow] {
+        let core = MercuryCore.BackgroundTaskPresentationPolicy.shared.runningRows(rows: rows.map(\.core), now: now)
+        return core.map { row in
+            BackgroundTaskRow(runtime: row.runtimeId, childID: row.id, goal: row.goal,
+                action: row.action, status: BackgroundTaskStatus(row.status),
+                observedAtMillis: row.observedAtMillis, available: row.available,
+                identityKnown: row.identityKnown)
+        }
+    }
     func secondaryLabel(rows: [BackgroundTaskRow], now: Int64) -> String {
         MercuryCore.BackgroundTaskPresentationPolicy.shared.secondaryLabel(
             rows: rows.map(\.core), now: now

--- a/ios/Mercury/MercuryKit/Relay/RelayConnectionPool.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayConnectionPool.swift
@@ -43,6 +43,25 @@ actor RelayConnectionPool {
         routingTokenSink = sink
     }
 
+    /// Receives every durable background-task state a pooled reader rewrites:
+    /// (target, profile, durable session id, state). Delivered off the actor.
+    typealias TaskSink = @Sendable (RelayPairedTarget, String, String, BackgroundTasks) -> Void
+    private var taskSink: TaskSink?
+
+    func setTaskSink(_ sink: TaskSink?) {
+        taskSink = sink
+        for slot in slots.values {
+            guard let scope = slot.scope else { continue }
+            slot.taskOwner.setSink(Self.ownerSink(sink, target: scope.target, profile: scope.profile))
+        }
+    }
+
+    private static func ownerSink(_ sink: TaskSink?, target: RelayPairedTarget, profile: String)
+        -> (@Sendable (String, BackgroundTasks) -> Void)? {
+        guard let sink else { return nil }
+        return { durable, state in sink(target, profile, durable, state) }
+    }
+
     init(socketFactory: any RelayBinarySocketFactorying = URLSessionRelaySocketFactory(),
          selectionRequired: Bool = false) {
         self.selectionRequired = selectionRequired
@@ -105,6 +124,7 @@ actor RelayConnectionPool {
         }
         let checkpoint = slot.checkpoint
         let taskOwner = slot.taskOwner
+        taskOwner.setSink(Self.ownerSink(taskSink, target: target, profile: profile))
         previousOpening?.cancel()
         slot.generation = UUID()
         let token = slot.generation

--- a/ios/Mercury/MercuryKit/Relay/RelayTaskOwner.swift
+++ b/ios/Mercury/MercuryKit/Relay/RelayTaskOwner.swift
@@ -9,28 +9,50 @@ final class RelayTaskOwner: @unchecked Sendable {
     private var profile = ""
     private var bindings: [String: MercuryCore.RelayLeaseBinding] = [:]
     private var tasks: [String: BackgroundTasks] = [:]
+    /// Observes every durable state this owner rewrites, keyed by durable
+    /// session id. A Home surface reads it while no chat is subscribed to the
+    /// pooled reader, so a child completion never strands a stale row.
+    private var sink: (@Sendable (String, BackgroundTasks) -> Void)?
+
+    func setSink(_ sink: (@Sendable (String, BackgroundTasks) -> Void)?) {
+        lock.lock(); self.sink = sink; lock.unlock()
+    }
+
+    /// Delivers outside the lock so an observer may re-enter this owner.
+    private func publish(_ changes: [(String, BackgroundTasks)]) {
+        lock.lock(); let sink = self.sink; lock.unlock()
+        guard let sink else { return }
+        for (durable, state) in changes { sink(durable, state) }
+    }
 
     func attach(snapshot: MercuryCore.RelayLeaseSnapshot, profile: String) -> UUID {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
         generation = UUID()
         self.profile = profile
         bindings = Dictionary(uniqueKeysWithValues: snapshot.bindings
             .filter { $0.profile == profile }.map { ($0.runtimeId, $0) })
+        var changes: [(String, BackgroundTasks)] = []
         for durable in Set(tasks.keys).union(bindings.values.map(\.durableId)) {
             var state = tasks[durable] ?? BackgroundTasks()
             state.recover(snapshot: snapshot, durableID: durable, profile: profile, runtime: nil)
             tasks[durable] = state
+            if !state.rows.isEmpty { changes.append((durable, state)) }
         }
-        return generation
+        let attached = generation
+        lock.unlock()
+        publish(changes)
+        return attached
     }
 
     /// Only an authenticated, correlated create/resume response may add a live binding.
     func bind(generation: UUID, runtime: String, durable: String, profile: String) {
-        lock.lock(); defer { lock.unlock() }
-        guard self.generation == generation, self.profile == profile else { return }
+        lock.lock()
+        guard self.generation == generation, self.profile == profile else { lock.unlock(); return }
+        var changes: [(String, BackgroundTasks)] = []
         if bindings[runtime]?.durableId != durable || bindings[runtime]?.live != true {
             // A new runtime is not fresh activity evidence for the old worker.
             tasks[durable]?.markUnavailable()
+            if let state = tasks[durable], !state.rows.isEmpty { changes.append((durable, state)) }
         }
         for (id, binding) in bindings where binding.durableId == durable && id != runtime {
             bindings[id] = MercuryCore.RelayLeaseBinding(runtimeId: id, durableId: durable,
@@ -38,29 +60,43 @@ final class RelayTaskOwner: @unchecked Sendable {
         }
         bindings[runtime] = MercuryCore.RelayLeaseBinding(runtimeId: runtime, durableId: durable,
                                                          profile: profile, live: true)
+        lock.unlock()
+        publish(changes)
     }
 
     /// False means explicit rejection, never an application to the visible runtime.
     @discardableResult
     func apply(generation: UUID, runtime: String, evidence: BackgroundTaskEvidence) -> Bool {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
         guard self.generation == generation,
-              let binding = bindings[runtime], binding.live, binding.profile == profile else { return false }
+              let binding = bindings[runtime], binding.live, binding.profile == profile else {
+            lock.unlock()
+            return false
+        }
         var state = tasks[binding.durableId] ?? BackgroundTasks()
         state.apply(.backgroundTask(sessionID: runtime, evidence: evidence), runtime: runtime,
                     now: Int64(Date().timeIntervalSince1970 * 1000))
+        let changed = state != tasks[binding.durableId]
         tasks[binding.durableId] = state
+        lock.unlock()
+        if changed { publish([(binding.durableId, state)]) }
         return true
     }
 
     func reconcile(generation: UUID, durable: String, runtime: String,
                    statuses: [String: String]) -> BackgroundTasks? {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
         guard self.generation == generation, let binding = bindings[runtime],
-              binding.live, binding.durableId == durable, binding.profile == profile else { return nil }
+              binding.live, binding.durableId == durable, binding.profile == profile else {
+            lock.unlock()
+            return nil
+        }
         var state = tasks[durable] ?? BackgroundTasks()
         state.reconcile(statuses, runtime: runtime, now: Int64(Date().timeIntervalSince1970 * 1000))
+        let changed = state != tasks[durable]
         tasks[durable] = state
+        lock.unlock()
+        if changed { publish([(durable, state)]) }
         return state
     }
 

--- a/ios/Mercury/Views/ChatProgressRecovery.swift
+++ b/ios/Mercury/Views/ChatProgressRecovery.swift
@@ -58,6 +58,14 @@ extension ChatView {
     /// How often a chat re-asks the gateway registry about unresolved children.
     static let backgroundRegistryPollInterval: Duration = .seconds(30)
 
+    /// A registry poll stops for a definitively unsupported method or a dead
+    /// connection (its reconnect restarts polling); every other failure is
+    /// retried on the next interval, matching the Android loop.
+    static func registryPollContinues(after error: Error, connectionClosed: Bool) -> Bool {
+        if connectionClosed || error is CancellationError || error is ChatMethodNotFoundError { return false }
+        return true
+    }
+
     /// A reopened app's only child evidence is a recovered snapshot with no
     /// fresh event to observe, and a child inside a long tool call emits
     /// nothing. The gateway's `delegation.status` registry is the authoritative
@@ -80,9 +88,17 @@ extension ChatView {
             while !Task.isCancelled {
                 guard let candidate, state.connectionOwnership.isCurrent(ownershipToken), state.connection === candidate,
                       backgroundTaskScope == scope, state.runtimeSessionID == childRuntime else { return }
-                guard let statuses = try? await candidate.backgroundTaskStatuses() else {
-                    // Retain last known rows; an unanswered registry is not success or failure.
-                    return
+                let statuses: [String: String]
+                do {
+                    statuses = try await candidate.backgroundTaskStatuses()
+                } catch {
+                    // Retain last known rows; an unanswered registry is not
+                    // success or failure. Only a host without the method ends
+                    // the poll: a transient RPC failure must not hide a
+                    // still-running silent child once its window expires.
+                    guard Self.registryPollContinues(after: error, connectionClosed: candidate.isClosed) else { return }
+                    try? await Task.sleep(for: Self.backgroundRegistryPollInterval)
+                    continue
                 }
                 guard !Task.isCancelled, state.connectionOwnership.isCurrent(ownershipToken), state.connection === candidate,
                       backgroundTaskScope == scope, state.runtimeSessionID == childRuntime else { return }

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -83,9 +83,10 @@ struct ChatView: View {
     @State var state: ChatSessionState
 
     var backgroundTaskScope: String {
-        let origin = appModel.activeRelayTarget.map { "relay:\($0.relayOrigin)|\($0.id)" }
-            ?? "direct:\(appModel.serverOrigin ?? "unconfigured")"
-        return "\(origin)|\(appModel.activeProfile)|\(state.durableID ?? sessionID)"
+        AppModel.backgroundTaskScope(relayTarget: appModel.activeRelayTarget,
+                                     serverOrigin: appModel.serverOrigin,
+                                     profile: appModel.activeProfile,
+                                     durable: state.durableID ?? sessionID)
     }
     var backgroundTasks: BackgroundTasks {
         appModel.backgroundTasksBySession[backgroundTaskScope] ?? BackgroundTasks()
@@ -252,7 +253,10 @@ struct ChatView: View {
             state.backgroundRegistryTask?.cancel()
             state.backgroundRegistryTask = nil
             let closingConnection = state.connection
-            markBackgroundTasksUnavailable()
+            // A pooled relay reader outlives this screen and keeps applying
+            // child evidence through the pool's task sink; only a direct
+            // connection actually stops observing here.
+            if closingConnection?.relaySocket == nil { markBackgroundTasksUnavailable() }
             state.connectionOwnership.invalidate()
             state.connection = nil
             Task { if let closingConnection { await RelayConnectionPool.release(closingConnection) } }

--- a/ios/Mercury/Views/SessionListView.swift
+++ b/ios/Mercury/Views/SessionListView.swift
@@ -130,13 +130,18 @@ struct SessionListView: View {
     }
 
     /// Android Home "Running subagents" parity, from what this phone has
-    /// observed in opened sessions (not a host-wide delegation query).
+    /// observed in opened sessions (not a host-wide delegation query). Only
+    /// rows with recent, still-observable child activity qualify: stale or
+    /// unavailable evidence belongs to the owning chat's strip, not here.
     private var observedRunningSubagents: [BackgroundTaskRow] {
-        appModel.backgroundTasksBySession.values
-            .flatMap(\.rows)
-            .filter { !$0.terminal }
-            .sorted { $0.observedAtMillis > $1.observedAtMillis }
+        BackgroundTasks.runningRows(
+            appModel.backgroundTasksBySession.values.flatMap(\.rows),
+            now: Int64(homeClock.timeIntervalSince1970 * 1000)
+        )
     }
+    /// Re-evaluates the recency window while Home is visible.
+    @State private var homeClock = Date()
+    private let homeClockTicks = Timer.publish(every: 15, on: .main, in: .common).autoconnect()
 
     private var homeSessions: [SessionRow] {
         HomeInboxPolicy.recentSessionPreview(appModel.sessions)
@@ -192,7 +197,7 @@ struct SessionListView: View {
                                     .foregroundStyle(Color.secondary)
                                     .lineLimit(1)
                             }
-                            .listRowBackground(Color.accentContainer.opacity(0.3))
+                            .listRowBackground(Color.accentPrimary.opacity(0.18))
                             .accessibilityElement(children: .combine)
                             .accessibilityLabel("Running subagent: \(row.goal), \(row.action ?? "running")")
                         }
@@ -405,6 +410,7 @@ struct SessionListView: View {
                 await appModel.loadSessions()
                 showShareInbox = !appModel.pendingShareEntries.isEmpty
             }
+            .onReceive(homeClockTicks) { homeClock = $0 }
             .onChange(of: relayChatIsOpen) { _, isOpen in
                 // The relay host keeps one live stream per device: a fresh
                 // connection supersedes the previous lease. While a chat owns

--- a/ios/MercuryTests/BackgroundRegistryPollPolicyTests.swift
+++ b/ios/MercuryTests/BackgroundRegistryPollPolicyTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Mercury
+
+/// A registry poll that ends on a transient RPC failure hides a still-running
+/// silent child once its activity window expires (PR #70 review).
+final class BackgroundRegistryPollPolicyTests: XCTestCase {
+    func testTransientFailuresRetryWhileUnsupportedMethodAndDeadConnectionStop() {
+        XCTAssertTrue(ChatView.registryPollContinues(after: ChatError.protocolError("Hermes RPC request failed (-32000)"),
+                                                     connectionClosed: false))
+        XCTAssertTrue(ChatView.registryPollContinues(after: ChatError.transport("timed out"), connectionClosed: false))
+        XCTAssertFalse(ChatView.registryPollContinues(after: ChatMethodNotFoundError(method: "delegation.status"),
+                                                      connectionClosed: false))
+        XCTAssertFalse(ChatView.registryPollContinues(after: CancellationError(), connectionClosed: false))
+        XCTAssertFalse(ChatView.registryPollContinues(after: ChatError.transport("closed"), connectionClosed: true))
+    }
+}

--- a/ios/MercuryTests/RelayTaskOwnerSinkTests.swift
+++ b/ios/MercuryTests/RelayTaskOwnerSinkTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import MercuryCore
+@testable import Mercury
+
+/// A pooled relay reader keeps applying child evidence after the chat screen
+/// closes. The owner must publish every rewrite so Home never shows a row the
+/// host already finished.
+final class RelayTaskOwnerSinkTests: XCTestCase {
+    private func snapshot(live: Bool = true) -> MercuryCore.RelayLeaseSnapshot {
+        MercuryCore.RelayLeaseSnapshot(
+            leaseId: "lease", lastSeq: 0, gap: false, reset: false,
+            bindings: [MercuryCore.RelayLeaseBinding(runtimeId: "runtime", durableId: "durable",
+                                                     profile: "default", live: live)],
+            tasks: [], truncated: false, routingToken: nil
+        )
+    }
+    private func evidence(_ type: String, status: String? = nil) -> BackgroundTaskEvidence {
+        var payload: [String: Any] = ["subagent_id": "child", "goal": "Write a poem"]
+        if let status { payload["status"] = status }
+        return BackgroundTaskEvidence.decode(type: type, payload: payload)!
+    }
+
+    func testCompletionAppliedWithoutSubscriberIsPublished() {
+        let owner = RelayTaskOwner()
+        let published = Locked<[(String, Mercury.BackgroundTasks)]>([])
+        owner.setSink { durable, state in published.mutate { $0.append((durable, state)) } }
+        let generation = owner.attach(snapshot: snapshot(), profile: "default")
+        XCTAssertTrue(owner.apply(generation: generation, runtime: "runtime", evidence: evidence("subagent.tool")))
+        XCTAssertTrue(owner.apply(generation: generation, runtime: "runtime",
+                                  evidence: evidence("subagent.complete", status: "completed")))
+        let events = published.value
+        XCTAssertEqual(events.map { $0.0 }, ["durable", "durable"])
+        XCTAssertEqual(events.first?.1.rows.first?.status, .active)
+        XCTAssertEqual(events.last?.1.rows.first?.status, .finished)
+        XCTAssertEqual(events.last?.1, owner.retained(generation: generation, durable: "durable", runtime: "runtime"))
+    }
+
+    func testRejectedOrUnchangedEvidenceIsNotPublished() {
+        let owner = RelayTaskOwner()
+        let count = Locked(0)
+        owner.setSink { _, _ in count.mutate { $0 += 1 } }
+        let generation = owner.attach(snapshot: snapshot(live: false), profile: "default")
+        XCTAssertFalse(owner.apply(generation: generation, runtime: "runtime", evidence: evidence("subagent.tool")))
+        XCTAssertFalse(owner.apply(generation: UUID(), runtime: "runtime", evidence: evidence("subagent.tool")))
+        XCTAssertEqual(count.value, 0)
+        owner.bind(generation: generation, runtime: "runtime", durable: "durable", profile: "default")
+        XCTAssertTrue(owner.apply(generation: generation, runtime: "runtime", evidence: evidence("subagent.tool")))
+        XCTAssertEqual(count.value, 1)
+        // A "running" confirmation is fresh liveness and is published; a poll
+        // that changes nothing is silent.
+        _ = owner.reconcile(generation: generation, durable: "durable", runtime: "runtime", statuses: ["child": "running"])
+        XCTAssertEqual(count.value, 2)
+        _ = owner.reconcile(generation: generation, durable: "durable", runtime: "runtime", statuses: [:])
+        XCTAssertEqual(count.value, 2)
+        _ = owner.reconcile(generation: generation, durable: "durable", runtime: "runtime", statuses: ["child": "exited"])
+        XCTAssertEqual(count.value, 3)
+    }
+
+    @MainActor
+    func testBackgroundTaskScopeMatchesChatAndSink() {
+        let target = RelayPairedTarget(
+            id: UUID(), label: "study", relayOrigin: "https://relay.example.com",
+            installationID: Data(), hostPublicKey: Data(), deviceID: "device",
+            deviceStaticPrivateKey: Data(), fingerprint: "f", status: .approved,
+            createdAtEpochSeconds: 1, lastUsedEpochSeconds: nil
+        )
+        let relay = AppModel.backgroundTaskScope(relayTarget: target, serverOrigin: "https://direct",
+                                                 profile: "default", durable: "d1")
+        XCTAssertEqual(relay, "relay:https://relay.example.com|\(target.id)|default|d1")
+        let direct = AppModel.backgroundTaskScope(relayTarget: nil, serverOrigin: "https://direct",
+                                                  profile: "default", durable: "d1")
+        XCTAssertEqual(direct, "direct:https://direct|default|d1")
+    }
+}
+
+private final class Locked<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Value
+    init(_ value: Value) { stored = value }
+    var value: Value { lock.lock(); defer { lock.unlock() }; return stored }
+    func mutate(_ body: (inout Value) -> Void) { lock.lock(); body(&stored); lock.unlock() }
+}

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/relay/BackgroundTasks.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/relay/BackgroundTasks.kt
@@ -175,6 +175,15 @@ object BackgroundTaskPresentationPolicy {
         return timeLabel(rows.maxBy { it.observedAtMillis }, now)
     }
 
+    /**
+     * Rows a host-wide "running" surface may show: identity known, still
+     * observable, and with worker activity inside the recency window. A stale
+     * or unavailable row is evidence for the owning chat's strip, not proof
+     * that anything is running now.
+     */
+    fun runningRows(rows: List<BackgroundTaskRow>, now: Long): List<BackgroundTaskRow> =
+        rows.filter { it.recentlyActive(now) }.sortedByDescending { it.observedAtMillis }
+
     private fun isStatusUnavailable(row: BackgroundTaskRow, now: Long): Boolean =
         !row.available || !row.identityKnown || row.status == BackgroundTaskStatus.Unknown || !row.recentlyActive(now)
 }
@@ -293,8 +302,14 @@ internal fun decodeBackgroundTaskEvent(type: String, runtime: String, payload: J
         else -> return null
     }
     if (runtime.isBlank() || runtime.length > 512) return null
+    // Identifiers and enums must be exact: an over-long value is rejected.
     fun text(key: String, max: Int): String? = (payload[key] as? JsonPrimitive)
         ?.takeIf { it.isString }?.content?.takeIf { it.isNotBlank() && it.length <= max }
+    // Free text is display evidence: an over-long value is clipped, never
+    // dropped, so a long delegation goal still yields a legible title.
+    fun clipped(key: String, max: Int): String? = (payload[key] as? JsonPrimitive)
+        ?.takeIf { it.isString }?.content?.takeIf { it.isNotBlank() }
+        ?.let { clipDisplayText(it, max) }
     val child = text("subagent_id", 256) ?: text("child_session_id", 256)?.let { "session:$it" }
         ?: text("delegation_id", 256)?.let { batch ->
             (payload["task_index"] as? JsonPrimitive)?.intOrNull?.takeIf { it in 0..255 }?.let { "$batch:$it" }
@@ -305,8 +320,26 @@ internal fun decodeBackgroundTaskEvent(type: String, runtime: String, payload: J
         "interrupted", "cancelled", "canceled", "stopped" -> BackgroundTaskStatus.Stopped
         else -> BackgroundTaskStatus.Unknown
     }
-    return BackgroundTaskEvent(runtime, kind, child, text("goal", 240),
-        text("tool_preview", 320) ?: text("text", 320) ?: text("tool_name", 120) ?: text("summary", 320), terminal)
+    return BackgroundTaskEvent(runtime, kind, child, clipped("goal", GOAL_DISPLAY_CHARS),
+        clipped("tool_preview", ACTION_DISPLAY_CHARS) ?: clipped("text", ACTION_DISPLAY_CHARS)
+            ?: text("tool_name", 120) ?: clipped("summary", ACTION_DISPLAY_CHARS), terminal)
+}
+
+internal const val GOAL_DISPLAY_CHARS = 240
+internal const val ACTION_DISPLAY_CHARS = 320
+
+/**
+ * Bounds free text for a one-line native row: only the first line is kept and
+ * anything beyond [max] is cut at a word boundary with an ellipsis.
+ */
+internal fun clipDisplayText(value: String, max: Int = Int.MAX_VALUE): String {
+    val firstLine = value.lineSequence().map(String::trim).firstOrNull(String::isNotEmpty) ?: return ""
+    if (firstLine.length <= max) return firstLine
+    val budget = (max - 1).coerceAtLeast(1)
+    val cut = firstLine.take(budget)
+    val boundary = cut.lastIndexOf(' ')
+    val head = if (boundary >= budget / 2) cut.substring(0, boundary) else cut
+    return head.trimEnd() + "\u2026"
 }
 
 data class BackgroundTaskRegistryEntry(val subagentId: String, val status: String)

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/relay/BackgroundTasksTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/relay/BackgroundTasksTest.kt
@@ -125,4 +125,40 @@ class BackgroundTasksTest {
         assertEquals(1000L, stale.rows.single().observedAtMillis)
         assertEquals(0, started.activeCount(121001))
     }
+
+    @Test fun longGoalIsClippedToLegibleTitleNotDropped() {
+        val goal = ("Write one original long poem, 80-100 lines, titled 'The House That Kept the Rain'. " +
+            "Literary free verse about siblings clearing their late mother's house and discovering she secretly " +
+            "repaired neighbors' broken things for decades. Concrete images, restraint, no rhyme, and an ending that " +
+            "lands on an object rather than a statement.")
+        assertTrue(goal.length > GOAL_DISPLAY_CHARS)
+        val decoded = event("subagent.tool", """{"subagent_id":"child","goal":${Json.encodeToString(kotlinx.serialization.json.JsonPrimitive.serializer(), kotlinx.serialization.json.JsonPrimitive(goal))},"text":"humanizer"}""")
+        val title = requireNotNull(decoded.goal)
+        assertTrue(title.length <= GOAL_DISPLAY_CHARS)
+        assertTrue(title.endsWith("\u2026"))
+        assertTrue(title.startsWith("Write one original long poem"))
+        assertFalse(title.dropLast(1).endsWith(" "))
+        assertEquals("humanizer", decoded.action)
+        val row = BackgroundTasks().reduce(decoded, runtime, 1000).rows.single()
+        assertEquals(title, row.goal)
+    }
+
+    @Test fun clipKeepsFirstLineAndCutsAtWordBoundary() {
+        assertEquals("first line", clipDisplayText("  first line \nsecond", 100))
+        assertEquals("alpha beta\u2026", clipDisplayText("alpha beta gamma delta", 14))
+        assertEquals("abcdefghijklm\u2026", clipDisplayText("abcdefghijklmnopqrstuvwxyz", 14))
+        assertEquals("", clipDisplayText("  \n  ", 14))
+    }
+
+    @Test fun runningRowsShowOnlyRecentAvailableIdentifiedActivity() {
+        val active = BackgroundTasks().reduce(event("subagent.tool"), runtime, 100_000).rows.single()
+        val stale = active.copy(id = "stale", observedAtMillis = 1_000)
+        val unavailable = active.copy(id = "gone", available = false)
+        val finished = active.copy(id = "done", status = BackgroundTaskStatus.Finished)
+        val anonymous = active.copy(id = "identity-unavailable", identityKnown = false, status = BackgroundTaskStatus.Unknown)
+        val newer = active.copy(id = "newer", observedAtMillis = 101_000)
+        val rows = listOf(stale, unavailable, active, finished, anonymous, newer)
+        assertEquals(listOf(newer, active), BackgroundTaskPresentationPolicy.runningRows(rows, 125_000))
+        assertEquals(emptyList(), BackgroundTaskPresentationPolicy.runningRows(rows, 250_000))
+    }
 }


### PR DESCRIPTION
## Summary

Stacked on #70. The iPhone Home screen showed four "Background task · details unavailable" / "humanizer" rows under **Running subagents** at 11:42 while nothing was running (screenshot analysed in session `20260909_034244_e60304`). They were the four poem subagents from `20260909_031442_6f2c36`, all completed at 03:16:55 per `async_delegations` and the relay's retained `subagent.complete` events.

Three causes, all fixed:

- **Title dropped, not clipped.** The shared decoder rejected any `goal` over 240 chars (these were 346–418), so the row fell back to the placeholder. Free text is now clipped at a word boundary with an ellipsis; identifiers and enums stay exact-or-rejected.
- **Home read a frozen copy.** After the chat screen closed, the pooled relay reader kept applying child completions inside `RelayTaskOwner`, but nothing copied that back into `AppModel.backgroundTasksBySession`, which Home reads. The owner now publishes every rewrite through a `RelayConnectionPool` task sink into `AppModel`; closing a chat over a relay no longer marks rows unavailable since the reader stays live. Home additionally lists only rows with recent, still-observable child activity (shared `BackgroundTaskPresentationPolicy.runningRows`), re-evaluated on a 15s clock, so stale/unavailable evidence stays in the owning chat's strip instead of claiming to be running.
- **Row colour.** The Home row used the container tint (muddy green in dark mode); it now uses the primary teal accent like the composer's send control.

Also addresses both Codex findings on #70:

- **Android P1**: the registry poll is now a per-controller job started either on connect (retained rows) or on the first live child event that leaves unresolved identified children. Cancelled with the event job.
- **iOS P2**: a transient `delegation.status` failure retries on the next interval; the poll stops only for `ChatMethodNotFoundError`, cancellation, or a closed connection (its reconnect restarts polling).

## Hermes compatibility

No gateway, plugin, or worker change. Uses only `delegation.status` and the relay-retained `subagent.*` events already consumed by both apps.

## Cross-platform

Decoder clipping and the running-rows policy live in `shared/mercury-core`. Android Home already reads the host-wide `delegation.status` query rather than a per-phone snapshot, so it did not have the stale-copy bug; the polling fix is Android-side and the retry fix is iOS-side per the review.

## Verification

- [x] `./gradlew :shared:mercury-core:testAndroidHostTest :app:testDebugUnitTest` (BackgroundTasks, RelayLeaseRecovery, HermesConnectionViewModel, BackgroundTaskStrip, SessionProgressRecovery) — 0 failures
- [x] `./gradlew :app:lintDebug` — clean
- [x] iOS `MercuryTests` on the iPhone 17 Pro simulator — 669 passed, 0 failures
- [ ] Device install (not done in this PR)
- [x] No credentials, transcripts, or build output added

New tests: core `BackgroundTasksTest.longGoalIsClippedToLegibleTitleNotDropped`, `clipKeepsFirstLineAndCutsAtWordBoundary`, `runningRowsShowOnlyRecentAvailableIdentifiedActivity`; Android `HermesConnectionViewModelTest.firstLiveChildEventStartsRegistryPollingAndKeepsSilentChildConfirmed`; iOS `RelayTaskOwnerSinkTests` (publish on apply/reconcile, silence on rejection/no-op, scope key parity) and `BackgroundRegistryPollPolicyTests`.
