### PR TITLE
fix: Android composer sentence capitalization

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetailScreen.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/SessionDetailScreen.kt
@@ -21,7 +21,9 @@ import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -878,6 +880,9 @@ internal fun SessionDetailScreen(
                             if (textChanged) onDraftChanged(newValue.text)
                         },
                         enabled = composerEnabled,
+                        keyboardOptions = KeyboardOptions(
+                            capitalization = KeyboardCapitalization.Sentences,
+                        ),
                         modifier = Modifier
                             .weight(1f)
                             .heightIn(min = 44.dp, max = 132.dp),


### PR DESCRIPTION
## Summary

The Android message composer did not request sentence capitalization from
the active keyboard, causing Mercury to behave differently from typical
messaging applications.

Configure the Compose text field with
`KeyboardCapitalization.Sentences` so Android keyboards are asked to
capitalize the beginning of sentences. Users can still select lowercase
manually.

## Hermes compatibility

This is a client-side Android input configuration change. It does not alter
or depend on any Hermes API, server route, plugin, worker, or fork.

## Cross-platform

The problem is specific to the Android IME configuration. iOS already uses
native text-entry capitalization behavior, so no iOS implementation change
is required.

## Verification

- [x] `./gradlew testDebugUnitTest lintDebug assembleDebug`
- [ ] `./gradlew :shared:mercury-core:check` (not applicable; shared core unchanged)
- [ ] iOS build/test (not applicable; iOS and shared core unchanged)
- [ ] Screenshot test (not applicable; keyboard state is not covered by screenshot references)
- [x] Manually verified sentence capitalization on an Android device/emulator.
- [x] No credentials, server addresses, private content, signing material, or generated output added.

## Screenshots

Not included because this changes the keyboard capitalization hint rather
than Mercury's rendered UI.