### PR TITLE
fix(android): complete composer microphone discovery and permission flow

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,7 @@
 # Contributors
 
+- [@modelarious](https://github.com/modelarious) (Michael Hackman) — diagnosed Android speech-recognition service visibility and authored the manifest fix in [PR #73](https://github.com/unsupportedpastels/mercury/pull/73), preserved in the complete composer microphone permission fix.
+
 - [@snowzlmbot](https://github.com/snowzlmbot) — originated the device voice-input idea carried forward from [PR #26](https://github.com/unsupportedpastels/mercury/pull/26).
 - [@forcewake](https://github.com/forcewake) — authored the original Android managed-video playback, download/cache implementation, and tests in [PR #48](https://github.com/unsupportedpastels/mercury/pull/48), adapted into the shared-core and native mobile video support.
 - [@HotRod5k](https://github.com/HotRod5k) — reported and diagnosed the named-profile transcript loading bug in [issue #46](https://github.com/unsupportedpastels/mercury/issues/46), fixed in [PR #54](https://github.com/unsupportedpastels/mercury/pull/54).

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
 
     <queries>
         <intent>
-            <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
+            <action android:name="android.speech.RecognitionService" />
         </intent>
     </queries>
 

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetailScreen.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetailScreen.kt
@@ -926,6 +926,7 @@ internal fun SessionDetailScreen(
                             onDraftChanged = currentOnDraftChanged,
                             onError = { message -> attachmentError = message },
                             modifier = Modifier.size(40.dp),
+                            requestIdentity = voiceInputScopeKey,
                         )
                         if (voiceHost != null) {
                             VoiceConversationToggleButton(

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechInputButton.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechInputButton.kt
@@ -1,5 +1,9 @@
 package com.unsupportedpastels.hermesandroid.voice
 
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Stop
@@ -7,12 +11,17 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 
 /** Composer mic for app-owned, pause-tolerant device speech recognition. */
 @Composable
@@ -23,19 +32,63 @@ fun DeviceSpeechInputButton(
     currentDraft: String,
     onDraftChanged: (String) -> Unit,
     onError: (String) -> Unit,
+    requestIdentity: String,
     modifier: Modifier = Modifier,
 ) {
+    // A changed session/origin gets a new permission continuation. Any result
+    // delivered to the disposed scope is ignored by its coordinator.
+    key(requestIdentity) {
+        DeviceSpeechInputButtonForRequestScope(
+            controller = controller,
+            available = available,
+            enabled = enabled,
+            currentDraft = currentDraft,
+            onDraftChanged = onDraftChanged,
+            onError = onError,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun DeviceSpeechInputButtonForRequestScope(
+    controller: DeviceSpeechRecognizerController,
+    available: Boolean,
+    enabled: Boolean,
+    currentDraft: String,
+    onDraftChanged: (String) -> Unit,
+    onError: (String) -> Unit,
+    modifier: Modifier,
+) {
+    val context = LocalContext.current
     val state by controller.state.collectAsState()
     val active = state != DeviceSpeechRecognizerState.Idle
     val description = if (active) "Stop voice input" else "Voice input"
+    val coordinator = remember(controller) { DeviceSpeechPermissionCoordinator(controller) }
+    SideEffect {
+        coordinator.update(available, enabled, currentDraft, onDraftChanged, onError)
+    }
+    DisposableEffect(coordinator) {
+        onDispose { coordinator.dispose() }
+    }
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        coordinator.onPermissionResult(granted)
+    }
 
     IconButton(
         onClick = {
-            if (active) {
-                controller.finish()
-            } else if (!controller.start(currentDraft, onDraftChanged, onError)) {
-                onError("Voice input is unavailable")
-            }
+            coordinator.onClick(
+                hasRecordAudioPermission = ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.RECORD_AUDIO,
+                ) == PackageManager.PERMISSION_GRANTED,
+                requestRecordAudioPermission = {
+                    runCatching { permissionLauncher.launch(Manifest.permission.RECORD_AUDIO) }
+                        .onFailure { coordinator.onPermissionRequestFailed() }
+                },
+            )
         },
         enabled = enabled && (available || active),
         modifier = modifier.semantics { contentDescription = description },
@@ -51,5 +104,81 @@ fun DeviceSpeechInputButton(
                 MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
             },
         )
+    }
+}
+
+internal class DeviceSpeechPermissionCoordinator(
+    private val controller: DeviceSpeechRecognizer,
+) {
+    private var alive = true
+    private var permissionPending = false
+    private var available = false
+    private var enabled = false
+    private var currentDraft = ""
+    private var onDraftChanged: (String) -> Unit = {}
+    private var onError: (String) -> Unit = {}
+
+    fun update(
+        available: Boolean,
+        enabled: Boolean,
+        currentDraft: String,
+        onDraftChanged: (String) -> Unit,
+        onError: (String) -> Unit,
+    ) {
+        this.available = available
+        this.enabled = enabled
+        this.currentDraft = currentDraft
+        this.onDraftChanged = onDraftChanged
+        this.onError = onError
+    }
+
+    fun onClick(
+        hasRecordAudioPermission: Boolean,
+        requestRecordAudioPermission: () -> Unit,
+    ) {
+        if (controller.isActive) {
+            controller.finish()
+            return
+        }
+        if (!alive || !available || !enabled) return
+        if (hasRecordAudioPermission) {
+            start()
+        } else if (!permissionPending) {
+            permissionPending = true
+            requestRecordAudioPermission()
+        }
+    }
+
+    fun onPermissionResult(granted: Boolean) {
+        if (!permissionPending) return
+        permissionPending = false
+        if (!alive || !available || !enabled || controller.isActive) return
+        if (granted) {
+            start()
+        } else {
+            onError(RECORD_AUDIO_DENIED_MESSAGE)
+        }
+    }
+
+    fun onPermissionRequestFailed() {
+        if (!permissionPending) return
+        permissionPending = false
+        if (alive && available && enabled) onError(RECORD_AUDIO_DENIED_MESSAGE)
+    }
+
+    fun dispose() {
+        alive = false
+        permissionPending = false
+    }
+
+    private fun start() {
+        if (!controller.start(currentDraft, onDraftChanged, onError)) {
+            onError("Voice input is unavailable")
+        }
+    }
+
+    private companion object {
+        const val RECORD_AUDIO_DENIED_MESSAGE =
+            "Microphone permission is required for voice input"
     }
 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechInputButton.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechInputButton.kt
@@ -16,7 +16,12 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
@@ -45,6 +50,7 @@ fun DeviceSpeechInputButton(
             currentDraft = currentDraft,
             onDraftChanged = onDraftChanged,
             onError = onError,
+            requestIdentity = requestIdentity,
             modifier = modifier,
         )
     }
@@ -58,18 +64,16 @@ private fun DeviceSpeechInputButtonForRequestScope(
     currentDraft: String,
     onDraftChanged: (String) -> Unit,
     onError: (String) -> Unit,
+    requestIdentity: String,
     modifier: Modifier,
 ) {
     val context = LocalContext.current
     val state by controller.state.collectAsState()
     val active = state != DeviceSpeechRecognizerState.Idle
     val description = if (active) "Stop voice input" else "Voice input"
-    val coordinator = remember(controller) { DeviceSpeechPermissionCoordinator(controller) }
+    val coordinator = rememberDeviceSpeechPermissionCoordinator(controller, requestIdentity)
     SideEffect {
         coordinator.update(available, enabled, currentDraft, onDraftChanged, onError)
-    }
-    DisposableEffect(coordinator) {
-        onDispose { coordinator.dispose() }
     }
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
@@ -107,11 +111,60 @@ private fun DeviceSpeechInputButtonForRequestScope(
     }
 }
 
+// Saved permission continuations are valid across Activity recreation only. A
+// fresh process gets a different identity and must not revive an old request.
+private val deviceSpeechPermissionProcessIdentity = java.util.UUID.randomUUID().toString()
+
+internal class DeviceSpeechPermissionRequestState(
+    pending: Boolean = false,
+) {
+    var pending by mutableStateOf(pending)
+}
+
+internal fun deviceSpeechPermissionRequestStateSaver(
+    requestIdentity: String,
+    processIdentity: String,
+): Saver<DeviceSpeechPermissionRequestState, Any> = listSaver(
+    save = { state -> listOf(requestIdentity, processIdentity, state.pending) },
+    restore = { saved ->
+        DeviceSpeechPermissionRequestState(
+            pending = saved.size == 3 &&
+                saved[0] == requestIdentity &&
+                saved[1] == processIdentity &&
+                saved[2] == true,
+        )
+    },
+)
+
+@Composable
+internal fun rememberDeviceSpeechPermissionCoordinator(
+    controller: DeviceSpeechRecognizer,
+    requestIdentity: String,
+): DeviceSpeechPermissionCoordinator {
+    val requestState = rememberSaveable(
+        requestIdentity,
+        saver = deviceSpeechPermissionRequestStateSaver(
+            requestIdentity = requestIdentity,
+            processIdentity = deviceSpeechPermissionProcessIdentity,
+        ),
+    ) {
+        DeviceSpeechPermissionRequestState()
+    }
+    val coordinator = remember(controller, requestState) {
+        DeviceSpeechPermissionCoordinator(controller, requestState)
+    }
+    DisposableEffect(coordinator) {
+        onDispose { coordinator.dispose() }
+    }
+    return coordinator
+}
+
 internal class DeviceSpeechPermissionCoordinator(
     private val controller: DeviceSpeechRecognizer,
+    private val requestState: DeviceSpeechPermissionRequestState =
+        DeviceSpeechPermissionRequestState(),
 ) {
     private var alive = true
-    private var permissionPending = false
     private var available = false
     private var enabled = false
     private var currentDraft = ""
@@ -143,15 +196,15 @@ internal class DeviceSpeechPermissionCoordinator(
         if (!alive || !available || !enabled) return
         if (hasRecordAudioPermission) {
             start()
-        } else if (!permissionPending) {
-            permissionPending = true
+        } else if (!requestState.pending) {
+            requestState.pending = true
             requestRecordAudioPermission()
         }
     }
 
     fun onPermissionResult(granted: Boolean) {
-        if (!permissionPending) return
-        permissionPending = false
+        if (!requestState.pending) return
+        requestState.pending = false
         if (!alive || !available || !enabled || controller.isActive) return
         if (granted) {
             start()
@@ -161,14 +214,14 @@ internal class DeviceSpeechPermissionCoordinator(
     }
 
     fun onPermissionRequestFailed() {
-        if (!permissionPending) return
-        permissionPending = false
+        if (!requestState.pending) return
+        requestState.pending = false
         if (alive && available && enabled) onError(RECORD_AUDIO_DENIED_MESSAGE)
     }
 
     fun dispose() {
         alive = false
-        permissionPending = false
+        requestState.pending = false
     }
 
     private fun start() {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechRecognizerController.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechRecognizerController.kt
@@ -18,6 +18,19 @@ enum class DeviceSpeechRecognizerState {
     Restarting,
 }
 
+internal interface DeviceSpeechRecognizer {
+    val state: StateFlow<DeviceSpeechRecognizerState>
+    val isActive: Boolean
+
+    fun start(
+        currentDraft: String,
+        onDraftChanged: (String) -> Unit,
+        onError: (String) -> Unit,
+    ): Boolean
+
+    fun finish()
+}
+
 /**
  * App-owned wrapper around the installed Android recognition service. Unlike
  * ACTION_RECOGNIZE_SPEECH, this keeps control of the recognition session and
@@ -25,10 +38,10 @@ enum class DeviceSpeechRecognizerState {
  */
 class DeviceSpeechRecognizerController(
     private val context: Context,
-) {
+) : DeviceSpeechRecognizer {
     private val mainHandler = Handler(Looper.getMainLooper())
     private val _state = MutableStateFlow(DeviceSpeechRecognizerState.Idle)
-    val state: StateFlow<DeviceSpeechRecognizerState> = _state.asStateFlow()
+    override val state: StateFlow<DeviceSpeechRecognizerState> = _state.asStateFlow()
 
     private var recognizer: SpeechRecognizer? = null
     private var generation = 0L
@@ -37,10 +50,10 @@ class DeviceSpeechRecognizerController(
     private var onDraftChanged: ((String) -> Unit)? = null
     private var onError: ((String) -> Unit)? = null
 
-    val isActive: Boolean
+    override val isActive: Boolean
         get() = _state.value != DeviceSpeechRecognizerState.Idle
 
-    fun start(
+    override fun start(
         currentDraft: String,
         onDraftChanged: (String) -> Unit,
         onError: (String) -> Unit,
@@ -69,7 +82,7 @@ class DeviceSpeechRecognizerController(
     }
 
     /** Finish and keep all recognized text currently in the draft. */
-    fun finish() {
+    override fun finish() {
         stop(keepDraft = true)
     }
 

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechInputButtonTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechInputButtonTest.kt
@@ -1,0 +1,193 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeviceSpeechInputButtonTest {
+    private class FakeRecognizer(
+        var startResult: Boolean = true,
+    ) : DeviceSpeechRecognizer {
+        private val mutableState = MutableStateFlow(DeviceSpeechRecognizerState.Idle)
+        override val state: StateFlow<DeviceSpeechRecognizerState> = mutableState
+        override val isActive: Boolean get() = mutableState.value != DeviceSpeechRecognizerState.Idle
+        var starts = 0
+        var finishes = 0
+        var startedDraft: String? = null
+        var draftCallback: ((String) -> Unit)? = null
+        var errorCallback: ((String) -> Unit)? = null
+
+        override fun start(
+            currentDraft: String,
+            onDraftChanged: (String) -> Unit,
+            onError: (String) -> Unit,
+        ): Boolean {
+            starts++
+            startedDraft = currentDraft
+            draftCallback = onDraftChanged
+            errorCallback = onError
+            if (startResult) mutableState.value = DeviceSpeechRecognizerState.Listening
+            return startResult
+        }
+
+        override fun finish() {
+            finishes++
+            mutableState.value = DeviceSpeechRecognizerState.Idle
+        }
+    }
+
+    private fun coordinator(
+        recognizer: FakeRecognizer,
+        available: Boolean = true,
+        enabled: Boolean = true,
+        draft: String = "draft",
+        onDraftChanged: (String) -> Unit = {},
+        onError: (String) -> Unit = {},
+    ) = DeviceSpeechPermissionCoordinator(recognizer).also {
+        it.update(available, enabled, draft, onDraftChanged, onError)
+    }
+
+    @Test
+    fun missingRecordAudioPermissionRequestsPermissionBeforeStarting() {
+        val recognizer = FakeRecognizer()
+        val coordinator = coordinator(recognizer)
+        var requests = 0
+
+        coordinator.onClick(
+            hasRecordAudioPermission = false,
+            requestRecordAudioPermission = { requests++ },
+        )
+
+        assertEquals(1, requests)
+        assertEquals(0, recognizer.starts)
+        assertFalse(recognizer.isActive)
+    }
+
+    @Test
+    fun permissionGrantStartsWithCurrentDraftAndCallbacks() {
+        val recognizer = FakeRecognizer()
+        var changedDraft: String? = null
+        var error: String? = null
+        val coordinator = coordinator(
+            recognizer = recognizer,
+            draft = "existing draft",
+            onDraftChanged = { changedDraft = it },
+            onError = { error = it },
+        )
+        coordinator.onClick(false) {}
+
+        coordinator.onPermissionResult(granted = true)
+        recognizer.draftCallback?.invoke("recognized draft")
+        recognizer.errorCallback?.invoke("recognizer error")
+
+        assertEquals(1, recognizer.starts)
+        assertEquals("existing draft", recognizer.startedDraft)
+        assertEquals("recognized draft", changedDraft)
+        assertEquals("recognizer error", error)
+    }
+
+    @Test
+    fun alreadyGrantedStartsWithoutRequestingAgain() {
+        val recognizer = FakeRecognizer()
+        val coordinator = coordinator(recognizer)
+        var requests = 0
+
+        coordinator.onClick(true) { requests++ }
+
+        assertEquals(1, recognizer.starts)
+        assertEquals(0, requests)
+    }
+
+    @Test
+    fun denialReportsMeaningfulErrorAndDoesNotStart() {
+        val recognizer = FakeRecognizer()
+        var error: String? = null
+        val coordinator = coordinator(recognizer, onError = { error = it })
+        coordinator.onClick(false) {}
+
+        coordinator.onPermissionResult(granted = false)
+
+        assertEquals(0, recognizer.starts)
+        assertEquals("Microphone permission is required for voice input", error)
+    }
+
+    @Test
+    fun repeatedTapsWhilePermissionIsPendingLaunchOnlyOneRequest() {
+        val recognizer = FakeRecognizer()
+        val coordinator = coordinator(recognizer)
+        var requests = 0
+
+        coordinator.onClick(false) { requests++ }
+        coordinator.onClick(false) { requests++ }
+
+        assertEquals(1, requests)
+        assertEquals(0, recognizer.starts)
+    }
+
+    @Test
+    fun unavailableRecognizerReportsExistingUnavailableError() {
+        val recognizer = FakeRecognizer(startResult = false)
+        var error: String? = null
+        val coordinator = coordinator(recognizer, onError = { error = it })
+
+        coordinator.onClick(true) {}
+
+        assertEquals(1, recognizer.starts)
+        assertEquals("Voice input is unavailable", error)
+    }
+
+    @Test
+    fun advertisedUnavailableDoesNotRequestOrStart() {
+        val recognizer = FakeRecognizer()
+        val coordinator = coordinator(recognizer, available = false)
+        var requests = 0
+
+        coordinator.onClick(false) { requests++ }
+
+        assertEquals(0, requests)
+        assertEquals(0, recognizer.starts)
+    }
+
+    @Test
+    fun activeTapStopsWithoutCheckingOrRequestingPermission() {
+        val recognizer = FakeRecognizer()
+        val coordinator = coordinator(recognizer)
+        coordinator.onClick(true) {}
+        var requests = 0
+
+        coordinator.onClick(false) { requests++ }
+
+        assertEquals(1, recognizer.finishes)
+        assertEquals(0, requests)
+        assertFalse(recognizer.isActive)
+    }
+
+    @Test
+    fun grantAfterDisabledDoesNotStart() {
+        val recognizer = FakeRecognizer()
+        val coordinator = coordinator(recognizer)
+        coordinator.onClick(false) {}
+        coordinator.update(true, false, "new draft", {}, {})
+
+        coordinator.onPermissionResult(granted = true)
+
+        assertEquals(0, recognizer.starts)
+    }
+
+    @Test
+    fun grantAfterRequestScopeIsDisposedDoesNotStart() {
+        val recognizer = FakeRecognizer()
+        var error: String? = null
+        val coordinator = coordinator(recognizer, onError = { error = it })
+        coordinator.onClick(false) {}
+        coordinator.dispose()
+
+        coordinator.onPermissionResult(granted = true)
+
+        assertEquals(0, recognizer.starts)
+        assertTrue(error == null)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechInputButtonTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechInputButtonTest.kt
@@ -67,6 +67,16 @@ class DeviceSpeechInputButtonTest {
     }
 
     @Test
+    fun permissionGrantWithoutMatchingRequestDoesNotStart() {
+        val recognizer = FakeRecognizer()
+        val coordinator = coordinator(recognizer)
+
+        coordinator.onPermissionResult(granted = true)
+
+        assertEquals(0, recognizer.starts)
+    }
+
+    @Test
     fun permissionGrantStartsWithCurrentDraftAndCallbacks() {
         val recognizer = FakeRecognizer()
         var changedDraft: String? = null

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechPermissionRestorationTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/voice/DeviceSpeechPermissionRestorationTest.kt
@@ -1,0 +1,180 @@
+package com.unsupportedpastels.hermesandroid.voice
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.SaverScope
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class DeviceSpeechPermissionRestorationTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private class FakeRecognizer : DeviceSpeechRecognizer {
+        override val state: StateFlow<DeviceSpeechRecognizerState> =
+            MutableStateFlow(DeviceSpeechRecognizerState.Idle)
+        override val isActive: Boolean = false
+        var starts = 0
+
+        override fun start(
+            currentDraft: String,
+            onDraftChanged: (String) -> Unit,
+            onError: (String) -> Unit,
+        ): Boolean {
+            starts++
+            return true
+        }
+
+        override fun finish() = Unit
+    }
+
+    @Test
+    fun pendingPermissionGrantSurvivesSavedInstanceStateRestoreForSameRequestScope() {
+        val restoration = StateRestorationTester(composeRule)
+        val recognizer = FakeRecognizer()
+        var coordinator: DeviceSpeechPermissionCoordinator? = null
+
+        restoration.setContent {
+            coordinator = rememberDeviceSpeechPermissionCoordinator(
+                controller = recognizer,
+                requestIdentity = "session-a",
+            )
+        }
+        composeRule.runOnIdle {
+            checkNotNull(coordinator).apply {
+                update(true, true, "draft", {}, {})
+                onClick(false) {}
+            }
+        }
+
+        restoration.emulateSavedInstanceStateRestore()
+        composeRule.runOnIdle {
+            checkNotNull(coordinator).apply {
+                update(true, true, "draft", {}, {})
+                onPermissionResult(granted = true)
+            }
+        }
+
+        assertEquals(1, recognizer.starts)
+    }
+
+    @Test
+    fun pendingPermissionDenialSurvivesSavedInstanceStateRestoreForSameRequestScope() {
+        val restoration = StateRestorationTester(composeRule)
+        val recognizer = FakeRecognizer()
+        var coordinator: DeviceSpeechPermissionCoordinator? = null
+        var error: String? = null
+
+        restoration.setContent {
+            coordinator = rememberDeviceSpeechPermissionCoordinator(
+                controller = recognizer,
+                requestIdentity = "session-a",
+            )
+        }
+        composeRule.runOnIdle {
+            checkNotNull(coordinator).apply {
+                update(true, true, "draft", {}, { error = it })
+                onClick(false) {}
+            }
+        }
+
+        restoration.emulateSavedInstanceStateRestore()
+        composeRule.runOnIdle {
+            checkNotNull(coordinator).apply {
+                update(true, true, "draft", {}, { error = it })
+                onPermissionResult(granted = false)
+            }
+        }
+
+        assertEquals("Microphone permission is required for voice input", error)
+        assertEquals(0, recognizer.starts)
+    }
+
+    @Test
+    fun changingRequestScopeDropsPendingPermissionGrant() {
+        val recognizer = FakeRecognizer()
+        var requestIdentity by mutableStateOf("session-a")
+        var coordinator: DeviceSpeechPermissionCoordinator? = null
+
+        composeRule.setContent {
+            coordinator = rememberDeviceSpeechPermissionCoordinator(
+                controller = recognizer,
+                requestIdentity = requestIdentity,
+            )
+        }
+        composeRule.runOnIdle {
+            checkNotNull(coordinator).apply {
+                update(true, true, "draft", {}, {})
+                onClick(false) {}
+            }
+            requestIdentity = "session-b"
+        }
+        composeRule.runOnIdle {
+            checkNotNull(coordinator).apply {
+                update(true, true, "draft", {}, {})
+                onPermissionResult(granted = true)
+            }
+        }
+
+        assertEquals(0, recognizer.starts)
+    }
+
+    @Test
+    fun restoredPermissionIntentIsRejectedAfterProcessIdentityChanges() {
+        val recognizer = FakeRecognizer()
+        val pendingState = DeviceSpeechPermissionRequestState()
+        DeviceSpeechPermissionCoordinator(recognizer, pendingState).apply {
+            update(true, true, "draft", {}, {})
+            onClick(false) {}
+        }
+        val saver = deviceSpeechPermissionRequestStateSaver("session-a", "process-a")
+        val saved = checkNotNull(
+            with(saver) { SaverScope { true }.save(pendingState) },
+        )
+        val restoredState = checkNotNull(
+            deviceSpeechPermissionRequestStateSaver("session-a", "process-b").restore(saved),
+        )
+
+        DeviceSpeechPermissionCoordinator(recognizer, restoredState).apply {
+            update(true, true, "draft", {}, {})
+            onPermissionResult(granted = true)
+        }
+
+        assertEquals(0, recognizer.starts)
+    }
+
+    @Test
+    fun restoredPermissionIntentIsRejectedForDifferentRequestScope() {
+        val recognizer = FakeRecognizer()
+        val pendingState = DeviceSpeechPermissionRequestState()
+        DeviceSpeechPermissionCoordinator(recognizer, pendingState).apply {
+            update(true, true, "draft", {}, {})
+            onClick(false) {}
+        }
+        val saver = deviceSpeechPermissionRequestStateSaver("session-a", "process-a")
+        val saved = checkNotNull(
+            with(saver) { SaverScope { true }.save(pendingState) },
+        )
+        val restoredState = checkNotNull(
+            deviceSpeechPermissionRequestStateSaver("session-b", "process-a").restore(saved),
+        )
+
+        DeviceSpeechPermissionCoordinator(recognizer, restoredState).apply {
+            update(true, true, "draft", {}, {})
+            onPermissionResult(granted = true)
+        }
+
+        assertEquals(0, recognizer.starts)
+    }
+}


### PR DESCRIPTION
## Summary
- Preserve the speech-recognition service visibility fix from #73 as an authored cherry-pick.
- Request RECORD_AUDIO before starting composer dictation; start on grant and show a clear permission-denial message.
- Suppress duplicate permission requests and discard stale continuations after request-scope disposal or while disabled.
- Preserve stop behavior and draft/error callbacks; add 10 focused permission-flow tests.

## Contributor credit
Supersedes #73. Thanks to @modelarious (Michael Hackman) for diagnosing service visibility and authoring the original manifest fix. His commit authorship is preserved in 47e45a8, with explicit credit in CONTRIBUTORS.md. The permission-flow completion is a separate commit on top.

## Verification
- ./gradlew testDebugUnitTest lintDebug assembleDebug --continue: passed
- 1,048 tests; zero failures, errors, or skips
- Merged debug manifest contains android.speech.RecognitionService and RECORD_AUDIO
- git diff --check: passed
- Physical-device permission-dialog and speech recognition verification not performed

## Platform scope
Android-only package visibility and runtime-permission wiring. iOS already uses its native speech/microphone authorization flow; no shared protocol or server changes.