### PR TITLE
fix(android): expose speech recognition service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
 
     <queries>
         <intent>
-            <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
+            <action android:name="android.speech.RecognitionService" />
         </intent>
     </queries>
 


### PR DESCRIPTION
## Summary

- declare the speech recognition service in Android package-visibility queries
- allow `SpeechRecognizer.isRecognitionAvailable()` to detect the installed recognizer on Android 11+

## Context

On a Galaxy S25 Ultra, tapping Mercury’s composer microphone immediately reports “Voice input is unavailable” without requesting microphone permission. Android requires apps targeting Android 11+ to query `android.speech.RecognitionService`; the existing manifest queries the recognition activity action instead.

Android documentation: https://developer.android.com/about/versions/11/behavior-changes-11#speech-recognition

## Verification

- `./gradlew lintDebug assembleDebug` — passed
- merged debug manifest contains `android.speech.RecognitionService`
- full unit run completed 1,038 tests; the same six unrelated `NativeOAuthTest` failures previously reproduced on the unmodified v0.2.5 checkout remain