### PR TITLE
fix(ios): add chat scroll-to-latest and resume following

### DIFF
--- a/ios/Mercury/MercuryApp.swift
+++ b/ios/Mercury/MercuryApp.swift
@@ -76,6 +76,8 @@ struct MercuryApp: App {
                 #if DEBUG
                 if ProcessInfo.processInfo.arguments.contains("-uitest-background-tasks") {
                     BackgroundTaskFixtureView()
+                } else if ProcessInfo.processInfo.arguments.contains("-uitest-chat-scroll") {
+                    ChatTranscriptScrollFixtureView()
                 } else { RootView() }
                 #else
                 RootView()
@@ -84,7 +86,8 @@ struct MercuryApp: App {
                 .environment(appModel)
                 .task {
                     #if DEBUG
-                    if ProcessInfo.processInfo.arguments.contains("-uitest-background-tasks") { return }
+                    if ProcessInfo.processInfo.arguments.contains("-uitest-background-tasks")
+                        || ProcessInfo.processInfo.arguments.contains("-uitest-chat-scroll") { return }
                     if ProcessInfo.processInfo.arguments.contains("-uitest-reset-local-state") {
                         await appModel.resetLocalStateForUITest()
                     }

--- a/ios/Mercury/Views/ChatSessionState.swift
+++ b/ios/Mercury/Views/ChatSessionState.swift
@@ -191,6 +191,8 @@ final class ChatSessionState {
     // MARK: Follow-scroll intent
 
     var followBottom = true
+    var transcriptTailMaxY: CGFloat?
+    var transcriptViewportHeight: CGFloat = 0
     var initialScrollDone = false
     var loadedTranscriptCount = 0
     var hasMoreHistory = false

--- a/ios/Mercury/Views/ChatTranscriptList.swift
+++ b/ios/Mercury/Views/ChatTranscriptList.swift
@@ -5,9 +5,17 @@ extension ChatView {
     // MARK: Transcript
 
     var transcriptList: some View {
+        transcriptList(backgroundTasks: backgroundTasks)
+    }
+
+    /// Parameterized only so the DEBUG fixture can render this production UI
+    /// without evaluating ChatView's environment-backed task store directly.
+    func transcriptList(backgroundTasks: BackgroundTasks) -> some View {
         ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 12) {
+            GeometryReader { viewport in
+                ZStack(alignment: .bottomTrailing) {
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 12) {
                     if state.hasMoreHistory || state.historyError != nil {
                         Button {
                             Task { await loadEarlierHistory() }
@@ -74,18 +82,33 @@ extension ChatView {
                         Button("Provide requested input") { state.presentPendingInput() }
                             .frame(minHeight: 44)
                     }
-                    Color.clear.frame(height: 1).id(lastRowID)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-            }
-            .scrollDismissesKeyboard(.interactively)
-            .simultaneousGesture(
-                DragGesture().onChanged { _ in
-                    // A user drag disengages follow; reaching bottom re-engages.
-                    state.followBottom = false
-                }
-            )
+                            Color.clear
+                                .frame(height: 1)
+                                .id(lastRowID)
+                                .background {
+                                    GeometryReader { tail in
+                                        Color.clear.preference(
+                                            key: TranscriptTailPreferenceKey.self,
+                                            value: tail.frame(in: .named("chat-transcript-viewport")).maxY
+                                        )
+                                    }
+                                }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                    }
+                    .coordinateSpace(name: "chat-transcript-viewport")
+                    .accessibilityIdentifier("Chat transcript")
+                    .scrollDismissesKeyboard(.interactively)
+                    .simultaneousGesture(
+                        DragGesture()
+                            .onChanged { _ in
+                                state.followBottom = false
+                            }
+                            .onEnded { _ in
+                                resumeFollowingIfAtBottom()
+                            }
+                    )
             .onChange(of: state.transcript.rows.count) {
                 guard state.followBottom else { return }
                 // A local user echo must land in its final position in one
@@ -129,6 +152,52 @@ extension ChatView {
                 state.initialScrollDone = true
                 proxy.scrollTo(lastRowID, anchor: .bottom)
             }
+                    if !isTranscriptAtBottom,
+                       state.pendingRequest == nil,
+                       state.pendingSecure == nil {
+                        Button {
+                            state.followBottom = true
+                            withAnimation(.easeOut(duration: 0.15)) {
+                                proxy.scrollTo(lastRowID, anchor: .bottom)
+                            }
+                        } label: {
+                            Image(systemName: "arrow.down")
+                                .font(.system(size: 20, weight: .semibold))
+                                .frame(width: 44, height: 44)
+                                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+                                .shadow(color: .black.opacity(0.22), radius: 4, y: 2)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.trailing, 12)
+                        .padding(.bottom, 8)
+                        .accessibilityLabel("Scroll to latest message")
+                    }
+                }
+                .onAppear {
+                    state.transcriptViewportHeight = viewport.size.height
+                }
+                .onChange(of: viewport.size.height) { _, height in
+                    state.transcriptViewportHeight = height
+                    resumeFollowingIfAtBottom()
+                }
+                .onPreferenceChange(TranscriptTailPreferenceKey.self) { tailMaxY in
+                    state.transcriptTailMaxY = tailMaxY
+                    resumeFollowingIfAtBottom()
+                }
+            }
+        }
+    }
+
+    private var isTranscriptAtBottom: Bool {
+        TranscriptScrollPosition.isAtBottom(
+            tailMaxY: state.transcriptTailMaxY,
+            viewportHeight: state.transcriptViewportHeight
+        )
+    }
+
+    private func resumeFollowingIfAtBottom() {
+        if isTranscriptAtBottom {
+            state.followBottom = true
         }
     }
 }

--- a/ios/Mercury/Views/ChatTranscriptScrollFixtureView.swift
+++ b/ios/Mercury/Views/ChatTranscriptScrollFixtureView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+#if DEBUG
+/// Synthetic XCUITest host for the production transcript view. It has no
+/// transport, credentials, persistence, or live-session side effects.
+struct ChatTranscriptScrollFixtureView: View {
+    @State private var state = ChatSessionState(
+        sessionID: "fixture",
+        title: "Transcript scroll fixture",
+        isNewSession: false,
+        incomingShare: nil
+    )
+    @State private var loaded = false
+    @State private var streamChunk = 0
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                Button("Append synthetic stream chunk") {
+                    state.isSending = true
+                    streamChunk += 1
+                    state.transcript.ensureInflightAssistantRow(
+                        text: "Synthetic streaming response\n" + String(
+                            repeating: "A growing response line exercises follow scrolling.\n",
+                            count: streamChunk * 12
+                        ),
+                        completed: false
+                    )
+                }
+                .buttonStyle(.bordered)
+                .padding(8)
+
+                ChatView(fixtureState: state).transcriptList(backgroundTasks: BackgroundTasks())
+            }
+            .navigationTitle("Transcript fixture")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .preferredColorScheme(.dark)
+        .task {
+            guard !loaded else { return }
+            loaded = true
+            // Ensure the production transcript has mounted before its async
+            // load changes row count, matching the real REST-load lifecycle.
+            try? await Task.sleep(for: .milliseconds(250))
+            var messages: [(role: String, content: String)] = []
+            for index in 1...35 {
+                messages.append((
+                    role: index.isMultiple(of: 2) ? "assistant" : "user",
+                    content: "Synthetic message \(index)\nA second line makes the transcript tall enough to scroll."
+                ))
+            }
+            messages.append((role: "assistant", content: "Synthetic latest message"))
+            state.transcript.loadTranscript(messages)
+        }
+    }
+}
+#endif

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -44,6 +44,19 @@ struct ChatView: View {
         ))
     }
 
+    #if DEBUG
+    /// Synthetic UI-test entry point. It renders the production transcript
+    /// without starting ChatView's connection-owning body/task lifecycle.
+    init(fixtureState: ChatSessionState) {
+        sessionID = "fixture"
+        title = "Transcript scroll fixture"
+        isNewSession = false
+        newSessionWorkspacePath = nil
+        incomingShare = nil
+        _state = State(initialValue: fixtureState)
+    }
+    #endif
+
     /// Entry point for SessionListView's new-chat flow: empty session id,
     /// placeholder title, lazy runtime creation on first connect.
     static func newSession(incomingShare: IncomingShareDraft? = nil) -> ChatView {

--- a/ios/Mercury/Views/TranscriptScrollPosition.swift
+++ b/ios/Mercury/Views/TranscriptScrollPosition.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Geometry policy for native transcript follow mode.
+///
+/// The tail marker must be inside the viewport (or within a small settled-
+/// scroll tolerance). Merely having the final row instantiated is not enough:
+/// a tall streaming row can remain visible while its actual end is offscreen.
+enum TranscriptScrollPosition {
+    static let endTolerance: CGFloat = 2
+
+    static func isAtBottom(
+        tailMaxY: CGFloat?,
+        viewportHeight: CGFloat,
+        tolerance: CGFloat = endTolerance
+    ) -> Bool {
+        guard let tailMaxY, viewportHeight > 0 else { return false }
+        return tailMaxY >= -tolerance && tailMaxY <= viewportHeight + tolerance
+    }
+}
+
+struct TranscriptTailPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat?
+
+    static func reduce(value: inout CGFloat?, nextValue: () -> CGFloat?) {
+        value = nextValue() ?? value
+    }
+}

--- a/ios/MercuryTests/TranscriptScrollPositionTests.swift
+++ b/ios/MercuryTests/TranscriptScrollPositionTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Mercury
+
+final class TranscriptScrollPositionTests: XCTestCase {
+    func testTailBelowViewportIsAwayFromBottom() {
+        XCTAssertFalse(TranscriptScrollPosition.isAtBottom(
+            tailMaxY: 721,
+            viewportHeight: 700,
+            tolerance: 2
+        ))
+    }
+
+    func testTailFlushOrWithinToleranceIsAtBottom() {
+        XCTAssertTrue(TranscriptScrollPosition.isAtBottom(
+            tailMaxY: 700,
+            viewportHeight: 700,
+            tolerance: 2
+        ))
+        XCTAssertTrue(TranscriptScrollPosition.isAtBottom(
+            tailMaxY: 702,
+            viewportHeight: 700,
+            tolerance: 2
+        ))
+    }
+
+    func testShortContentIsAtBottom() {
+        XCTAssertTrue(TranscriptScrollPosition.isAtBottom(
+            tailMaxY: 420,
+            viewportHeight: 700,
+            tolerance: 2
+        ))
+    }
+
+    func testMissingOrAboveViewportTailIsNotAtBottom() {
+        XCTAssertFalse(TranscriptScrollPosition.isAtBottom(
+            tailMaxY: nil,
+            viewportHeight: 700,
+            tolerance: 2
+        ))
+        XCTAssertFalse(TranscriptScrollPosition.isAtBottom(
+            tailMaxY: -3,
+            viewportHeight: 700,
+            tolerance: 2
+        ))
+    }
+}

--- a/ios/MercuryUITests/ChatTranscriptScrollUITests.swift
+++ b/ios/MercuryUITests/ChatTranscriptScrollUITests.swift
@@ -1,0 +1,66 @@
+import XCTest
+
+/// Exercises the production SwiftUI transcript, backed only by synthetic rows.
+final class ChatTranscriptScrollUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testJumpAndManualReturnResumeFollowingWithoutStreamingYank() {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitest-chat-scroll"]
+        app.launch()
+
+        let timeline = app.scrollViews["Chat transcript"]
+        XCTAssertTrue(timeline.waitForExistence(timeout: 15))
+        XCTAssertTrue(app.staticTexts["Synthetic latest message"].waitForExistence(timeout: 5))
+
+        timeline.swipeDown()
+        timeline.swipeDown()
+        let jump = app.buttons["Scroll to latest message"]
+        XCTAssertTrue(jump.waitForExistence(timeout: 5))
+        let awayScreenshot = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        awayScreenshot.name = "ios-chat-scroll-away-control"
+        awayScreenshot.lifetime = .keepAlways
+        add(awayScreenshot)
+
+        app.buttons["Append synthetic stream chunk"].tap()
+        XCTAssertTrue(jump.exists, "Incoming streaming content must not yank an away reader to the tail")
+
+        jump.tap()
+        let streaming = app.staticTexts.containing(
+            NSPredicate(format: "label CONTAINS %@", "Synthetic streaming response")
+        ).firstMatch
+        XCTAssertTrue(streaming.waitForExistence(timeout: 5))
+        let jumpGone = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"),
+            object: jump
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [jumpGone], timeout: 5), .completed)
+        app.buttons["Append synthetic stream chunk"].tap()
+        assertFollowingAfterGrowth(jump)
+
+        timeline.swipeDown()
+        timeline.swipeDown()
+        XCTAssertTrue(jump.waitForExistence(timeout: 5))
+        for _ in 0..<8 where jump.exists {
+            timeline.swipeUp()
+        }
+        XCTAssertFalse(jump.exists, "Manually returning to the true end must resume follow mode")
+        app.buttons["Append synthetic stream chunk"].tap()
+        assertFollowingAfterGrowth(jump)
+
+        let screenshot = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        screenshot.name = "ios-chat-scroll-at-latest"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+    }
+
+    private func assertFollowingAfterGrowth(_ jump: XCUIElement) {
+        let atBottom = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"), object: jump
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [atBottom], timeout: 5), .completed,
+                       "Growing streaming text must stay at the tail after follow resumes")
+    }
+}


### PR DESCRIPTION
## Summary
- Add an accessible floating scroll-to-latest button to the iOS transcript.
- Resume automatic following after tapping the button or manually returning to the true transcript end; preserve reader position while away.
- Preserve the current composer activity UI, completed-turn folding, and background-task recovery behavior.

## Scope
Native iOS UI parity with existing Android behavior. No Android, shared-core, server, or relay changes. Based on main at 61b1379.

## Verification
- Mercury simulator build and unit suite: 674 tests passed.
- Focused composer activity and scroll UI suite: 7 tests passed.
- Scroll regression exercises incoming growth while away, explicit jump, manual return, and continued growth after following resumes.
- Simulator screenshots reviewed; signed physical-device build installed and installed-version readback verified. Automatic launch of the final build was blocked by the device lock.
- User approved the simulator screenshot before publication.

The debug-only fixture uses synthetic messages and renders the production transcript. No private screenshots or environment identifiers are included.