### PR TITLE
fix: render local Markdown images on Android and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,33 @@ Mercury ships the same product on **Android** and **iOS** over one shared Kotlin
 - Preserves a Mercury-started live turn when you navigate away; it does not take over or close another client's runtime.
 - Speaks and listens through your server's audited voice stack: app-owned dictation into the composer with a stop control, per-message read-aloud, streaming speech that overlaps generation, and a hands-free voice conversation with spoken stop phrases and barge-in. Voice controls appear only when the connected server exposes the official `/api/audio/…` routes, audio is never persisted on the device, and the microphone permission is requested only when you first use voice.
 
+## Inline screenshots and images
+
+For host-local images, ask the agent to return a standalone directive using the
+verified file's actual absolute path:
+
+```text
+MEDIA:/absolute/path/screenshot.png
+```
+
+Both native clients also render explicit local Markdown images such as
+`![Screenshot](/absolute/path/screenshot.png)`. Bare paths and ordinary file links
+are not inline image requests. Code examples and escaped image syntax do not
+trigger image downloads. Local image requests use the same authenticated loader
+and host file-access rules as `MEDIA:`; this does not expose files publicly.
+
+Direct image responses are bounded to 10 MiB. Relay image reads require the host's
+advertised image-read capability and are bounded to 2 MiB. PNG, JPEG, GIF, WebP,
+and BMP are portable choices; iOS direct mode also retains HEIC and TIFF support.
+The file must exist on the connected host and be readable under its file policy.
+
+The optional [Mercury Relay host plugin](https://github.com/unsupportedpastels/mercury-relay-plugin)
+can supply media-delivery guidance to new sessions on compatible Hermes hosts.
+This is profile-wide guidance, not a guarantee of model compliance, and it does
+not retrofit existing frozen session prompts. Direct mode and native rendering
+remain usable without the plugin. Installing the mobile app alone does not
+rewrite the host's system prompt.
+
 ## Real screens, real agent
 
 Real captures from a live session on device — no mockups, no staged data.

--- a/app/src/androidTest/java/com/unsupportedpastels/hermesandroid/ui/MarkdownManagedImageInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/unsupportedpastels/hermesandroid/ui/MarkdownManagedImageInstrumentedTest.kt
@@ -1,0 +1,79 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.util.Log
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.unsupportedpastels.hermesandroid.theme.HermesAndroidTheme
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.concurrent.ConcurrentLinkedQueue
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Synthetic device fixture proving both accepted syntaxes reach the managed loader and an Image node. */
+@RunWith(AndroidJUnit4::class)
+class MarkdownManagedImageInstrumentedTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun mediaAndExplicitMarkdownSyntaxRenderThroughManagedImageLoader() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val requested = ConcurrentLinkedQueue<String>()
+        val bytes = ByteArrayOutputStream().also {
+            Bitmap.createBitmap(24, 16, Bitmap.Config.ARGB_8888).apply {
+                eraseColor(Color.BLUE)
+                Canvas(this).drawRect(0f, 0f, width / 2f, height.toFloat(), Paint().apply { color = Color.YELLOW })
+            }
+                .compress(Bitmap.CompressFormat.PNG, 100, it)
+        }.toByteArray()
+        val mediaPath = "/tmp/instrumented-media-29.png"
+        val markdownPath = "/tmp/instrumented-markdown-29.png"
+
+        composeRule.setContent {
+            CompositionLocalProvider(LocalManagedImageScope provides "instrumented:inline-markdown-images") {
+                HermesAndroidTheme {
+                    MarkdownMessage(
+                        text = "MEDIA:$mediaPath\n\nInline prose ![chart]($markdownPath) remains",
+                        loadManagedImage = { path ->
+                            requested += path
+                            bytes
+                        },
+                    )
+                }
+            }
+        }
+
+        composeRule.waitUntil(10_000) { requested.size == 2 }
+        composeRule.waitUntil(10_000) {
+            composeRule.onAllNodes(hasContentDescription("Generated image; tap to enlarge"))
+                .fetchSemanticsNodes().size == 2
+        }
+        assertEquals(setOf(mediaPath, markdownPath), requested.toSet())
+        composeRule.onAllNodes(hasContentDescription("Generated image; tap to enlarge"))
+            .assertCountEquals(2)
+
+        instrumentation.waitForIdleSync()
+        android.os.SystemClock.sleep(750)
+        val screenshot = File(
+            instrumentation.targetContext.getExternalFilesDir(null),
+            "inline-markdown-images.png",
+        )
+        screenshot.outputStream().use { output ->
+            instrumentation.uiAutomation.takeScreenshot()
+                .compress(Bitmap.CompressFormat.PNG, 100, output)
+        }
+        Log.i("InlineMarkdownImageQA", "screenshot=${screenshot.absolutePath}")
+    }
+}

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
@@ -46,6 +46,11 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import com.unsupportedpastels.hermesandroid.files.ManagedVideoMedia
+import com.unsupportedpastels.mercury.core.artifacts.ArtifactExtractor
+import com.unsupportedpastels.mercury.core.artifacts.ManagedImageContentSegmentKind
+import com.unsupportedpastels.mercury.core.artifacts.ManagedImageFormatPolicy
+import com.unsupportedpastels.mercury.core.artifacts.MarkdownFenceSegmentKind
+import com.unsupportedpastels.mercury.core.artifacts.MarkdownPresentationPolicy
 
 internal sealed interface MarkdownBlock
 
@@ -271,64 +276,29 @@ private fun Char.isBase64PayloadCharacter(): Boolean =
  * must render as plain text until more of the stream arrives.
  */
 internal fun stableMarkdownPrefixLength(text: String): Int {
-    var stableEnd = 0
-    var openFence: MarkdownFence? = null
-    var cursor = 0
-    while (cursor < text.length) {
-        val newline = text.indexOf('\n', cursor)
-        val lineEnd = if (newline < 0) text.length else newline
-        val line = text.substring(cursor, lineEnd)
-        val fence = markdownFenceAtLineStart(line)
-        if (openFence?.isClosedBy(line, fence) == true) {
-            openFence = null
-        } else if (openFence == null && fence != null) {
-            openFence = fence
-        } else if (openFence == null && line.isBlank() && newline >= 0) {
-            stableEnd = newline + 1
+    return MarkdownPresentationPolicy.stablePrefixLength(text)
+}
+
+internal fun parseMessageMarkdown(source: String): List<MarkdownBlock> =
+    ArtifactExtractor.orderedManagedImageSegments(source, ManagedImageFormatPolicy.Android).flatMap { content ->
+        when (content.kind) {
+            ManagedImageContentSegmentKind.Image -> listOfNotNull(content.source?.let(::MarkdownImageBlock))
+            ManagedImageContentSegmentKind.Text -> MarkdownPresentationPolicy.fencedSegments(content.text.orEmpty())
+                .flatMap { fence ->
+                    when (fence.kind) {
+                        MarkdownFenceSegmentKind.Code -> listOf(
+                            MarkdownCodeBlock(code = fence.text, language = fence.language),
+                        )
+                        MarkdownFenceSegmentKind.Text -> parseMessageMarkdownText(fence.text)
+                    }
+                }
         }
-        if (newline < 0) break
-        cursor = newline + 1
     }
-    return stableEnd
-}
 
-private data class MarkdownFence(val marker: Char, val length: Int, val info: String) {
-    fun isClosedBy(line: String, candidate: MarkdownFence?): Boolean =
-        candidate?.marker == marker && candidate.length >= length &&
-            line.dropWhile { it == ' ' }.drop(candidate.length).all { it == ' ' || it == '\t' }
-}
-
-private fun markdownFenceAtLineStart(line: String): MarkdownFence? {
-    val indent = line.takeWhile { it == ' ' }.length
-    if (indent > 3 || indent >= line.length) return null
-    val marker = line[indent].takeIf { it == '`' || it == '~' } ?: return null
-    var end = indent
-    while (end < line.length && line[end] == marker) end += 1
-    val length = end - indent
-    if (length < 3) return null
-    val info = line.substring(end).trim()
-    if (marker == '`' && info.contains('`')) return null
-    return MarkdownFence(marker, length, info)
-}
-
-internal fun parseMessageMarkdown(source: String): List<MarkdownBlock> {
+private fun parseMessageMarkdownText(source: String): List<MarkdownBlock> {
     if (source.isEmpty()) return emptyList()
     val normalizedSource = source.replace("\r\n", "\n").replace('\r', '\n')
     val lines = normalizedSource.split('\n')
-    val lineOffsets = ArrayList<Int>(lines.size)
-    var nextLineOffset = 0
-    lines.forEach { line ->
-        lineOffsets += nextLineOffset
-        nextLineOffset += line.length + 1
-    }
-    val explicitImagesByLine =
-        com.unsupportedpastels.mercury.core.artifacts.ArtifactExtractor
-            .explicitLocalMarkdownImages(normalizedSource)
-            .groupBy { reference ->
-                lineOffsets.binarySearch(reference.startOffset).let { exactOrInsertion ->
-                    if (exactOrInsertion >= 0) exactOrInsertion else -exactOrInsertion - 2
-                }
-            }
     val blocks = mutableListOf<MarkdownBlock>()
     val renderedImageSources = mutableSetOf<String>()
     val paragraph = mutableListOf<String>()
@@ -362,45 +332,7 @@ internal fun parseMessageMarkdown(source: String): List<MarkdownBlock> {
                 continue
             }
         }
-        val openingFence = markdownFenceAtLineStart(line)
-        if (openingFence != null) {
-            flushParagraph()
-            val language = openingFence.info
-                .take(32)
-                .ifBlank { null }
-            val codeLines = mutableListOf<String>()
-            index += 1
-            while (index < lines.size && !openingFence.isClosedBy(lines[index], markdownFenceAtLineStart(lines[index]))) {
-                codeLines += lines[index]
-                index += 1
-            }
-            blocks += MarkdownCodeBlock(
-                code = codeLines.joinToString("\n").trimEnd('\n'),
-                language = language,
-            )
-            if (index < lines.size) index += 1
-            continue
-        }
-        val explicitImages = explicitImagesByLine[index].orEmpty()
-        if (explicitImages.isNotEmpty()) {
-            val lineOffset = lineOffsets[index]
-            var cursor = 0
-            explicitImages.forEach { reference ->
-                val imageStart = reference.startOffset - lineOffset
-                val imageEnd = reference.endOffsetExclusive - lineOffset
-                val before = line.substring(cursor, imageStart)
-                if (before.isNotEmpty()) paragraph += before
-                flushParagraph()
-                if (reference.shouldRender && renderedImageSources.add(reference.source)) {
-                    blocks += MarkdownImageBlock(reference.source)
-                }
-                cursor = imageEnd
-            }
-            val after = line.substring(cursor)
-            if (after.isNotEmpty()) paragraph += after
-            index += 1
-            continue
-        }
+
         if (line.isBlank()) {
             flushParagraph()
             index += 1

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdown.kt
@@ -272,15 +272,18 @@ private fun Char.isBase64PayloadCharacter(): Boolean =
  */
 internal fun stableMarkdownPrefixLength(text: String): Int {
     var stableEnd = 0
-    var inFence = false
+    var openFence: MarkdownFence? = null
     var cursor = 0
     while (cursor < text.length) {
         val newline = text.indexOf('\n', cursor)
         val lineEnd = if (newline < 0) text.length else newline
         val line = text.substring(cursor, lineEnd)
-        if (line.trimStart().startsWith("```")) {
-            inFence = !inFence
-        } else if (!inFence && line.isBlank() && newline >= 0) {
+        val fence = markdownFenceAtLineStart(line)
+        if (openFence?.isClosedBy(line, fence) == true) {
+            openFence = null
+        } else if (openFence == null && fence != null) {
+            openFence = fence
+        } else if (openFence == null && line.isBlank() && newline >= 0) {
             stableEnd = newline + 1
         }
         if (newline < 0) break
@@ -289,10 +292,45 @@ internal fun stableMarkdownPrefixLength(text: String): Int {
     return stableEnd
 }
 
+private data class MarkdownFence(val marker: Char, val length: Int, val info: String) {
+    fun isClosedBy(line: String, candidate: MarkdownFence?): Boolean =
+        candidate?.marker == marker && candidate.length >= length &&
+            line.dropWhile { it == ' ' }.drop(candidate.length).all { it == ' ' || it == '\t' }
+}
+
+private fun markdownFenceAtLineStart(line: String): MarkdownFence? {
+    val indent = line.takeWhile { it == ' ' }.length
+    if (indent > 3 || indent >= line.length) return null
+    val marker = line[indent].takeIf { it == '`' || it == '~' } ?: return null
+    var end = indent
+    while (end < line.length && line[end] == marker) end += 1
+    val length = end - indent
+    if (length < 3) return null
+    val info = line.substring(end).trim()
+    if (marker == '`' && info.contains('`')) return null
+    return MarkdownFence(marker, length, info)
+}
+
 internal fun parseMessageMarkdown(source: String): List<MarkdownBlock> {
     if (source.isEmpty()) return emptyList()
-    val lines = source.replace("\r\n", "\n").replace('\r', '\n').split('\n')
+    val normalizedSource = source.replace("\r\n", "\n").replace('\r', '\n')
+    val lines = normalizedSource.split('\n')
+    val lineOffsets = ArrayList<Int>(lines.size)
+    var nextLineOffset = 0
+    lines.forEach { line ->
+        lineOffsets += nextLineOffset
+        nextLineOffset += line.length + 1
+    }
+    val explicitImagesByLine =
+        com.unsupportedpastels.mercury.core.artifacts.ArtifactExtractor
+            .explicitLocalMarkdownImages(normalizedSource)
+            .groupBy { reference ->
+                lineOffsets.binarySearch(reference.startOffset).let { exactOrInsertion ->
+                    if (exactOrInsertion >= 0) exactOrInsertion else -exactOrInsertion - 2
+                }
+            }
     val blocks = mutableListOf<MarkdownBlock>()
+    val renderedImageSources = mutableSetOf<String>()
     val paragraph = mutableListOf<String>()
 
     fun flushParagraph() {
@@ -313,7 +351,7 @@ internal fun parseMessageMarkdown(source: String): List<MarkdownBlock> {
             val source = mediaSource
             if (validateRemoteMediaUrl(source) || validateGatewayMediaPath(source)) {
                 flushParagraph()
-                blocks += MarkdownImageBlock(source)
+                if (renderedImageSources.add(source)) blocks += MarkdownImageBlock(source)
                 index += 1
                 continue
             }
@@ -324,14 +362,15 @@ internal fun parseMessageMarkdown(source: String): List<MarkdownBlock> {
                 continue
             }
         }
-        if (trimmedStart.startsWith("```")) {
+        val openingFence = markdownFenceAtLineStart(line)
+        if (openingFence != null) {
             flushParagraph()
-            val language = trimmedStart.removePrefix("```").trim()
+            val language = openingFence.info
                 .take(32)
                 .ifBlank { null }
             val codeLines = mutableListOf<String>()
             index += 1
-            while (index < lines.size && !lines[index].trimStart().startsWith("```")) {
+            while (index < lines.size && !openingFence.isClosedBy(lines[index], markdownFenceAtLineStart(lines[index]))) {
                 codeLines += lines[index]
                 index += 1
             }
@@ -340,6 +379,26 @@ internal fun parseMessageMarkdown(source: String): List<MarkdownBlock> {
                 language = language,
             )
             if (index < lines.size) index += 1
+            continue
+        }
+        val explicitImages = explicitImagesByLine[index].orEmpty()
+        if (explicitImages.isNotEmpty()) {
+            val lineOffset = lineOffsets[index]
+            var cursor = 0
+            explicitImages.forEach { reference ->
+                val imageStart = reference.startOffset - lineOffset
+                val imageEnd = reference.endOffsetExclusive - lineOffset
+                val before = line.substring(cursor, imageStart)
+                if (before.isNotEmpty()) paragraph += before
+                flushParagraph()
+                if (reference.shouldRender && renderedImageSources.add(reference.source)) {
+                    blocks += MarkdownImageBlock(reference.source)
+                }
+                cursor = imageEnd
+            }
+            val after = line.substring(cursor)
+            if (after.isNotEmpty()) paragraph += after
+            index += 1
             continue
         }
         if (line.isBlank()) {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImage.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/RemoteMediaImage.kt
@@ -116,11 +116,7 @@ internal fun validateGatewayVideoPath(value: String): Boolean =
     com.unsupportedpastels.mercury.core.artifacts.ManagedVideoPolicy.isManagedVideoPath(value)
 
 internal fun validateGatewayMediaPath(value: String): Boolean =
-    value.startsWith('/') &&
-        '\u0000' !in value &&
-        value.length in 2..4_096 &&
-        value.substringAfterLast('.', missingDelimiterValue = "")
-            .lowercase() in setOf("png", "jpg", "jpeg", "webp", "gif", "bmp")
+    com.unsupportedpastels.mercury.core.artifacts.ManagedImagePolicy.isManagedImagePath(value)
 
 internal fun HttpClientConfig<*>.configureRemoteImageHttpClient() {
     followRedirects = false

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModelTest.kt
@@ -136,6 +136,39 @@ class HermesConnectionViewModelTest {
     }
 
     @Test
+    fun managedImageUsesDirectAuthenticatedFileTransportWhenRelayIsNotSelected() = runTest(dispatcher) {
+        val origin = ServerOrigin.parse("https://hermes.example")
+        val requests = mutableListOf<Triple<ServerOrigin, String?, String>>()
+        val client = object : HermesConnectionClient {
+            override suspend fun probe(serverOrigin: ServerOrigin) = HermesConnectionInfo(
+                version = "0.20.0",
+                authRequired = false,
+                nativeOAuthSupported = false,
+                providers = emptyList(),
+            )
+
+            override suspend fun downloadManagedImage(
+                serverOrigin: ServerOrigin,
+                accessToken: String?,
+                path: String,
+            ): ByteArray {
+                requests += Triple(serverOrigin, accessToken, path)
+                return byteArrayOf(1, 2, 3)
+            }
+        }
+        val viewModel = HermesConnectionViewModel(
+            MutableStateFlow<ServerSettingsState>(ServerSettingsState.Ready(origin)),
+            client,
+        )
+        advanceUntilIdle()
+
+        val bytes = viewModel.downloadManagedImage("/workspace/inline.png")
+
+        assertTrue(bytes.contentEquals(byteArrayOf(1, 2, 3)))
+        assertEquals(listOf(Triple(origin, null, "/workspace/inline.png")), requests)
+    }
+
+    @Test
     fun videoDownloadCannotReturnOldOriginMediaAfterSettingsChange() = runTest(dispatcher) {
         val origin = ServerOrigin.parse("https://hermes.example")
         val other = ServerOrigin.parse("https://other.example")

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownImageUiTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownImageUiTest.kt
@@ -1,0 +1,71 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.unsupportedpastels.hermesandroid.theme.HermesAndroidTheme
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.ConcurrentLinkedQueue
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class MessageMarkdownImageUiTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun mediaAndExplicitMarkdownImagesReachTheSameManagedLoaderAndRender() {
+        val requested = ConcurrentLinkedQueue<String>()
+        val bytes = ByteArrayOutputStream().also {
+            Bitmap.createBitmap(12, 8, Bitmap.Config.ARGB_8888).apply {
+                eraseColor(Color.BLUE)
+                Canvas(this).drawRect(0f, 0f, width / 2f, height.toFloat(), Paint().apply { color = Color.YELLOW })
+            }
+                .compress(Bitmap.CompressFormat.PNG, 100, it)
+        }.toByteArray()
+        val mediaPath = "/tmp/ui-media-11.png"
+        val markdownPath = "/tmp/ui-markdown-11.png"
+
+        composeRule.setContent {
+            CompositionLocalProvider(LocalManagedImageScope provides "test:inline-markdown-images") {
+                HermesAndroidTheme {
+                    MarkdownMessage(
+                        text = "Before\n\nMEDIA:$mediaPath\n\nMiddle ![chart]($markdownPath) after",
+                        loadManagedImage = { path ->
+                            requested += path
+                            bytes
+                        },
+                    )
+                }
+            }
+        }
+
+        composeRule.waitUntil(5_000) { requested.size == 2 }
+        composeRule.waitUntil(5_000) {
+            composeRule.onAllNodes(hasContentDescription("Generated image; tap to enlarge"))
+                .fetchSemanticsNodes().size == 2
+        }
+        assertEquals(setOf(mediaPath, markdownPath), requested.toSet())
+        composeRule.onAllNodes(hasContentDescription("Generated image; tap to enlarge"))
+            .assertCountEquals(2)
+        composeRule.onNodeWithText("Before").assertIsDisplayed()
+        composeRule.onNodeWithText("Middle").assertIsDisplayed()
+        composeRule.onAllNodesWithText("after", substring = true).assertCountEquals(1)
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
@@ -60,6 +60,71 @@ class MessageMarkdownTest {
     }
 
     @Test
+    fun parsesExplicitLocalMarkdownImagesInlineWhilePreservingAdjacentProseAndDedupe() {
+        val blocks = parseMessageMarkdown(
+            "MEDIA:/workspace/first.png\n\nBefore ![first](/workspace/first.png) between " +
+                "![second](/workspace/second.jpg) duplicate " +
+                "![first again](/workspace/first.png) after",
+        )
+
+        assertEquals(
+            listOf("/workspace/first.png", "/workspace/second.jpg"),
+            blocks.filterIsInstance<MarkdownImageBlock>().map { it.url },
+        )
+        assertEquals(
+            "Before between duplicate after",
+            blocks.filterIsInstance<MarkdownTextBlock>().joinToString("") { it.plainText },
+        )
+    }
+
+    @Test
+    fun explicitMarkdownImagesDoNotFetchRemoteOrInvalidPathsAndStayInsideCode() {
+        val source = """
+            ![remote](https://example.com/image.png)
+            ![traversal](/workspace/../secret.png)
+            ![double slash](/workspace//image.png)
+            ![backslash](/workspace\image.png)
+            [ordinary local link](/workspace/linked.png)
+            bare /workspace/bare.png
+            `![inline code](/workspace/inline.png)`
+            ```markdown
+            ![fenced](/workspace/fenced.png)
+            ```
+        """.trimIndent()
+
+        val blocks = parseMessageMarkdown(source)
+
+        assertTrue(blocks.filterIsInstance<MarkdownImageBlock>().isEmpty())
+        assertTrue(blocks.filterIsInstance<MarkdownTextBlock>().any { it.plainText.contains("remote") })
+        assertTrue(blocks.filterIsInstance<MarkdownCodeBlock>().any { it.code.contains("fenced") })
+    }
+
+    @Test
+    fun explicitMarkdownImagesHandleEmptyAltCodeEscapesAndNeverCrossLines() {
+        val source = """
+            ``![double tick](/workspace/double.png)``
+            ~~~~markdown
+            ![tilde fenced](/workspace/tilde.png)
+            ~~~
+            ![still fenced](/workspace/still-fenced.png)
+            ~~~~
+            \![escaped](/workspace/escaped.png)
+            ![line break](
+            /workspace/cross-line.png)
+            ![](/workspace/empty-alt.png)
+        """.trimIndent()
+
+        val blocks = parseMessageMarkdown(source)
+
+        assertEquals(
+            listOf("/workspace/empty-alt.png"),
+            blocks.filterIsInstance<MarkdownImageBlock>().map { it.url },
+        )
+        assertTrue(blocks.filterIsInstance<MarkdownCodeBlock>().any { it.code.contains("tilde fenced") })
+        assertTrue(blocks.filterIsInstance<MarkdownTextBlock>().any { it.plainText.contains("escaped") })
+    }
+
+    @Test
     fun parsesGatewayLocalVideoMediaDirectiveAsVideoBlockInsteadOfRawPath() {
         val path = "/workspace/project/scene-00/preview.mp4"
 

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/MessageMarkdownTest.kt
@@ -125,6 +125,32 @@ class MessageMarkdownTest {
     }
 
     @Test
+    fun orderedImagesStayBetweenTheirSurroundingProseAndMultilineCodeIsExcluded() {
+        val blocks = parseMessageMarkdown(
+            "Before ![first](/workspace/first.png) middle ``code\n" +
+                "![hidden](/workspace/hidden.png)`` after ![second](/workspace/second.png) end",
+        )
+
+        assertEquals(
+            listOf("text:Before", "image:/workspace/first.png", "text:middle", "image:/workspace/second.png", "text:end"),
+            blocks.mapNotNull { block ->
+                when (block) {
+                    is MarkdownTextBlock -> "text:${block.plainText.trim().substringBefore(' ')}"
+                    is MarkdownImageBlock -> "image:${block.url}"
+                    else -> null
+                }
+            },
+        )
+    }
+
+    @Test
+    fun escapedOpeningBracketImageExampleRemainsText() {
+        val blocks = parseMessageMarkdown("!\\[example](/tmp/synthetic.png)")
+        assertTrue(blocks.filterIsInstance<MarkdownImageBlock>().isEmpty())
+        assertTrue(blocks.filterIsInstance<MarkdownTextBlock>().single().plainText.contains("example"))
+    }
+
+    @Test
     fun parsesGatewayLocalVideoMediaDirectiveAsVideoBlockInsteadOfRawPath() {
         val path = "/workspace/project/scene-00/preview.mp4"
 

--- a/ios/Mercury/MercuryApp.swift
+++ b/ios/Mercury/MercuryApp.swift
@@ -78,6 +78,8 @@ struct MercuryApp: App {
                     BackgroundTaskFixtureView()
                 } else if ProcessInfo.processInfo.arguments.contains("-uitest-chat-scroll") {
                     ChatTranscriptScrollFixtureView()
+                } else if ProcessInfo.processInfo.arguments.contains("-uitest-managed-images") {
+                    ManagedImageFixtureView()
                 } else { RootView() }
                 #else
                 RootView()
@@ -87,7 +89,8 @@ struct MercuryApp: App {
                 .task {
                     #if DEBUG
                     if ProcessInfo.processInfo.arguments.contains("-uitest-background-tasks")
-                        || ProcessInfo.processInfo.arguments.contains("-uitest-chat-scroll") { return }
+                        || ProcessInfo.processInfo.arguments.contains("-uitest-chat-scroll")
+                        || ProcessInfo.processInfo.arguments.contains("-uitest-managed-images") { return }
                     if ProcessInfo.processInfo.arguments.contains("-uitest-reset-local-state") {
                         await appModel.resetLocalStateForUITest()
                     }

--- a/ios/Mercury/MercuryKit/Chat/MediaDirectiveExtractor.swift
+++ b/ios/Mercury/MercuryKit/Chat/MediaDirectiveExtractor.swift
@@ -80,6 +80,11 @@ struct MediaExtractionMessage: Sendable, Equatable {
     }
 }
 
+enum ManagedMessageContentSegment: Sendable, Equatable {
+    case text(String)
+    case image(source: String, stableIdentity: String)
+}
+
 // MARK: - Extractor (facade over the shared KMP core)
 
 /// Facade over the shared core's `ArtifactExtractor`
@@ -122,6 +127,30 @@ enum MediaDirectiveExtractor {
                 limits: limits.core
             )
             .map(Artifact.init)
+    }
+
+    static func orderedManagedImageSegments(
+        _ text: String,
+        limits: ArtifactExtractionLimits = ArtifactExtractionLimits()
+    ) -> [ManagedMessageContentSegment] {
+        MercuryCore.ArtifactExtractor.shared
+            .orderedManagedImageSegments(
+                text: text,
+                formatPolicy: MercuryCore.ManagedImageFormatPolicy.ios,
+                limits: limits.core
+            )
+            .compactMap { segment -> ManagedMessageContentSegment? in
+                if segment.kind == MercuryCore.ManagedImageContentSegmentKind.image,
+                   let source = segment.source,
+                   let identity = segment.stableIdentity {
+                    return .image(source: source, stableIdentity: identity)
+                }
+                if segment.kind == MercuryCore.ManagedImageContentSegmentKind.text,
+                   let text = segment.text {
+                    return .text(text)
+                }
+                return nil
+            }
     }
 }
 

--- a/ios/Mercury/MercuryKit/Chat/MediaDirectiveExtractor.swift
+++ b/ios/Mercury/MercuryKit/Chat/MediaDirectiveExtractor.swift
@@ -110,6 +110,19 @@ enum MediaDirectiveExtractor {
     ) -> [Artifact] {
         extract(messages: [MediaExtractionMessage(text: text)], limits: limits)
     }
+
+    static func managedImageArtifacts(
+        _ text: String,
+        limits: ArtifactExtractionLimits = ArtifactExtractionLimits()
+    ) -> [Artifact] {
+        MercuryCore.ArtifactExtractor.shared
+            .managedImageArtifacts(
+                text: text,
+                formatPolicy: MercuryCore.ManagedImageFormatPolicy.ios,
+                limits: limits.core
+            )
+            .map(Artifact.init)
+    }
 }
 
 func extractArtifacts(

--- a/ios/Mercury/MercuryKit/Networking/HermesHTTPClient.swift
+++ b/ios/Mercury/MercuryKit/Networking/HermesHTTPClient.swift
@@ -148,7 +148,10 @@ final class HermesHTTPClient {
     /// Fetches one authenticated image from the unchanged Hermes managed-file
     /// route. Images have their own 10 MiB bound: the generic JSON cap remains
     /// 64 KiB, but ordinary PNG previews are frequently larger than that.
-    func downloadManagedImage(path: String) async throws -> Data {
+    func downloadManagedImage(
+        path: String,
+        maximumResponseBytes: Int = HermesHTTPClient.maxManagedImageBytes
+    ) async throws -> Data {
         guard Self.isCanonicalManagedPath(path) else { throw URLError(.badURL) }
         var components = try urlComponents(path: "/api/files/download")
         components.queryItems = [URLQueryItem(name: "path", value: path)]
@@ -156,13 +159,36 @@ final class HermesHTTPClient {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("image/*", forHTTPHeaderField: "Accept")
-        let (data, response) = try await run(request, maximumResponseBytes: Self.maxManagedImageBytes)
-        guard (200..<300).contains(response.statusCode),
-              (response.value(forHTTPHeaderField: "Content-Type") ?? "")
-                .lowercased().hasPrefix("image/") else {
-            throw URLError(.cannotDecodeContentData)
+        let maximumBytes = max(0, min(maximumResponseBytes, Self.maxManagedImageBytes))
+        func authenticatedRequest() -> URLRequest {
+            var authenticated = request
+            if let bearerToken, !bearerToken.isEmpty {
+                authenticated.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+            }
+            if let cookies = session.configuration.httpCookieStorage?.cookies(for: url), !cookies.isEmpty {
+                authenticated.setValue(
+                    HTTPCookie.requestHeaderFields(with: cookies)["Cookie"],
+                    forHTTPHeaderField: "Cookie"
+                )
+            }
+            return authenticated
         }
-        return data
+
+        try Task.checkCancellation()
+        do {
+            return try await ManagedImageDownload(maximumBytes: maximumBytes).download(
+                request: authenticatedRequest(),
+                configuration: session.configuration
+            )
+        } catch let failure as ManagedImageHTTPFailure
+            where failure.statusCode == 401 && refreshTokenProvider != nil {
+            guard await refreshAndApplyToken() else { throw failure }
+            try Task.checkCancellation()
+            return try await ManagedImageDownload(maximumBytes: maximumBytes).download(
+                request: authenticatedRequest(),
+                configuration: session.configuration
+            )
+        }
     }
 
     private static func isCanonicalManagedPath(_ path: String) -> Bool {

--- a/ios/Mercury/MercuryKit/Networking/HermesHTTPClient.swift
+++ b/ios/Mercury/MercuryKit/Networking/HermesHTTPClient.swift
@@ -17,6 +17,7 @@ final class HermesHTTPClient {
 
     /// Hard cap on response body size (64 KiB).
     static let maxResponseBytes = 65_536
+    static let maxManagedImageBytes = 10 * 1024 * 1024
 
     /// Normalized origin, e.g. "https://hermes.example.com" (no trailing slash).
     let origin: String
@@ -142,6 +143,33 @@ final class HermesHTTPClient {
         request.httpMethod = "DELETE"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         return try await run(request)
+    }
+
+    /// Fetches one authenticated image from the unchanged Hermes managed-file
+    /// route. Images have their own 10 MiB bound: the generic JSON cap remains
+    /// 64 KiB, but ordinary PNG previews are frequently larger than that.
+    func downloadManagedImage(path: String) async throws -> Data {
+        guard Self.isCanonicalManagedPath(path) else { throw URLError(.badURL) }
+        var components = try urlComponents(path: "/api/files/download")
+        components.queryItems = [URLQueryItem(name: "path", value: path)]
+        guard let url = components.url else { throw URLError(.badURL) }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("image/*", forHTTPHeaderField: "Accept")
+        let (data, response) = try await run(request, maximumResponseBytes: Self.maxManagedImageBytes)
+        guard (200..<300).contains(response.statusCode),
+              (response.value(forHTTPHeaderField: "Content-Type") ?? "")
+                .lowercased().hasPrefix("image/") else {
+            throw URLError(.cannotDecodeContentData)
+        }
+        return data
+    }
+
+    private static func isCanonicalManagedPath(_ path: String) -> Bool {
+        MercuryCore.ManagedImagePolicy.shared.isManagedImagePath(
+            path: path,
+            formatPolicy: MercuryCore.ManagedImageFormatPolicy.ios
+        )
     }
 
     /// Video uses the same origin-scoped credentials, but a bounded disk stream

--- a/ios/Mercury/MercuryKit/Networking/ManagedImageDownload.swift
+++ b/ios/Mercury/MercuryKit/Networking/ManagedImageDownload.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+struct ManagedImageHTTPFailure: Error {
+    let statusCode: Int
+}
+
+/// Incremental in-memory transport for managed images. It owns only a child
+/// session made from the caller's configuration, so injected protocol classes,
+/// cookie storage and cache policy are retained without invalidating the caller.
+final class ManagedImageDownload: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    private let lock = NSRecursiveLock()
+    private let maximumBytes: Int64
+    private var session: URLSession?
+    private var task: URLSessionDataTask?
+    private var continuation: CheckedContinuation<Data, Error>?
+    private var data = Data()
+    private var accepted = false
+    private var cancelled = false
+
+    init(maximumBytes: Int) {
+        self.maximumBytes = Int64(max(0, min(maximumBytes, HermesHTTPClient.maxManagedImageBytes)))
+        super.init()
+    }
+
+    func download(
+        request: URLRequest,
+        configuration: URLSessionConfiguration
+    ) async throws -> Data {
+        try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            return try await withCheckedThrowingContinuation { continuation in
+                lock.lock()
+                defer { lock.unlock() }
+                guard !cancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                self.continuation = continuation
+                data.reserveCapacity(Int(min(maximumBytes, 64 * 1_024)))
+                configuration.urlCache = nil
+                configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+                let childSession = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+                session = childSession
+                let task = childSession.dataTask(with: request)
+                self.task = task
+                task.resume()
+            }
+        } onCancel: {
+            self.cancel()
+        }
+    }
+
+    func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
+        cancelled = true
+        finish(CancellationError())
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+        completionHandler(nil)
+        finish(URLError(.redirectToNonExistentLocation))
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard continuation != nil, !cancelled, let http = response as? HTTPURLResponse else {
+            completionHandler(.cancel)
+            finish(URLError(.cannotDecodeContentData))
+            return
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            completionHandler(.cancel)
+            finish(ManagedImageHTTPFailure(statusCode: http.statusCode))
+            return
+        }
+        guard (http.value(forHTTPHeaderField: "Content-Type") ?? "")
+            .lowercased().hasPrefix("image/") else {
+            completionHandler(.cancel)
+            finish(URLError(.cannotDecodeContentData))
+            return
+        }
+        if let rawLength = http.value(forHTTPHeaderField: "Content-Length") {
+            guard let declaredLength = Int64(rawLength), declaredLength >= 0 else {
+                completionHandler(.cancel)
+                finish(URLError(.cannotDecodeContentData))
+                return
+            }
+            guard declaredLength <= maximumBytes else {
+                completionHandler(.cancel)
+                finish(ResponseTooLargeError())
+                return
+            }
+        }
+        accepted = true
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive chunk: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard continuation != nil, accepted, !cancelled else { return }
+        guard Int64(chunk.count) <= maximumBytes - Int64(data.count) else {
+            finish(ResponseTooLargeError())
+            return
+        }
+        data.append(chunk)
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard continuation != nil else { return }
+        if let error {
+            if cancelled || (error as? URLError)?.code == .cancelled {
+                finish(CancellationError())
+            } else {
+                finish(TransportError(underlying: error))
+            }
+            return
+        }
+        guard accepted, !cancelled else {
+            finish(URLError(.cannotDecodeContentData))
+            return
+        }
+        let result = data
+        let completion = continuation
+        continuation = nil
+        self.task = nil
+        session.finishTasksAndInvalidate()
+        self.session = nil
+        completion?.resume(returning: result)
+    }
+
+    private func finish(_ error: Error) {
+        task?.cancel()
+        task = nil
+        session?.invalidateAndCancel()
+        session = nil
+        data.removeAll(keepingCapacity: false)
+        let completion = continuation
+        continuation = nil
+        completion?.resume(throwing: error)
+    }
+}

--- a/ios/Mercury/Views/ChatManagedImages.swift
+++ b/ios/Mercury/Views/ChatManagedImages.swift
@@ -1,5 +1,30 @@
 import SwiftUI
 
+enum ChatManagedImagePolicy {
+    static func artifacts(in text: String) -> [Artifact] {
+        let managedImageIdentities = Set(MediaDirectiveExtractor.managedImageArtifacts(text).map(\.stableIdentity))
+        return MediaDirectiveExtractor.extract(text).filter {
+            ($0.origin == .managedPath && $0.type == .image
+                && managedImageIdentities.contains($0.stableIdentity)) || $0.type == .video
+        }
+    }
+}
+
+enum ManagedImageLoader {
+    static func direct(client: HermesHTTPClient, path: String) async throws -> Data {
+        try await client.downloadManagedImage(path: path)
+    }
+
+    static func relay(
+        reader: RelayImageReader = .shared,
+        profile: String,
+        path: String,
+        request: @MainActor (String, [String: Any]) async throws -> [String: Any]
+    ) async throws -> Data {
+        try await reader.read(profile: profile, path: path, request: request)
+    }
+}
+
 extension ChatView {
     // MARK: Managed images
 
@@ -8,8 +33,7 @@ extension ChatView {
     /// server-managed absolute paths render; remote URLs stay links.
     @ViewBuilder
     func managedImages(in text: String) -> some View {
-        let artifacts = MediaDirectiveExtractor.extract(text)
-            .filter { ($0.origin == .managedPath && $0.type == .image) || $0.type == .video }
+        let artifacts = ChatManagedImagePolicy.artifacts(in: text)
         ForEach(artifacts, id: \.stableIdentity) { artifact in
             Group {
                 if artifact.type == .video, artifact.origin == .remoteURL {
@@ -61,7 +85,7 @@ extension ChatView {
         let scope = managedImageScope
         if appModel.activeRelayTarget != nil {
             guard let live = state.connection else { throw ChatError.transport("Connect the Relay chat to load images") }
-            let bytes = try await RelayImageReader.shared.read(profile: appModel.activeProfile, path: path) { method, params in
+            let bytes = try await ManagedImageLoader.relay(profile: appModel.activeProfile, path: path) { method, params in
                 try Task.checkCancellation()
                 guard managedImageScope == scope, state.connection === live else { throw CancellationError() }
                 return try await live.relayRequest(method, params: params)
@@ -73,17 +97,7 @@ extension ChatView {
         guard let origin = appModel.serverOrigin else {
             throw URLError(.userAuthenticationRequired)
         }
-        let client = makeHTTPClient(origin: origin)
-        let (data, response) = try await client.get(
-            path: "/api/files/download",
-            queryItems: [URLQueryItem(name: "path", value: path)]
-        )
-        guard (200..<300).contains(response.statusCode),
-              (response.value(forHTTPHeaderField: "Content-Type") ?? "")
-                  .lowercased().hasPrefix("image/"),
-              data.count <= 10 * 1024 * 1024 else {
-            throw URLError(.cannotDecodeContentData)
-        }
+        let data = try await ManagedImageLoader.direct(client: makeHTTPClient(origin: origin), path: path)
         try Task.checkCancellation()
         guard managedImageScope == scope else { throw CancellationError() }
         return data

--- a/ios/Mercury/Views/ChatManagedImages.swift
+++ b/ios/Mercury/Views/ChatManagedImages.swift
@@ -28,6 +28,30 @@ enum ManagedImageLoader {
 extension ChatView {
     // MARK: Managed images
 
+    @ViewBuilder
+    func completedAssistantMessage(in text: String) -> some View {
+        OrderedManagedMessageView(text: text) { source in
+            AnyView(
+                RemoteManagedImage(path: source, scope: managedImageScope) { path in
+                    try await loadManagedImage(path: path)
+                }
+            )
+        }
+        ForEach(ChatManagedImagePolicy.artifacts(in: text).filter { $0.type == .video }, id: \.stableIdentity) { artifact in
+            if artifact.origin == .remoteURL,
+               let url = URL(string: artifact.source), url.scheme?.lowercased() == "https" {
+                Link(destination: url) {
+                    Label("Open video: \(artifact.displayName)", systemImage: "arrow.up.right.video")
+                }
+            } else if artifact.origin == .managedPath {
+                RemoteManagedVideo(path: artifact.source, scope: managedImageScope,
+                                   available: appModel.activeRelayTarget == nil) { path in
+                    try await loadManagedVideo(path: path)
+                }
+            }
+        }
+    }
+
     /// Managed MEDIA:/markdown image artifacts in a completed assistant
     /// message, rendered as authenticated inline images (M6.4). Only
     /// server-managed absolute paths render; remote URLs stay links.
@@ -61,6 +85,9 @@ extension ChatView {
     /// with the bearer token; image/* content type required; 10 MiB cap
     /// (Android downloadManagedImage parity).
     private var managedImageScope: String {
+        #if DEBUG
+        if fixtureManagedImageLoader != nil { return "synthetic-managed-image-fixture" }
+        #endif
         let transport = appModel.activeRelayTarget.map { "relay:\($0.relayOrigin)|\($0.id)" }
             ?? "direct:\(appModel.serverOrigin ?? "unconfigured")"
         return "\(transport)|\(appModel.activeProfile)|\(state.connection.map { String(describing: ObjectIdentifier($0)) } ?? "disconnected")"
@@ -82,6 +109,11 @@ extension ChatView {
     }
 
     private func loadManagedImage(path: String) async throws -> Data {
+        #if DEBUG
+        if let fixtureManagedImageLoader {
+            return try await fixtureManagedImageLoader(path)
+        }
+        #endif
         let scope = managedImageScope
         if appModel.activeRelayTarget != nil {
             guard let live = state.connection else { throw ChatError.transport("Connect the Relay chat to load images") }

--- a/ios/Mercury/Views/ChatProgressRecovery.swift
+++ b/ios/Mercury/Views/ChatProgressRecovery.swift
@@ -140,7 +140,7 @@ extension ChatView {
             backgroundTasks: backgroundTasks,
             onRefresh: { Task { await refreshSessionProgress() } },
             onReconnect: { retryConnectionNow() },
-            media: { AnyView(managedImages(in: $0)) }
+            media: { AnyView(completedAssistantMessage(in: $0)) }
         )
     }
 }

--- a/ios/Mercury/Views/ChatTranscriptList.swift
+++ b/ios/Mercury/Views/ChatTranscriptList.swift
@@ -45,10 +45,13 @@ extension ChatView {
                                     role: row.role,
                                     text: row.text
                                 ) {
-                                    MessageBubble(role: row.role, text: row.text, isStreaming: !row.completed)
+                                    if row.role.lowercased() == "assistant", row.completed {
+                                        completedAssistantMessage(in: row.text)
+                                    } else {
+                                        MessageBubble(role: row.role, text: row.text, isStreaming: !row.completed)
+                                    }
                                 }
                                 if row.role.lowercased() == "assistant", row.completed, !row.text.isEmpty {
-                                    managedImages(in: row.text)
                                     if TranscriptPresentationPolicy.shouldShowPlaybackControl(
                                         enabled: showMessagePlaybackControls,
                                         role: row.role,
@@ -66,7 +69,7 @@ extension ChatView {
                             .id(row.id)
                         case .activity(_, let steps, let reasoning, let count):
                             TurnActivityView(steps: steps, answerReasoning: reasoning, stepCount: count,
-                                             media: { AnyView(managedImages(in: $0)) })
+                                             media: { AnyView(completedAssistantMessage(in: $0)) })
                                 .id(entry.id)
                         }
                     }

--- a/ios/Mercury/Views/ChatView.swift
+++ b/ios/Mercury/Views/ChatView.swift
@@ -95,6 +95,11 @@ struct ChatView: View {
     /// See ChatSessionState for the property inventory.
     @State var state: ChatSessionState
 
+    #if DEBUG
+    /// Synthetic production-transcript fixture hook; never set by app flows.
+    var fixtureManagedImageLoader: ((String) async throws -> Data)? = nil
+    #endif
+
     var backgroundTaskScope: String {
         AppModel.backgroundTaskScope(relayTarget: appModel.activeRelayTarget,
                                      serverOrigin: appModel.serverOrigin,

--- a/ios/Mercury/Views/ManagedImageFixtureView.swift
+++ b/ios/Mercury/Views/ManagedImageFixtureView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import UIKit
+
+#if DEBUG
+/// Synthetic simulator fixture for the production artifact policy and image
+/// renderer. It performs no network, credential, or private transcript access.
+struct ManagedImageFixtureView: View {
+    private let message = """
+    Standalone MEDIA and local Markdown images should both render below.
+
+    MEDIA:/tmp/fixture-media.png
+    ![Local Markdown image](/tmp/fixture-markdown.png)
+    /tmp/bare-path-must-not-render.png
+    ![Remote image stays a link](https://cdn.example/remote.png)
+    """
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Synthetic image fixture")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    MessageBubble(role: "assistant", text: message, isStreaming: false)
+                    ForEach(ChatManagedImagePolicy.artifacts(in: message), id: \.stableIdentity) { artifact in
+                        if artifact.origin == .managedPath, artifact.type == .image {
+                            RemoteManagedImage(path: artifact.source, scope: "synthetic-inline-images") { path in
+                                Self.png(for: path)
+                            }
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Inline images")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    private static func png(for path: String) -> Data {
+        let color: UIColor = path.contains("markdown") ? .systemTeal : .systemIndigo
+        return UIGraphicsImageRenderer(size: CGSize(width: 720, height: 360)).pngData { context in
+            color.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 720, height: 360))
+            UIColor.white.setFill()
+            let title = path.contains("markdown") ? "LOCAL MARKDOWN" : "MEDIA"
+            title.draw(at: CGPoint(x: 36, y: 145), withAttributes: [
+                .font: UIFont.boldSystemFont(ofSize: 42),
+                .foregroundColor: UIColor.white,
+            ])
+        }
+    }
+}
+#endif

--- a/ios/Mercury/Views/ManagedImageFixtureView.swift
+++ b/ios/Mercury/Views/ManagedImageFixtureView.swift
@@ -5,37 +5,46 @@ import UIKit
 /// Synthetic simulator fixture for the production artifact policy and image
 /// renderer. It performs no network, credential, or private transcript access.
 struct ManagedImageFixtureView: View {
-    private let message = """
-    Standalone MEDIA and local Markdown images should both render below.
+    @State private var state = ChatSessionState(
+        sessionID: "managed-image-fixture",
+        title: "Inline images",
+        isNewSession: false,
+        incomingShare: nil
+    )
+    @State private var loaded = false
 
-    MEDIA:/tmp/fixture-media.png
+    private let message = """
+    PROSE BEFORE
     ![Local Markdown image](/tmp/fixture-markdown.png)
+    PROSE BETWEEN
+    MEDIA:/tmp/fixture-media.png
+    PROSE AFTER
+    ``multiline code starts
+    ![Code image must not render](/tmp/fixture-code.png)
+    and ends``
+    !\\[example](/tmp/synthetic.png)
     /tmp/bare-path-must-not-render.png
     ![Remote image stays a link](https://cdn.example/remote.png)
     """
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Synthetic image fixture")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    MessageBubble(role: "assistant", text: message, isStreaming: false)
-                    ForEach(ChatManagedImagePolicy.artifacts(in: message), id: \.stableIdentity) { artifact in
-                        if artifact.origin == .managedPath, artifact.type == .image {
-                            RemoteManagedImage(path: artifact.source, scope: "synthetic-inline-images") { path in
-                                Self.png(for: path)
-                            }
-                        }
-                    }
-                }
-                .padding()
-            }
+            productionTranscript
             .navigationTitle("Inline images")
             .navigationBarTitleDisplayMode(.inline)
         }
         .preferredColorScheme(.dark)
+        .task {
+            guard !loaded else { return }
+            loaded = true
+            state.transcript.loadTranscript([(role: "assistant", content: message)])
+        }
+    }
+
+    private var productionTranscript: some View {
+        var chat = ChatView(fixtureState: state)
+        chat.fixtureManagedImageLoader = { path in Self.png(for: path) }
+        return chat.transcriptList(backgroundTasks: BackgroundTasks())
     }
 
     private static func png(for path: String) -> Data {

--- a/ios/Mercury/Views/MessageMarkdown.swift
+++ b/ios/Mercury/Views/MessageMarkdown.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import MercuryCore
 
 enum MessageMarkdownTableAlignment: Equatable {
     case leading
@@ -101,6 +102,15 @@ private func orderedListParts(_ content: String) -> (marker: String, text: Strin
 /// Parses the block structure that Foundation's inline markdown mode omits.
 /// Inline emphasis and links remain Foundation-owned at render time.
 func parseMessageMarkdown(_ source: String) -> [MessageMarkdownBlock] {
+    MercuryCore.MarkdownPresentationPolicy.shared.fencedSegments(source: source).flatMap { segment -> [MessageMarkdownBlock] in
+        if segment.kind == MercuryCore.MarkdownFenceSegmentKind.code {
+            return [.code(language: segment.language, code: segment.text)]
+        }
+        return parseMessageMarkdownText(segment.text)
+    }
+}
+
+private func parseMessageMarkdownText(_ source: String) -> [MessageMarkdownBlock] {
     guard !source.isEmpty else { return [] }
     let lines = source.replacingOccurrences(of: "\r\n", with: "\n")
         .replacingOccurrences(of: "\r", with: "\n")
@@ -122,23 +132,6 @@ func parseMessageMarkdown(_ source: String) -> [MessageMarkdownBlock] {
         let line = lines[index]
         let trimmed = line.trimmingCharacters(in: .whitespaces)
 
-        if trimmed.hasPrefix("```") {
-            flushParagraph()
-            let language = String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespaces)
-            var codeLines: [String] = []
-            index += 1
-            while index < lines.count,
-                  !lines[index].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
-                codeLines.append(lines[index])
-                index += 1
-            }
-            blocks.append(.code(
-                language: language.isEmpty ? nil : String(language.prefix(32)),
-                code: codeLines.joined(separator: "\n")
-            ))
-            if index < lines.count { index += 1 }
-            continue
-        }
 
         if line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             flushParagraph()

--- a/ios/Mercury/Views/OrderedManagedMessageView.swift
+++ b/ios/Mercury/Views/OrderedManagedMessageView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Completed assistant-message renderer shared by the real transcript and its
+/// synthetic UI fixture. Text and authenticated managed images stay in the
+/// exact order selected by the shared KMP policy.
+struct OrderedManagedMessageView: View {
+    let text: String
+    var image: (_ source: String) -> AnyView
+
+    private var segments: [ManagedMessageContentSegment] {
+        MediaDirectiveExtractor.orderedManagedImageSegments(text)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(segments.enumerated()), id: \.offset) { index, segment in
+                switch segment {
+                case .text(let content):
+                    if !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        MessageBubble(role: "assistant", text: content, isStreaming: false)
+                            .accessibilityIdentifier("Ordered message text \(index)")
+                    }
+                case .image(let source, let stableIdentity):
+                    image(source)
+                        .id(stableIdentity)
+                        .accessibilityIdentifier("Ordered managed image \(index)")
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/ios/Mercury/Views/TurnActivityView.swift
+++ b/ios/Mercury/Views/TurnActivityView.swift
@@ -5,7 +5,9 @@ struct TurnActivityView: View {
     let steps: [TranscriptState.Row]
     let answerReasoning: String?
     let stepCount: Int
-    var media: (String) -> AnyView = { _ in AnyView(EmptyView()) }
+    var media: (String) -> AnyView = {
+        AnyView(MessageBubble(role: "assistant", text: $0, isStreaming: false))
+    }
     @State private var expanded = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -47,7 +49,9 @@ struct TurnActivityView: View {
 /// transcript renderers. No reduction or tool-result parsing in SwiftUI.
 struct ActivityTranscriptContent: View {
     let rows: [TranscriptState.Row]
-    var media: (String) -> AnyView = { _ in AnyView(EmptyView()) }
+    var media: (String) -> AnyView = {
+        AnyView(MessageBubble(role: "assistant", text: $0, isStreaming: false))
+    }
     var body: some View {
         ForEach(coalesceTranscriptEntries(rows, withinTurnActivity: true)) { entry in
             switch entry {
@@ -57,8 +61,11 @@ struct ActivityTranscriptContent: View {
                         ReasoningDisclosure(reasoningText: row.reasoningText, streaming: !row.completed)
                     }
                     if !row.text.isEmpty {
-                        MessageBubble(role: row.role, text: row.text, isStreaming: !row.completed)
-                        if row.completed { media(row.text) }
+                        if row.role.lowercased() == "assistant", row.completed {
+                            media(row.text)
+                        } else {
+                            MessageBubble(role: row.role, text: row.text, isStreaming: !row.completed)
+                        }
                     }
                 }
             case .toolRun(let rows):

--- a/ios/MercuryTests/ManagedImageLoadingTests.swift
+++ b/ios/MercuryTests/ManagedImageLoadingTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import Mercury
+
+private final class ManagedImageLoadingURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        Self.requests.append(request)
+        do {
+            let (response, data) = try XCTUnwrap(Self.handler)(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+    override func stopLoading() {}
+}
+
+final class ManagedImageLoadingTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        ManagedImageLoadingURLProtocol.requests = []
+        ManagedImageLoadingURLProtocol.handler = nil
+    }
+
+    override func tearDown() {
+        ManagedImageLoadingURLProtocol.requests = []
+        ManagedImageLoadingURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    private func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ManagedImageLoadingURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private func response(_ request: URLRequest, status: Int = 200, mime: String = "image/png") -> HTTPURLResponse {
+        HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: ["Content-Type": mime])!
+    }
+
+    func testDirectProductionLoaderAcceptsRealPreviewSizedBodyBeyondGenericJSONCap() async throws {
+        let previewByteCount = 170_924
+        var body = Data([137, 80, 78, 71, 13, 10, 26, 10])
+        body.append(Data(repeating: 0xA5, count: previewByteCount - body.count))
+        ManagedImageLoadingURLProtocol.handler = { request in
+            (self.response(request), body)
+        }
+        let client = HermesHTTPClient(origin: "https://images.example", session: session())
+        client.bearerToken = "synthetic-token"
+
+        do {
+            _ = try await client.get(
+                path: "/api/files/download",
+                queryItems: [URLQueryItem(name: "path", value: "/tmp/mercury-chat-preview.png")]
+            )
+            XCTFail("The generic JSON transport must retain its 64 KiB cap")
+        } catch is ResponseTooLargeError {}
+
+        let loaded = try await ManagedImageLoader.direct(client: client, path: "/tmp/mercury-chat-preview.png")
+
+        XCTAssertEqual(loaded.count, previewByteCount)
+        XCTAssertEqual(ManagedImageLoadingURLProtocol.requests.count, 2)
+        let request = try XCTUnwrap(ManagedImageLoadingURLProtocol.requests.last)
+        XCTAssertEqual(request.url?.path, "/api/files/download")
+        XCTAssertEqual(URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?.queryItems,
+                       [URLQueryItem(name: "path", value: "/tmp/mercury-chat-preview.png")])
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer synthetic-token")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "image/*")
+    }
+
+    func testDirectProductionLoaderKeepsPathMimeAndTenMiBBounds() async throws {
+        let client = HermesHTTPClient(origin: "https://images.example", session: session())
+        for invalid in ["tmp/bare.png", "https://example.com/x.png", "/tmp/../secret.png", "//host/x.png", "/tmp/image.bin"] {
+            do {
+                _ = try await ManagedImageLoader.direct(client: client, path: invalid)
+                XCTFail("Invalid managed path must fail: \(invalid)")
+            } catch {}
+        }
+        XCTAssertTrue(ManagedImageLoadingURLProtocol.requests.isEmpty)
+
+        ManagedImageLoadingURLProtocol.handler = { request in
+            (self.response(request, mime: "text/html"), Data([1]))
+        }
+        do {
+            _ = try await ManagedImageLoader.direct(client: client, path: "/tmp/image.png")
+            XCTFail("Non-image MIME must fail")
+        } catch {}
+
+        ManagedImageLoadingURLProtocol.handler = { request in
+            (self.response(request), Data(repeating: 0, count: 10 * 1024 * 1024 + 1))
+        }
+        do {
+            _ = try await ManagedImageLoader.direct(client: client, path: "/tmp/image.png")
+            XCTFail("Oversized image must fail")
+        } catch is ResponseTooLargeError {}
+    }
+
+    func testDirectProductionLoaderPreservesAppleNativeManagedImageFormats() async throws {
+        ManagedImageLoadingURLProtocol.handler = { request in
+            (self.response(request, mime: "image/heic"), Data([1, 2, 3]))
+        }
+        let client = HermesHTTPClient(origin: "https://images.example", session: session())
+
+        for path in ["/tmp/photo.heic", "/tmp/scan.tif", "/tmp/page.tiff"] {
+            let data = try await ManagedImageLoader.direct(client: client, path: path)
+            XCTAssertEqual(data, Data([1, 2, 3]))
+        }
+        XCTAssertEqual(
+            ManagedImageLoadingURLProtocol.requests.compactMap {
+                URLComponents(url: $0.url!, resolvingAgainstBaseURL: false)?.queryItems?.first?.value
+            },
+            ["/tmp/photo.heic", "/tmp/scan.tif", "/tmp/page.tiff"]
+        )
+    }
+
+    func testRelayProductionLoaderUsesCapabilityGatedReaderAndExactProfilePath() async throws {
+        let reader = RelayImageReader()
+        var methods: [String] = []
+        let bytes = try await ManagedImageLoader.relay(reader: reader, profile: "work", path: "/tmp/relay.png") { method, params in
+            methods.append(method)
+            if method == "relay.status" {
+                return ["capabilities": ["image_read": [
+                    "method": "relay.image.read", "max_bytes": 2 * 1024 * 1024,
+                    "mime_types": ["image/png", "image/jpeg"],
+                ]]]
+            }
+            XCTAssertEqual(params["profile"] as? String, "work")
+            XCTAssertEqual(params["path"] as? String, "/tmp/relay.png")
+            return ["mime_type": "image/png", "size": 8, "base64": "iVBORw0KGgo="]
+        }
+        XCTAssertEqual(methods, ["relay.status", "relay.image.read"])
+        XCTAssertEqual(bytes, Data(base64Encoded: "iVBORw0KGgo="))
+    }
+
+    func testProductionRenderPolicyPreservesMediaAndLocalMarkdownOnly() {
+        let artifacts = ChatManagedImagePolicy.artifacts(in: """
+        MEDIA:/tmp/media.png
+        ![](/tmp/markdown-image.png)
+        MEDIA:/tmp/photo.heic
+        ![scan](/tmp/scan.tif)
+        MEDIA:/tmp/page.tiff
+        /tmp/bare.png
+        [ordinary](/tmp/ordinary.png)
+        ![remote](https://cdn.example/remote.png)
+        ``![code](/tmp/code.png)``
+        ~~~~markdown
+        MEDIA:/tmp/fenced-media.png
+        ![fenced](/tmp/fenced-markdown.png)
+        ~~~
+        MEDIA:/tmp/still-fenced.png
+        ~~~~
+        """)
+        XCTAssertEqual(
+            artifacts.map(\.source),
+            ["/tmp/media.png", "/tmp/markdown-image.png", "/tmp/photo.heic", "/tmp/scan.tif", "/tmp/page.tiff"]
+        )
+        XCTAssertTrue(artifacts.allSatisfy { $0.origin == .managedPath && $0.type == .image })
+    }
+}

--- a/ios/MercuryTests/ManagedImageNetworkTests.swift
+++ b/ios/MercuryTests/ManagedImageNetworkTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+@testable import Mercury
+
+private final class ManagedImageNetworkURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((ManagedImageNetworkURLProtocol) -> Void)?
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+    nonisolated(unsafe) static var onStop: (() -> Void)?
+    private let stopObserver = ManagedImageNetworkURLProtocol.onStop
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requests.append(request)
+        Self.handler?(self)
+    }
+
+    override func stopLoading() {
+        stopObserver?()
+    }
+
+    func respond(status: Int = 200, headers: [String: String] = ["Content-Type": "image/png"]) {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: status,
+            httpVersion: nil,
+            headerFields: headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    }
+}
+
+final class ManagedImageNetworkTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        ManagedImageNetworkURLProtocol.handler = nil
+        ManagedImageNetworkURLProtocol.requests = []
+        ManagedImageNetworkURLProtocol.onStop = nil
+    }
+
+    override func tearDown() {
+        ManagedImageNetworkURLProtocol.handler = nil
+        ManagedImageNetworkURLProtocol.requests = []
+        super.tearDown()
+    }
+
+    private func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ManagedImageNetworkURLProtocol.self]
+        configuration.httpCookieStorage = HTTPCookieStorage.shared
+        return URLSession(configuration: configuration)
+    }
+
+    func testUnknownLengthOverflowStopsTransferBeforeCompletion() async throws {
+        let stopped = expectation(description: "underlying transfer stopped")
+        ManagedImageNetworkURLProtocol.onStop = { stopped.fulfill() }
+        let started = expectation(description: "request started")
+        ManagedImageNetworkURLProtocol.handler = { _ in started.fulfill() }
+        let downloader = ManagedImageDownload(maximumBytes: 4)
+        let request = URLRequest(url: URL(string: "https://images.example/image.png")!)
+        let configuration = session().configuration
+        let work = Task { try await downloader.download(request: request, configuration: configuration) }
+        await fulfillment(of: [started], timeout: 1)
+        let callbackSession = URLSession(configuration: .ephemeral)
+        defer { callbackSession.invalidateAndCancel() }
+        let callbackTask = callbackSession.dataTask(with: request)
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: nil,
+            headerFields: ["Content-Type": "image/png"]
+        )!
+        downloader.urlSession(callbackSession, dataTask: callbackTask, didReceive: response) {
+            XCTAssertEqual($0, .allow)
+        }
+        downloader.urlSession(callbackSession, dataTask: callbackTask, didReceive: Data([1, 2, 3]))
+        downloader.urlSession(callbackSession, dataTask: callbackTask, didReceive: Data([4, 5]))
+        do {
+            _ = try await work.value
+            XCTFail("Oversized stream returned data")
+        } catch is ResponseTooLargeError {}
+
+        await fulfillment(of: [stopped], timeout: 2)
+    }
+
+    func testMissingAndDishonestContentLengthUseActualByteCap() async throws {
+        var attempt = 0
+        ManagedImageNetworkURLProtocol.handler = { protocolInstance in
+            attempt += 1
+            let headers = attempt == 1
+                ? ["Content-Type": "image/png"]
+                : ["Content-Type": "image/png", "Content-Length": "3"]
+            protocolInstance.respond(headers: headers)
+            let data = attempt == 1 ? Data([1, 2, 3, 4]) : Data([1, 2, 3, 4, 5])
+            protocolInstance.client?.urlProtocol(protocolInstance, didLoad: data)
+            protocolInstance.client?.urlProtocolDidFinishLoading(protocolInstance)
+        }
+        let client = HermesHTTPClient(origin: "https://images.example", session: session())
+
+        let exactLimitData = try await client.downloadManagedImage(
+            path: "/tmp/image.png",
+            maximumResponseBytes: 4
+        )
+        XCTAssertEqual(exactLimitData, Data([1, 2, 3, 4]))
+        do {
+            _ = try await client.downloadManagedImage(path: "/tmp/image.png", maximumResponseBytes: 4)
+            XCTFail("Dishonest Content-Length bypassed actual-byte cap")
+        } catch is ResponseTooLargeError {}
+    }
+
+    func testDeclaredOversizeStopsBeforeBodyIsConsumed() async throws {
+        let stopped = expectation(description: "underlying transfer stopped")
+        ManagedImageNetworkURLProtocol.onStop = { stopped.fulfill() }
+        let started = expectation(description: "request started")
+        ManagedImageNetworkURLProtocol.handler = { _ in started.fulfill() }
+        let downloader = ManagedImageDownload(maximumBytes: 4)
+        let request = URLRequest(url: URL(string: "https://images.example/image.png")!)
+        let configuration = session().configuration
+        let work = Task { try await downloader.download(request: request, configuration: configuration) }
+        await fulfillment(of: [started], timeout: 1)
+        let callbackSession = URLSession(configuration: .ephemeral)
+        defer { callbackSession.invalidateAndCancel() }
+        let callbackTask = callbackSession.dataTask(with: request)
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: nil,
+            headerFields: ["Content-Type": "image/png", "Content-Length": "5"]
+        )!
+        downloader.urlSession(callbackSession, dataTask: callbackTask, didReceive: response) {
+            XCTAssertEqual($0, .cancel)
+        }
+        do {
+            _ = try await work.value
+            XCTFail("Oversized declaration was accepted")
+        } catch is ResponseTooLargeError {}
+        await fulfillment(of: [stopped], timeout: 2)
+    }
+
+    func test401RefreshRetryKeepsCapAndOriginCredentials() async throws {
+        let cookieStorage = HTTPCookieStorage.shared
+        let cookie = HTTPCookie(properties: [
+            .domain: "images.example", .path: "/", .name: "session", .value: "synthetic-cookie",
+            .secure: "TRUE", .expires: Date(timeIntervalSinceNow: 60),
+        ])!
+        cookieStorage.setCookie(cookie)
+        defer { cookieStorage.deleteCookie(cookie) }
+
+        ManagedImageNetworkURLProtocol.handler = { protocolInstance in
+            let attempt = ManagedImageNetworkURLProtocol.requests.count
+            if attempt == 1 {
+                protocolInstance.respond(status: 401, headers: ["Content-Type": "application/json"])
+                protocolInstance.client?.urlProtocolDidFinishLoading(protocolInstance)
+                return
+            }
+            protocolInstance.respond()
+            protocolInstance.client?.urlProtocol(protocolInstance, didLoad: Data([1, 2, 3]))
+            protocolInstance.client?.urlProtocol(protocolInstance, didLoad: Data([4, 5]))
+            protocolInstance.client?.urlProtocolDidFinishLoading(protocolInstance)
+        }
+        let client = HermesHTTPClient(origin: "https://images.example", session: session())
+        client.bearerToken = "expired"
+        client.refreshTokenProvider = {
+            NativeTokenSet(
+                accessToken: "refreshed", refreshToken: "refresh-2", expiresAt: 9_000_000_000,
+                provider: "nous", userID: "user"
+            )
+        }
+
+        do {
+            _ = try await client.downloadManagedImage(path: "/tmp/image.png", maximumResponseBytes: 4)
+            XCTFail("Retry bypassed the stream cap")
+        } catch is ResponseTooLargeError {}
+
+        XCTAssertEqual(ManagedImageNetworkURLProtocol.requests.count, 2)
+        XCTAssertEqual(ManagedImageNetworkURLProtocol.requests[0].value(forHTTPHeaderField: "Authorization"), "Bearer expired")
+        XCTAssertEqual(ManagedImageNetworkURLProtocol.requests[1].value(forHTTPHeaderField: "Authorization"), "Bearer refreshed")
+        XCTAssertEqual(ManagedImageNetworkURLProtocol.requests[0].value(forHTTPHeaderField: "Cookie"), "session=synthetic-cookie")
+        XCTAssertEqual(ManagedImageNetworkURLProtocol.requests[1].value(forHTTPHeaderField: "Cookie"), "session=synthetic-cookie")
+    }
+
+    func testCallerCancellationStopsInFlightTransfer() async throws {
+        let stopped = expectation(description: "underlying transfer stopped")
+        ManagedImageNetworkURLProtocol.onStop = { stopped.fulfill() }
+        let started = expectation(description: "stream started")
+        ManagedImageNetworkURLProtocol.handler = { protocolInstance in
+            protocolInstance.respond()
+            protocolInstance.client?.urlProtocol(protocolInstance, didLoad: Data([1, 2]))
+            started.fulfill()
+        }
+        let client = HermesHTTPClient(origin: "https://images.example", session: session())
+        let work = Task {
+            try await client.downloadManagedImage(path: "/tmp/image.png", maximumResponseBytes: 4)
+        }
+        await fulfillment(of: [started], timeout: 2)
+
+        work.cancel()
+        do {
+            _ = try await work.value
+            XCTFail("Cancelled transfer returned data")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        await fulfillment(of: [stopped], timeout: 2)
+    }
+
+    func testRedirectIsRefusedWithoutForwardingCredentials() {
+        let downloader = ManagedImageDownload(maximumBytes: 4)
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.invalidateAndCancel() }
+        var original = URLRequest(url: URL(string: "https://images.example/image.png")!)
+        original.setValue("Bearer synthetic", forHTTPHeaderField: "Authorization")
+        let redirected = URLRequest(url: URL(string: "https://other.example/image.png")!)
+        let response = HTTPURLResponse(
+            url: original.url!, statusCode: 302, httpVersion: nil,
+            headerFields: ["Location": redirected.url!.absoluteString]
+        )!
+
+        downloader.urlSession(
+            session,
+            task: session.dataTask(with: original),
+            willPerformHTTPRedirection: response,
+            newRequest: redirected
+        ) {
+            XCTAssertNil($0)
+        }
+    }
+}

--- a/ios/MercuryTests/MediaDirectiveExtractorTests.swift
+++ b/ios/MercuryTests/MediaDirectiveExtractorTests.swift
@@ -209,4 +209,33 @@ final class MediaDirectiveExtractorTests: XCTestCase {
         XCTAssertEqual(artifacts.first?.displayName, "AA.png")
         XCTAssertEqual(artifacts.first?.type, .image)
     }
+
+    func testMultilineInlineCodeAndEscapedOpeningBracketNeverSelectImages() {
+        let text = """
+        Before ``code
+        ![hidden](/tmp/hidden.png)
+        ends`` after
+        !\\[example](/tmp/synthetic.png)
+        ![visible](/tmp/visible.png)
+        """
+
+        XCTAssertEqual(
+            MediaDirectiveExtractor.managedImageArtifacts(text).map(\.source),
+            ["/tmp/visible.png"]
+        )
+    }
+
+    func testOrderedManagedImageSegmentsKeepImagesBetweenProse() {
+        let segments = MediaDirectiveExtractor.orderedManagedImageSegments(
+            "Before ![one](/tmp/one.png) between\nMEDIA:/tmp/two.png\nafter"
+        )
+
+        XCTAssertEqual(segments, [
+            .text("Before "),
+            .image(source: "/tmp/one.png", stableIdentity: "managed:/tmp/one.png"),
+            .text(" between\n"),
+            .image(source: "/tmp/two.png", stableIdentity: "managed:/tmp/two.png"),
+            .text("\nafter"),
+        ])
+    }
 }

--- a/ios/MercuryTests/MessageMarkdownTests.swift
+++ b/ios/MercuryTests/MessageMarkdownTests.swift
@@ -68,4 +68,22 @@ final class MessageMarkdownTests: XCTestCase {
             .code(language: "python", code: "def greet(name):\n    return name"),
         ])
     }
+
+    func testTildeFenceRequiresMatchingLengthAndAcceptsLongerCloser() {
+        let blocks = parseMessageMarkdown("""
+        Before
+        ~~~~swift
+        let value = 1
+        ~~~
+        still code
+        ~~~~~
+        After
+        """)
+
+        XCTAssertEqual(blocks, [
+            .paragraph("Before"),
+            .code(language: "swift", code: "let value = 1\n~~~\nstill code"),
+            .paragraph("After"),
+        ])
+    }
 }

--- a/ios/MercuryUITests/ManagedImageRenderingUITests.swift
+++ b/ios/MercuryUITests/ManagedImageRenderingUITests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+final class ManagedImageRenderingUITests: XCTestCase {
+    func testMediaAndLocalMarkdownRenderThroughProductionImageView() {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitest-managed-images"]
+        app.launch()
+
+        let rendered = app.images.matching(
+            NSPredicate(format: "label == %@", "Generated image; tap to enlarge")
+        )
+        let countReached = NSPredicate { _, _ in rendered.count == 2 }
+        expectation(for: countReached, evaluatedWith: nil)
+        waitForExpectations(timeout: 20)
+        XCTAssertEqual(rendered.count, 2, "Bare paths and remote Markdown images must not auto-fetch")
+        XCTAssertFalse(app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH %@", "Image unavailable:")).firstMatch.exists)
+
+        rendered.element(boundBy: 1).tap()
+        XCTAssertTrue(app.buttons["Close enlarged image"].waitForExistence(timeout: 10))
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "Local Markdown image fullscreen"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+        app.buttons["Close enlarged image"].tap()
+
+        XCTAssertEqual(rendered.count, 2)
+        let inline = XCTAttachment(screenshot: app.screenshot())
+        inline.name = "MEDIA and local Markdown inline images"
+        inline.lifetime = .keepAlways
+        add(inline)
+    }
+}

--- a/ios/MercuryUITests/ManagedImageRenderingUITests.swift
+++ b/ios/MercuryUITests/ManagedImageRenderingUITests.swift
@@ -15,6 +15,19 @@ final class ManagedImageRenderingUITests: XCTestCase {
         XCTAssertEqual(rendered.count, 2, "Bare paths and remote Markdown images must not auto-fetch")
         XCTAssertFalse(app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH %@", "Image unavailable:")).firstMatch.exists)
 
+        let before = app.staticTexts["PROSE BEFORE"]
+        let between = app.staticTexts["PROSE BETWEEN"]
+        let after = app.staticTexts.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "PROSE AFTER")
+        ).firstMatch
+        XCTAssertTrue(before.waitForExistence(timeout: 5))
+        XCTAssertTrue(between.exists)
+        XCTAssertTrue(after.exists)
+        XCTAssertLessThan(before.frame.minY, rendered.element(boundBy: 0).frame.minY)
+        XCTAssertLessThan(rendered.element(boundBy: 0).frame.minY, between.frame.minY)
+        XCTAssertLessThan(between.frame.minY, rendered.element(boundBy: 1).frame.minY)
+        XCTAssertLessThan(rendered.element(boundBy: 1).frame.minY, after.frame.minY)
+
         rendered.element(boundBy: 1).tap()
         XCTAssertTrue(app.buttons["Close enlarged image"].waitForExistence(timeout: 10))
         let screenshot = XCTAttachment(screenshot: app.screenshot())

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactExtractor.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactExtractor.kt
@@ -18,9 +18,6 @@ object ArtifactExtractor {
     private const val MEDIA_PREFIX = "MEDIA:"
     private const val MANAGED_ID_PREFIX = "managed:"
     private const val REMOTE_ID_PREFIX = "remote:"
-    private val markdownLinkPattern = Regex(
-        """(!?)\[([^]\r\n]{1,512})\]\(\s*(<[^>\r\n]{1,4096}>|[^()\s\r\n]+)\s*\)""",
-    )
     private val typePrefixPattern = Regex("(?i)^(image|audio|file|video)\\s*:\\s*")
     private val imageExtensions = setOf("bmp", "gif", "heic", "jpeg", "jpg", "png", "tif", "tiff", "webp")
     private val audioExtensions = setOf("aac", "flac", "m4a", "mp3", "oga", "ogg", "opus", "wav")
@@ -49,6 +46,162 @@ object ArtifactExtractor {
         limits: ArtifactExtractionLimits = ArtifactExtractionLimits(),
     ): List<Artifact> = extract(listOf(text), limits)
 
+    /**
+     * Returns only explicit `![label](/absolute/image.png)` occurrences that are
+     * safe managed-image paths. Remote destinations and references inside inline
+     * or fenced code are deliberately excluded so a renderer cannot turn prose,
+     * links, or code into a fetch.
+     */
+    fun explicitLocalMarkdownImages(
+        text: String,
+        limits: ArtifactExtractionLimits = ArtifactExtractionLimits(),
+    ): List<ExplicitLocalMarkdownImage> {
+        val bounded = text.take(limits.maxTranscriptChars)
+        return explicitLocalMarkdownImages(bounded, limits, ManagedImageFormatPolicy.Android)
+    }
+
+    /** Selects only explicit, code-safe managed images for a native decoder. */
+    fun managedImageArtifacts(
+        text: String,
+        formatPolicy: ManagedImageFormatPolicy,
+        limits: ArtifactExtractionLimits = ArtifactExtractionLimits(),
+    ): List<Artifact> {
+        val bounded = text.take(limits.maxTranscriptChars)
+        val exclusions = markdownCodeExclusions(bounded)
+        val selectedIdentities = LinkedHashSet<String>()
+
+        explicitLocalMarkdownImages(bounded, limits, formatPolicy)
+            .filter { it.shouldRender }
+            .forEach { selectedIdentities += it.stableIdentity }
+
+        var lineStart = 0
+        while (lineStart <= bounded.length) {
+            val newline = bounded.indexOf('\n', lineStart)
+            val lineEnd = if (newline < 0) bounded.length else newline
+            if (lineStart >= bounded.length || !exclusions.fenced.getOrElse(lineStart) { false }) {
+                val source = standaloneMediaSource(bounded.substring(lineStart, lineEnd).removeSuffix("\r"))
+                if (source != null && ManagedImagePolicy.isManagedImagePath(source, formatPolicy)) {
+                    resolveSource(source)?.let { selectedIdentities += it.identity }
+                }
+            }
+            if (newline < 0) break
+            lineStart = newline + 1
+        }
+
+        return extract(bounded, limits).filter {
+            it.origin == ArtifactOrigin.ManagedPath && it.type == ArtifactType.Image &&
+                it.stableIdentity in selectedIdentities
+        }
+    }
+
+    private fun explicitLocalMarkdownImages(
+        bounded: String,
+        limits: ArtifactExtractionLimits,
+        formatPolicy: ManagedImageFormatPolicy,
+    ): List<ExplicitLocalMarkdownImage> {
+        val excluded = markdownCodeExclusions(bounded).all
+        val identities = HashSet<String>(limits.maxItems)
+        val references = ArrayList<ExplicitLocalMarkdownImage>(limits.maxItems)
+
+        for (match in scanMarkdownLinks(bounded)) {
+            if (references.size >= limits.maxItems) break
+            if (!match.isImage || excluded.getOrElse(match.startOffset) { true }) continue
+            if ((match.startOffset until match.endOffsetExclusive).any { excluded[it] }) continue
+            val destination = match.destination
+            if (!ManagedImagePolicy.isManagedImagePath(destination, formatPolicy)) continue
+            val resolved = resolveSource(destination) ?: continue
+            if (resolved.origin != ArtifactOrigin.ManagedPath) continue
+            references += ExplicitLocalMarkdownImage(
+                source = resolved.location,
+                stableIdentity = resolved.identity,
+                startOffset = match.startOffset,
+                endOffsetExclusive = match.endOffsetExclusive,
+                shouldRender = identities.add(resolved.identity),
+            )
+        }
+        return references
+    }
+
+    private data class CodeExclusions(val all: BooleanArray, val fenced: BooleanArray)
+    private data class Fence(val marker: Char, val length: Int)
+
+    private fun markdownCodeExclusions(text: String): CodeExclusions {
+        val excluded = BooleanArray(text.length)
+        val fenced = BooleanArray(text.length)
+        var openFence: Fence? = null
+        var lineStart = 0
+        while (lineStart < text.length) {
+            val newline = text.indexOf('\n', lineStart)
+            val lineEnd = if (newline < 0) text.length else newline
+            val line = text.substring(lineStart, lineEnd).removeSuffix("\r")
+            val fence = fenceAtLineStart(line)
+            val isClosing = openFence?.let { current ->
+                fence?.marker == current.marker && fence.length >= current.length &&
+                    line.dropWhile { it == ' ' }.drop(fence.length).all { it == ' ' || it == '\t' }
+            } == true
+            val isOpening = openFence == null && fence != null
+            if (openFence != null || isOpening) {
+                for (index in lineStart until lineEnd) {
+                    excluded[index] = true
+                    fenced[index] = true
+                }
+            } else {
+                var cursor = lineStart
+                while (cursor < lineEnd) {
+                    if (text[cursor] != '`' || isEscaped(text, cursor)) {
+                        cursor += 1
+                        continue
+                    }
+                    val runLength = markerRunLength(text, cursor, '`', lineEnd)
+                    var close = cursor + runLength
+                    while (close < lineEnd) {
+                        close = text.indexOf('`', close).takeIf { it in 0 until lineEnd } ?: break
+                        val closeLength = markerRunLength(text, close, '`', lineEnd)
+                        if (!isEscaped(text, close) && closeLength == runLength) break
+                        close += closeLength
+                    }
+                    if (close < lineEnd) {
+                        val end = close + runLength
+                        for (index in cursor until end) excluded[index] = true
+                        cursor = end
+                    } else {
+                        cursor += runLength
+                    }
+                }
+            }
+            if (isClosing) openFence = null else if (isOpening) openFence = fence
+            if (newline < 0) break
+            lineStart = newline + 1
+        }
+        return CodeExclusions(excluded, fenced)
+    }
+
+    private fun fenceAtLineStart(line: String): Fence? {
+        val indent = line.takeWhile { it == ' ' }.length
+        if (indent > 3 || indent >= line.length) return null
+        val marker = line[indent].takeIf { it == '`' || it == '~' } ?: return null
+        val length = markerRunLength(line, indent, marker, line.length)
+        if (length < 3) return null
+        if (marker == '`' && line.drop(indent + length).contains('`')) return null
+        return Fence(marker, length)
+    }
+
+    private fun markerRunLength(text: String, start: Int, marker: Char, end: Int): Int {
+        var cursor = start
+        while (cursor < end && text[cursor] == marker) cursor += 1
+        return cursor - start
+    }
+
+    private fun isEscaped(text: String, index: Int): Boolean {
+        var backslashes = 0
+        var cursor = index - 1
+        while (cursor >= 0 && text[cursor] == '\\') {
+            backslashes += 1
+            cursor -= 1
+        }
+        return backslashes % 2 == 1
+    }
+
     private fun extractFromText(
         text: String,
         limits: ArtifactExtractionLimits,
@@ -72,21 +225,12 @@ object ArtifactExtractor {
             lineOffset += rawLine.length + 1
         }
 
-        markdownLinkPattern.findAll(text).forEach { match ->
-            val isImageLink = match.groupValues[1] == "!"
-            val label = match.groupValues[2]
-            val destination = match.groupValues[3].let { token ->
-                if (token.length >= 2 && token.startsWith('<') && token.endsWith('>')) {
-                    token.substring(1, token.length - 1)
-                } else {
-                    token
-                }
-            }
+        scanMarkdownLinks(text).forEach { match ->
             candidates += Candidate(
-                offset = match.range.first,
-                source = destination,
-                labelHint = label,
-                forcedType = if (isImageLink) ArtifactType.Image else null,
+                offset = match.startOffset,
+                source = match.destination,
+                labelHint = match.label,
+                forcedType = if (match.isImage) ArtifactType.Image else null,
             )
         }
 
@@ -113,6 +257,79 @@ object ArtifactExtractor {
         val labelHint: String?,
         val forcedType: ArtifactType?,
     )
+
+    private data class MarkdownLink(
+        val startOffset: Int,
+        val endOffsetExclusive: Int,
+        val isImage: Boolean,
+        val label: String,
+        val destination: String,
+    )
+
+    /** A deliberately bounded, single-line scanner for the supported Markdown link subset. */
+    private fun scanMarkdownLinks(text: String): List<MarkdownLink> {
+        val matches = ArrayList<MarkdownLink>()
+        var cursor = 0
+        while (cursor < text.length) {
+            val isImage = text[cursor] == '!' && cursor + 1 < text.length && text[cursor + 1] == '['
+            val bracket = if (isImage) cursor + 1 else cursor
+            if (text[bracket] != '[' || isEscaped(text, cursor)) {
+                cursor += 1
+                continue
+            }
+            val lineEnd = text.indexOfAny(charArrayOf('\r', '\n'), bracket + 1)
+                .let { if (it < 0) text.length else it }
+            var labelEnd = bracket + 1
+            while (labelEnd < lineEnd && (text[labelEnd] != ']' || isEscaped(text, labelEnd))) labelEnd += 1
+            val labelLength = labelEnd - bracket - 1
+            if (labelEnd >= lineEnd || labelLength > 512 || labelEnd + 1 >= lineEnd || text[labelEnd + 1] != '(') {
+                cursor += 1
+                continue
+            }
+            var destinationStart = labelEnd + 2
+            while (destinationStart < lineEnd && (text[destinationStart] == ' ' || text[destinationStart] == '\t')) {
+                destinationStart += 1
+            }
+            var destinationEnd = destinationStart
+            val destination: String
+            if (destinationStart < lineEnd && text[destinationStart] == '<') {
+                destinationEnd += 1
+                while (destinationEnd < lineEnd && (text[destinationEnd] != '>' || isEscaped(text, destinationEnd))) {
+                    destinationEnd += 1
+                }
+                if (destinationEnd >= lineEnd || destinationEnd - destinationStart - 1 !in 1..4096) {
+                    cursor += 1
+                    continue
+                }
+                destination = text.substring(destinationStart + 1, destinationEnd)
+                destinationEnd += 1
+            } else {
+                while (destinationEnd < lineEnd && text[destinationEnd] !in charArrayOf(' ', '\t', '(', ')')) {
+                    destinationEnd += 1
+                }
+                if (destinationEnd - destinationStart !in 1..4096) {
+                    cursor += 1
+                    continue
+                }
+                destination = text.substring(destinationStart, destinationEnd)
+            }
+            var close = destinationEnd
+            while (close < lineEnd && (text[close] == ' ' || text[close] == '\t')) close += 1
+            if (close >= lineEnd || text[close] != ')') {
+                cursor += 1
+                continue
+            }
+            matches += MarkdownLink(
+                startOffset = cursor,
+                endOffsetExclusive = close + 1,
+                isImage = isImage,
+                label = text.substring(bracket + 1, labelEnd),
+                destination = destination,
+            )
+            cursor = close + 1
+        }
+        return matches
+    }
 
     /** Parses only the standalone directive grammar; callers must validate the returned source before fetching it. */
     fun standaloneMediaSource(line: String): String? {

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactExtractor.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactExtractor.kt
@@ -94,6 +94,108 @@ object ArtifactExtractor {
         }
     }
 
+    /**
+     * Splits completed message text into deterministic prose/image slices.
+     * Every accepted image syntax is removed from prose; the first occurrence
+     * of each canonical identity emits an image slice at its actual position.
+     */
+    fun orderedManagedImageSegments(
+        text: String,
+        formatPolicy: ManagedImageFormatPolicy,
+        limits: ArtifactExtractionLimits = ArtifactExtractionLimits(),
+    ): List<ManagedImageContentSegment> {
+        val bounded = text.take(limits.maxTranscriptChars)
+        if (bounded.isEmpty()) return emptyList()
+        val occurrences = ArrayList<ManagedImageOccurrence>()
+
+        explicitLocalMarkdownImages(bounded, limits, formatPolicy).forEach { reference ->
+            occurrences += ManagedImageOccurrence(
+                start = reference.startOffset,
+                end = reference.endOffsetExclusive,
+                source = reference.source,
+                identity = reference.stableIdentity,
+            )
+        }
+
+        val exclusions = markdownCodeExclusions(bounded)
+        var lineStart = 0
+        while (lineStart <= bounded.length) {
+            val newline = bounded.indexOf('\n', lineStart)
+            val lineEnd = if (newline < 0) bounded.length else newline
+            if (lineStart < bounded.length && !exclusions.fenced[lineStart]) {
+                val source = standaloneMediaSource(bounded.substring(lineStart, lineEnd).removeSuffix("\r"))
+                if (source != null && ManagedImagePolicy.isManagedImagePath(source, formatPolicy)) {
+                    val resolved = resolveSource(source)
+                    if (resolved?.origin == ArtifactOrigin.ManagedPath) {
+                        occurrences += ManagedImageOccurrence(lineStart, lineEnd, resolved.location, resolved.identity)
+                    }
+                }
+            }
+            if (newline < 0) break
+            lineStart = newline + 1
+        }
+
+        if (occurrences.isEmpty()) {
+            return listOf(ManagedImageContentSegment(ManagedImageContentSegmentKind.Text, text = text))
+        }
+        occurrences.sortBy { it.start }
+        val segments = ArrayList<ManagedImageContentSegment>(occurrences.size * 2 + 1)
+        val rendered = HashSet<String>()
+        var collapseDuplicateBoundary = false
+        fun appendText(value: String) {
+            val adjusted = if (
+                collapseDuplicateBoundary &&
+                segments.lastOrNull()?.text?.lastOrNull()?.let { it == ' ' || it == '\t' } == true
+            ) {
+                value.trimStart(' ', '\t')
+            } else {
+                value
+            }
+            collapseDuplicateBoundary = false
+            if (adjusted.isEmpty()) return
+            val previous = segments.lastOrNull()
+            if (previous?.kind == ManagedImageContentSegmentKind.Text) {
+                segments[segments.lastIndex] = previous.copy(text = previous.text.orEmpty() + adjusted)
+            } else {
+                segments += ManagedImageContentSegment(
+                    kind = ManagedImageContentSegmentKind.Text,
+                    text = adjusted,
+                )
+            }
+        }
+        var cursor = 0
+        occurrences.forEach { occurrence ->
+            if (occurrence.start < cursor) return@forEach
+            if (occurrence.start > cursor) {
+                appendText(bounded.substring(cursor, occurrence.start))
+            }
+            if (rendered.size < limits.maxItems && rendered.add(occurrence.identity)) {
+                segments += ManagedImageContentSegment(
+                    kind = ManagedImageContentSegmentKind.Image,
+                    source = occurrence.source,
+                    stableIdentity = occurrence.identity,
+                )
+            } else {
+                collapseDuplicateBoundary = true
+            }
+            cursor = occurrence.end
+        }
+        if (cursor < bounded.length) {
+            appendText(bounded.substring(cursor))
+        }
+        if (bounded.length < text.length) {
+            appendText(text.substring(bounded.length))
+        }
+        return segments
+    }
+
+    private data class ManagedImageOccurrence(
+        val start: Int,
+        val end: Int,
+        val source: String,
+        val identity: String,
+    )
+
     private fun explicitLocalMarkdownImages(
         bounded: String,
         limits: ArtifactExtractionLimits,
@@ -123,67 +225,61 @@ object ArtifactExtractor {
     }
 
     private data class CodeExclusions(val all: BooleanArray, val fenced: BooleanArray)
-    private data class Fence(val marker: Char, val length: Int)
 
     private fun markdownCodeExclusions(text: String): CodeExclusions {
         val excluded = BooleanArray(text.length)
         val fenced = BooleanArray(text.length)
-        var openFence: Fence? = null
+        var openFence: MarkdownFence? = null
         var lineStart = 0
         while (lineStart < text.length) {
             val newline = text.indexOf('\n', lineStart)
             val lineEnd = if (newline < 0) text.length else newline
             val line = text.substring(lineStart, lineEnd).removeSuffix("\r")
-            val fence = fenceAtLineStart(line)
-            val isClosing = openFence?.let { current ->
-                fence?.marker == current.marker && fence.length >= current.length &&
-                    line.dropWhile { it == ' ' }.drop(fence.length).all { it == ' ' || it == '\t' }
-            } == true
+            val fence = markdownFenceAtLineStart(line)
+            val isClosing = openFence?.closes(line, fence) == true
             val isOpening = openFence == null && fence != null
             if (openFence != null || isOpening) {
                 for (index in lineStart until lineEnd) {
                     excluded[index] = true
                     fenced[index] = true
                 }
-            } else {
-                var cursor = lineStart
-                while (cursor < lineEnd) {
-                    if (text[cursor] != '`' || isEscaped(text, cursor)) {
-                        cursor += 1
-                        continue
-                    }
-                    val runLength = markerRunLength(text, cursor, '`', lineEnd)
-                    var close = cursor + runLength
-                    while (close < lineEnd) {
-                        close = text.indexOf('`', close).takeIf { it in 0 until lineEnd } ?: break
-                        val closeLength = markerRunLength(text, close, '`', lineEnd)
-                        if (!isEscaped(text, close) && closeLength == runLength) break
-                        close += closeLength
-                    }
-                    if (close < lineEnd) {
-                        val end = close + runLength
-                        for (index in cursor until end) excluded[index] = true
-                        cursor = end
-                    } else {
-                        cursor += runLength
-                    }
-                }
             }
             if (isClosing) openFence = null else if (isOpening) openFence = fence
             if (newline < 0) break
             lineStart = newline + 1
         }
-        return CodeExclusions(excluded, fenced)
-    }
 
-    private fun fenceAtLineStart(line: String): Fence? {
-        val indent = line.takeWhile { it == ' ' }.length
-        if (indent > 3 || indent >= line.length) return null
-        val marker = line[indent].takeIf { it == '`' || it == '~' } ?: return null
-        val length = markerRunLength(line, indent, marker, line.length)
-        if (length < 3) return null
-        if (marker == '`' && line.drop(indent + length).contains('`')) return null
-        return Fence(marker, length)
+        // Code spans may cross line endings. Mark a span only after finding an
+        // equal-length closing run, so an unmatched opener cannot hide later
+        // prose. A block fence ends the candidate rather than being crossed.
+        var cursor = 0
+        while (cursor < text.length) {
+            if (fenced[cursor] || text[cursor] != '`' || isEscaped(text, cursor)) {
+                cursor += 1
+                continue
+            }
+            val runLength = markerRunLength(text, cursor, '`', text.length)
+            var close = cursor + runLength
+            var matched = -1
+            while (close < text.length) {
+                close = text.indexOf('`', close)
+                if (close < 0 || fenced[close]) break
+                val closeLength = markerRunLength(text, close, '`', text.length)
+                if (!isEscaped(text, close) && closeLength == runLength) {
+                    matched = close
+                    break
+                }
+                close += closeLength
+            }
+            if (matched >= 0) {
+                val end = matched + runLength
+                for (index in cursor until end) excluded[index] = true
+                cursor = end
+            } else {
+                cursor += runLength
+            }
+        }
+        return CodeExclusions(excluded, fenced)
     }
 
     private fun markerRunLength(text: String, start: Int, marker: Char, end: Int): Int {

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactModels.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactModels.kt
@@ -14,6 +14,12 @@ enum class ArtifactOrigin {
     RemoteUrl,
 }
 
+/** Native image decoder formats intentionally supported by each client. */
+enum class ManagedImageFormatPolicy {
+    Android,
+    Ios,
+}
+
 /**
  * Bounded metadata for one transcript-delivered artifact.
  *
@@ -37,6 +43,20 @@ data class Artifact(
     val location: String
         get() = source
 }
+
+/**
+ * One validated explicit Markdown image occurrence backed by a managed host path.
+ * Offsets are UTF-16 indices into the input string. Duplicate occurrences remain
+ * present so renderers can remove their syntax while [shouldRender] preserves the
+ * artifact extractor's first-identity-wins policy.
+ */
+data class ExplicitLocalMarkdownImage(
+    val source: String,
+    val stableIdentity: String,
+    val startOffset: Int,
+    val endOffsetExclusive: Int,
+    val shouldRender: Boolean,
+)
 
 /** Input and output bounds for the pure transcript extractor. */
 data class ArtifactExtractionLimits(

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactModels.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactModels.kt
@@ -58,6 +58,35 @@ data class ExplicitLocalMarkdownImage(
     val shouldRender: Boolean,
 )
 
+/** One ordered slice of completed message content for native rendering. */
+enum class ManagedImageContentSegmentKind {
+    Text,
+    Image,
+}
+
+/**
+ * Swift-friendly DTO returned in document order. Exactly one of [text] or
+ * [source] is populated according to [kind].
+ */
+data class ManagedImageContentSegment(
+    val kind: ManagedImageContentSegmentKind,
+    val text: String? = null,
+    val source: String? = null,
+    val stableIdentity: String? = null,
+)
+
+/** Shared fenced-code segmentation consumed by both native Markdown renderers. */
+enum class MarkdownFenceSegmentKind {
+    Text,
+    Code,
+}
+
+data class MarkdownFenceSegment(
+    val kind: MarkdownFenceSegmentKind,
+    val text: String,
+    val language: String? = null,
+)
+
 /** Input and output bounds for the pure transcript extractor. */
 data class ArtifactExtractionLimits(
     val maxTranscriptChars: Int = 64 * 1024,

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ManagedImagePolicy.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/ManagedImagePolicy.kt
@@ -1,0 +1,20 @@
+package com.unsupportedpastels.mercury.core.artifacts
+
+/** Transport-free managed-image path and native-format rules. */
+object ManagedImagePolicy {
+    internal val androidExtensions = setOf("bmp", "gif", "jpeg", "jpg", "png", "webp")
+    internal val iosExtensions = androidExtensions + setOf("heic", "tif", "tiff")
+
+    fun isCanonicalManagedPath(path: String): Boolean =
+        path.length in 2..4096 && path.startsWith('/') && !path.startsWith("//") &&
+            path.none { it.isISOControl() || it == '\\' } &&
+            path.split('/').drop(1).none { it.isEmpty() || it == "." || it == ".." }
+
+    fun isManagedImagePath(
+        path: String,
+        formatPolicy: ManagedImageFormatPolicy = ManagedImageFormatPolicy.Android,
+    ): Boolean = isCanonicalManagedPath(path) && path.substringAfterLast('.', "").lowercase() in when (formatPolicy) {
+        ManagedImageFormatPolicy.Android -> androidExtensions
+        ManagedImageFormatPolicy.Ios -> iosExtensions
+    }
+}

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/MarkdownPresentationPolicy.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/artifacts/MarkdownPresentationPolicy.kt
@@ -1,0 +1,99 @@
+package com.unsupportedpastels.mercury.core.artifacts
+
+internal data class MarkdownFence(val marker: Char, val length: Int, val info: String) {
+    fun closes(line: String, candidate: MarkdownFence?): Boolean =
+        candidate?.marker == marker && candidate.length >= length &&
+            line.dropWhile { it == ' ' }.drop(candidate.length).all { it == ' ' || it == '\t' }
+}
+
+internal fun markdownFenceAtLineStart(line: String): MarkdownFence? {
+    val indent = line.takeWhile { it == ' ' }.length
+    if (indent > 3 || indent >= line.length) return null
+    val marker = line[indent].takeIf { it == '`' || it == '~' } ?: return null
+    var end = indent
+    while (end < line.length && line[end] == marker) end += 1
+    val length = end - indent
+    if (length < 3) return null
+    val info = line.substring(end).trim()
+    if (marker == '`' && info.contains('`')) return null
+    return MarkdownFence(marker, length, info)
+}
+
+/** Deterministic Markdown block decisions shared by Android and iOS adapters. */
+object MarkdownPresentationPolicy {
+    fun fencedSegments(source: String): List<MarkdownFenceSegment> {
+        if (source.isEmpty()) return emptyList()
+        val text = source.replace("\r\n", "\n").replace('\r', '\n')
+        val segments = ArrayList<MarkdownFenceSegment>()
+        var textStart = 0
+        var lineStart = 0
+
+        while (lineStart < text.length) {
+            val newline = text.indexOf('\n', lineStart)
+            val lineEnd = if (newline < 0) text.length else newline
+            val opening = markdownFenceAtLineStart(text.substring(lineStart, lineEnd))
+            if (opening == null) {
+                if (newline < 0) break
+                lineStart = newline + 1
+                continue
+            }
+
+            if (lineStart > textStart) {
+                segments += MarkdownFenceSegment(
+                    kind = MarkdownFenceSegmentKind.Text,
+                    text = text.substring(textStart, lineStart),
+                )
+            }
+            val codeStart = if (newline < 0) lineEnd else newline + 1
+            var scanStart = codeStart
+            var closingStart = text.length
+            var afterClosing = text.length
+            while (scanStart < text.length) {
+                val closeNewline = text.indexOf('\n', scanStart)
+                val closeEnd = if (closeNewline < 0) text.length else closeNewline
+                val closeLine = text.substring(scanStart, closeEnd)
+                if (opening.closes(closeLine, markdownFenceAtLineStart(closeLine))) {
+                    closingStart = scanStart
+                    afterClosing = if (closeNewline < 0) closeEnd else closeNewline + 1
+                    break
+                }
+                if (closeNewline < 0) break
+                scanStart = closeNewline + 1
+            }
+            segments += MarkdownFenceSegment(
+                kind = MarkdownFenceSegmentKind.Code,
+                text = text.substring(codeStart, closingStart).trimEnd('\n'),
+                language = opening.info.take(32).ifBlank { null },
+            )
+            textStart = afterClosing
+            lineStart = afterClosing
+        }
+
+        if (textStart < text.length) {
+            segments += MarkdownFenceSegment(MarkdownFenceSegmentKind.Text, text.substring(textStart))
+        }
+        return segments
+    }
+
+    fun stablePrefixLength(source: String): Int {
+        var stableEnd = 0
+        var openFence: MarkdownFence? = null
+        var cursor = 0
+        while (cursor < source.length) {
+            val newline = source.indexOf('\n', cursor)
+            val lineEnd = if (newline < 0) source.length else newline
+            val line = source.substring(cursor, lineEnd).removeSuffix("\r")
+            val candidate = markdownFenceAtLineStart(line)
+            if (openFence?.closes(line, candidate) == true) {
+                openFence = null
+            } else if (openFence == null && candidate != null) {
+                openFence = candidate
+            } else if (openFence == null && line.isBlank() && newline >= 0) {
+                stableEnd = newline + 1
+            }
+            if (newline < 0) break
+            cursor = newline + 1
+        }
+        return stableEnd
+    }
+}

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactExtractorTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactExtractorTest.kt
@@ -137,6 +137,75 @@ class ArtifactExtractorTest {
     }
 
     @Test
+    fun explicitLocalMarkdownImagesIgnoreMultilineInlineCodeSpans() {
+        val text = """
+            Before ``code starts
+            ![not visible](/runs/code.png)
+            and ends`` after
+            ![visible](/runs/visible.png)
+        """.trimIndent()
+
+        assertEquals(
+            listOf("/runs/visible.png"),
+            ArtifactExtractor.explicitLocalMarkdownImages(text).map { it.source },
+        )
+    }
+
+    @Test
+    fun escapedOpeningBracketNeverBecomesAnImage() {
+        assertTrue(
+            ArtifactExtractor.explicitLocalMarkdownImages("!\\[example](/tmp/synthetic.png)").isEmpty(),
+        )
+    }
+
+    @Test
+    fun orderedManagedImageSegmentsPreserveDocumentOrderAndRemoveDuplicateSyntax() {
+        val text = "Before ![one](/runs/one.png) middle\nMEDIA:/runs/two.png\nafter ![again](/runs/one.png)."
+
+        val segments = ArtifactExtractor.orderedManagedImageSegments(text, ManagedImageFormatPolicy.Android)
+
+        assertEquals(
+            listOf(
+                ManagedImageContentSegmentKind.Text,
+                ManagedImageContentSegmentKind.Image,
+                ManagedImageContentSegmentKind.Text,
+                ManagedImageContentSegmentKind.Image,
+                ManagedImageContentSegmentKind.Text,
+            ),
+            segments.map { it.kind },
+        )
+        assertEquals(listOf("/runs/one.png", "/runs/two.png"), segments.mapNotNull { it.source })
+        assertEquals("Before  middle\n\nafter .", segments.mapNotNull { it.text }.joinToString(""))
+    }
+
+    @Test
+    fun orderedManagedImageSegmentsPreserveTextBeyondExtractionBudget() {
+        val text = "![one](/a/one.png)" + "x".repeat(40)
+        val segments = ArtifactExtractor.orderedManagedImageSegments(
+            text,
+            ManagedImageFormatPolicy.Android,
+            ArtifactExtractionLimits(maxTranscriptChars = 24),
+        )
+
+        assertEquals("x".repeat(40), segments.mapNotNull { it.text }.joinToString(""))
+        assertEquals(listOf("/a/one.png"), segments.mapNotNull { it.source })
+    }
+
+    @Test
+    fun sharedFenceSegmentsSupportTildesAndVariableLengthClosers() {
+        val segments = MarkdownPresentationPolicy.fencedSegments(
+            "before\n~~~~swift\nlet value = 1\n~~~\nstill code\n~~~~~\nafter",
+        )
+
+        assertEquals(
+            listOf(MarkdownFenceSegmentKind.Text, MarkdownFenceSegmentKind.Code, MarkdownFenceSegmentKind.Text),
+            segments.map { it.kind },
+        )
+        assertEquals("swift", segments[1].language)
+        assertEquals("let value = 1\n~~~\nstill code", segments[1].text)
+    }
+
+    @Test
     fun explicitLocalMarkdownImagesRespectMarkdownCodeEscapesAndLineBounds() {
         val text = """
             ``![double tick](/runs/double.png)``

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactExtractorTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/artifacts/ArtifactExtractorTest.kt
@@ -96,6 +96,94 @@ class ArtifactExtractorTest {
     }
 
     @Test
+    fun explicitLocalMarkdownImagesPreserveRangesRejectUnsafeSourcesAndDedupe() {
+        val text = "Before ![one](/runs/one.png) middle ![two](/runs/two.jpg) " +
+            "again ![duplicate](/runs/one.png) after"
+
+        val references = ArtifactExtractor.explicitLocalMarkdownImages(text)
+
+        assertEquals(listOf("/runs/one.png", "/runs/two.jpg", "/runs/one.png"), references.map { it.source })
+        assertEquals(listOf(true, true, false), references.map { it.shouldRender })
+        assertEquals(
+            listOf("![one](/runs/one.png)", "![two](/runs/two.jpg)", "![duplicate](/runs/one.png)"),
+            references.map { text.substring(it.startOffset, it.endOffsetExclusive) },
+        )
+
+        for (invalid in listOf(
+            "![remote](https://example.com/image.png)",
+            "![traversal](/runs/../secret.png)",
+            "![double slash](/runs//image.png)",
+            "![backslash](/runs\\image.png)",
+            "![control](/runs/ima\u0000ge.png)",
+        )) {
+            assertTrue(ArtifactExtractor.explicitLocalMarkdownImages(invalid).isEmpty(), invalid)
+        }
+    }
+
+    @Test
+    fun explicitLocalMarkdownImagesIgnoreInlineAndFencedCode() {
+        val text = """
+            `![inline](/runs/inline.png)`
+            ```markdown
+            ![fenced](/runs/fenced.png)
+            ```
+            ![visible](/runs/visible.png)
+        """.trimIndent()
+
+        assertEquals(
+            listOf("/runs/visible.png"),
+            ArtifactExtractor.explicitLocalMarkdownImages(text).map { it.source },
+        )
+    }
+
+    @Test
+    fun explicitLocalMarkdownImagesRespectMarkdownCodeEscapesAndLineBounds() {
+        val text = """
+            ``![double tick](/runs/double.png)``
+            ~~~~markdown
+            ![tilde fenced](/runs/tilde.png)
+            ~~~
+            ![still fenced](/runs/still-fenced.png)
+            ~~~~
+            \![escaped](/runs/escaped.png)
+            ![line break](
+            /runs/cross-line.png)
+            ![](/runs/empty-alt.png)
+            ![visible](/runs/visible.png)
+        """.trimIndent()
+
+        assertEquals(
+            listOf("/runs/empty-alt.png", "/runs/visible.png"),
+            ArtifactExtractor.explicitLocalMarkdownImages(text).map { it.source },
+        )
+    }
+
+    @Test
+    fun managedImageSelectionExcludesFencedMediaAndPreservesPlatformFormats() {
+        val text = """
+            ~~~text
+            MEDIA:/runs/fenced.heic
+            ~~~
+            MEDIA:/runs/photo.heic
+            MEDIA:/runs/scan.tif
+            ![](/runs/page.tiff)
+            MEDIA:/runs/portable.png
+            /runs/bare.jpg
+            [ordinary](/runs/link.jpg)
+            ![remote](https://example.com/remote.jpg)
+        """.trimIndent()
+
+        assertEquals(
+            listOf("/runs/portable.png"),
+            ArtifactExtractor.managedImageArtifacts(text, ManagedImageFormatPolicy.Android).map { it.source },
+        )
+        assertEquals(
+            listOf("/runs/photo.heic", "/runs/scan.tif", "/runs/page.tiff", "/runs/portable.png"),
+            ArtifactExtractor.managedImageArtifacts(text, ManagedImageFormatPolicy.Ios).map { it.source },
+        )
+    }
+
+    @Test
     fun angleBracketDestinationsAllowSpaces() {
         val artifacts = extract("[report](</files/quarterly report.pdf>)")
         assertEquals("/files/quarterly report.pdf", artifacts.single().source)
@@ -166,9 +254,9 @@ class ArtifactExtractorTest {
 
     @Test
     fun displayNameSanitizesHostileCharacters() {
-        val artifacts = extract("[file: badname](/a/x)")
+        val artifacts = extract("[file: bad\u0007name](/a/x)")
         assertEquals("x", artifacts.single().displayName)
-        val hinted = extract("[file: weird   name](https://example.com/)")
+        val hinted = extract("[file: we\u0007ird   name](https://example.com/)")
         assertEquals("we_ird name", hinted.single().displayName)
     }
 


### PR DESCRIPTION
## Summary
- Render explicit local Markdown images through the existing authenticated managed-image loaders, while preserving standalone MEDIA delivery.
- Share bounded image selection and path policy across Android and iOS; exclude escaped syntax and supported inline/fenced code forms, preserve surrounding prose, and handle empty alt text.
- Keep portable Android formats and existing iOS HEIC/TIFF support. Do not turn bare paths, ordinary links, or remote Markdown images into new automatic fetches.
- Fix the iOS direct-image loader inheriting the 64 KiB JSON cap: images use a dedicated 10 MiB bound while other requests retain their existing bounds.
- Document delivery syntax, transport limits, and optional host guidance.

Companion host-plugin PR: https://github.com/unsupportedpastels/mercury-relay-plugin/pull/11

## Verification
- Android unit tests: 1,059 passed; lintDebug and assembleDebug passed.
- Shared core: 290 tests passed; check passed.
- Android emulator image-rendering instrumentation: passed before the final scanner refinements; parser and unit gates rerun afterward.
- Final Mac Mercury build/test: 679 tests passed.
- Final iOS managed-image loader suite: 5 tests passed; focused simulator image-rendering UI test: 1 passed.
- Shared/iOS source hashes matched between authoring and Mac build trees.
- Synthetic Android and iOS screenshots visually reviewed, including fullscreen viewing on iOS.

## Evidence boundaries
Direct and Relay routing were exercised through production loaders with controlled transport responses; no new live-server or paired-Relay end-to-end run is claimed. No physical-device deployment, host restart, or release is included. Tests preserve the existing authenticated routes and Relay capability checks. No private screenshots or deployment identifiers are committed.