### PR TITLE
fix: preserve reopened replies and render completion updates correctly

### DIFF
--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/cache/OfflineCacheRepository.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/cache/OfflineCacheRepository.kt
@@ -296,6 +296,7 @@ class EncryptedOfflineCacheRepository(
         role = message.role.name,
         text = boundText(message.text, OfflineCachePolicy.MAX_BODY_BYTES),
         reasoningText = boundText(message.reasoningText, OfflineCachePolicy.MAX_BODY_BYTES),
+        displayKind = message.displayKind?.let { boundText(it, 256) },
     )
 
     private fun boundMessages(messages: List<ChatMessage>): List<StoredMessage> {
@@ -307,7 +308,8 @@ class EncryptedOfflineCacheRepository(
             .forEach { message ->
                 val stored = boundMessage(message)
                 val bytes = stored.text.toByteArray(StandardCharsets.UTF_8).size +
-                    stored.reasoningText.toByteArray(StandardCharsets.UTF_8).size
+                    stored.reasoningText.toByteArray(StandardCharsets.UTF_8).size +
+                    stored.displayKind.orEmpty().toByteArray(StandardCharsets.UTF_8).size
                 if (selected.isEmpty() || retainedBytes + bytes <= transcriptBudget) {
                     selected.addFirst(stored)
                     retainedBytes += bytes
@@ -439,12 +441,14 @@ private data class StoredMessage(
     val role: String,
     val text: String,
     val reasoningText: String = "",
+    val displayKind: String? = null,
 ) {
     fun toMessage(): ChatMessage? = runCatching {
         ChatMessage(
             role = ChatMessageRole.valueOf(role),
             text = text,
             reasoningText = reasoningText,
+            displayKind = displayKind,
         )
     }.getOrNull()
 }

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/ConnectionReducers.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/ConnectionReducers.kt
@@ -85,6 +85,7 @@ internal fun chatMessageFromJson(row: JsonObject): ChatMessage? {
         role = role,
         text = text.orEmpty(),
         reasoningText = reasoning.orEmpty(),
+        displayKind = (row["display_kind"] as? JsonPrimitive)?.contentOrNull,
     )
 }
 
@@ -140,7 +141,8 @@ internal fun parseRelayTranscriptRows(result: JsonObject): List<ChatMessage> =
             ) {
                 return@mapNotNull null
             }
-            ChatMessage(role = role, text = text.orEmpty(), reasoningText = reasoning.orEmpty())
+            ChatMessage(role = role, text = text.orEmpty(), reasoningText = reasoning.orEmpty(),
+                displayKind = (row["display_kind"] as? JsonPrimitive)?.contentOrNull)
         }
 
 private fun JsonObject.assistantReasoningText(): String? =

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClient.kt
@@ -1639,6 +1639,7 @@ class HttpHermesConnectionClient(
                 role = role,
                 text = text.orEmpty(),
                 reasoningText = reasoning.orEmpty(),
+                displayKind = (row["display_kind"] as? JsonPrimitive)?.contentOrNull,
             )
         }
         return TranscriptEnvelope(messages, progress)

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionViewModel.kt
@@ -5831,7 +5831,7 @@ class HermesConnectionViewModel(
                     originGeneration,
                     operationGeneration,
                 )
-                applyResume(durableSessionId, resumed)
+                val sourceAuthority = applyResume(durableSessionId, resumed)
                 if (resumed.running || relayTarget != null) {
                     sessionControllerRegistry.activateController(
                         PerSessionController(
@@ -5857,13 +5857,20 @@ class HermesConnectionViewModel(
                     // Resume projections can omit persisted tool results. Reconcile via the read-only window.
                     refreshSessionProgress(durableSessionId)
                 } else {
+                    // Always recover bounded durable progress/tool metadata. A nonempty
+                    // official resume owns display rows; this raw projection is not a
+                    // replacement snapshot (and this reader does not publish cache).
                     val messages = loadTranscriptWithProgress(origin, originGeneration, token, durableSessionId, profile)
                     if (!isCurrentChatOperation(durableSessionId, origin, originGeneration, operationGeneration)) {
                         closeChatSessionNonCancellably(candidate)
                         return
                     }
                     updateChat(durableSessionId) {
-                        it.copy(messages = messages, isSending = false, error = null)
+                        it.copy(
+                            messages = if (sourceAuthority.publishesTranscript) messages else it.messages,
+                            isSending = false,
+                            error = null,
+                        )
                     }
                     closeChatSessionNonCancellably(candidate)
                 }
@@ -5974,7 +5981,10 @@ class HermesConnectionViewModel(
         }
     }
 
-    private fun applyResume(durableSessionId: DurableSessionId, resumed: ResumedChatSession) {
+    private fun applyResume(
+        durableSessionId: DurableSessionId,
+        resumed: ResumedChatSession,
+    ): com.unsupportedpastels.mercury.core.transcript.TranscriptReadAuthority {
         automaticChatReconnects.remove(durableSessionId)
         val resumedMessages = resumed.messages.mapNotNull(::chatMessageFromJson)
         updateChat(durableSessionId) { current ->
@@ -6035,6 +6045,7 @@ class HermesConnectionViewModel(
         // Replay intentionally omits foreground events; authoritative running=false
         // must provide the missing terminal fence without another explicit Send.
         if (activeRelayTarget != null && !resumed.running) clearSendingState(durableSessionId)
+        return com.unsupportedpastels.mercury.core.transcript.TranscriptReadPolicy.afterResume(resumedMessages.isNotEmpty())
     }
 
     private fun updateSessionTitle(

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/TranscriptEngineAdapter.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/connection/TranscriptEngineAdapter.kt
@@ -58,6 +58,7 @@ private fun seedTranscript(messages: List<ChatMessage>, previous: TranscriptPres
             text = message.text,
             completed = !message.isStreaming,
             reasoningText = message.reasoningText,
+            displayKind = message.displayKind,
         )
     }
     return TranscriptSnapshot(rows = rows, nextRowId = nextId)
@@ -73,6 +74,7 @@ private fun TranscriptRow.toMessage() = ChatMessage(
     text = text,
     isStreaming = !completed,
     reasoningText = reasoningText,
+    displayKind = displayKind,
 )
 
 private fun ChatMessageRole.toWireRole(): String = when (this) {

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesGateway.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/gateway/HermesGateway.kt
@@ -69,6 +69,7 @@ data class ChatMessage(
     val text: String,
     val isStreaming: Boolean = false,
     val reasoningText: String = "",
+    val displayKind: String? = null,
 )
 
 data class ChatBillingNotice(

--- a/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/TranscriptRendering.kt
+++ b/app/src/main/java/com/unsupportedpastels/hermesandroid/ui/TranscriptRendering.kt
@@ -64,7 +64,8 @@ internal sealed interface FoldedEntry {
 internal fun foldTranscriptTurns(messages: List<ChatMessage>, turnActive: Boolean): List<FoldedEntry> {
     val rows = messages.mapIndexed { index, message ->
         TranscriptRow(index.toLong(), message.role.name.lowercase(), message.text,
-            completed = !message.isStreaming, reasoningText = message.reasoningText)
+            completed = !message.isStreaming, reasoningText = message.reasoningText,
+            displayKind = message.displayKind)
     }
     val folded = com.unsupportedpastels.mercury.core.transcript.foldTranscriptTurns(rows, turnActive)
     return folded.mapIndexed { position, entry ->
@@ -159,8 +160,16 @@ internal fun TurnActivityGroup(
                                         innerExpanded, { innerExpanded = !innerExpanded })
                                 }
                                 if (group.message.text.isNotBlank()) {
-                                    MarkdownMessage(group.message.text, loadManagedImage = loadManagedImage,
-                                        loadManagedVideo = loadManagedVideo, peekManagedVideo = peekManagedVideo)
+                                    if (com.unsupportedpastels.mercury.core.transcript.InternalCompletionNotice.isNotice(
+                                            group.message.role.name.lowercase(), group.message.text, group.message.displayKind)) {
+                                        androidx.compose.foundation.text.selection.SelectionContainer {
+                                            Text(group.message.text, style = MaterialTheme.typography.bodySmall,
+                                                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace)
+                                        }
+                                    } else {
+                                        MarkdownMessage(group.message.text, loadManagedImage = loadManagedImage,
+                                            loadManagedVideo = loadManagedVideo, peekManagedVideo = peekManagedVideo)
+                                    }
                                 }
                             }
                             is TranscriptEntry.ToolRun -> TranscriptToolRunGroup(

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/cache/OfflineCacheRepositoryTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/cache/OfflineCacheRepositoryTest.kt
@@ -88,6 +88,18 @@ class OfflineCacheRepositoryTest {
     }
 
     @Test
+    fun completionPresentationMetadataSurvivesEncryptedCacheRoundTrip() = runTest {
+        val scope = CacheScope(ServerOrigin.parse("https://one.example"), "default")
+        val message = ChatMessage(ChatMessageRole.User, "New envelope", displayKind = "async_delegation_complete")
+        repository.setTranscriptCachingEnabled(true)
+        repository.writeTranscript(scope, summary("notice"), listOf(message), nowEpochSeconds = 10)
+        val restored = repository.read(scope, 11).sessions.single().messages.single()
+        assertEquals(message, restored)
+        assertTrue(com.unsupportedpastels.mercury.core.transcript.InternalCompletionNotice.isNotice(
+            restored.role.name.lowercase(), restored.text, restored.displayKind))
+    }
+
+    @Test
     fun disablingTranscriptCachingClearsBodiesButKeepsMetadata() = runTest {
         val scope = CacheScope(ServerOrigin.parse("https://one.example"), "default")
         repository.setTranscriptCachingEnabled(true)

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesChatIntegrationTest.kt
@@ -1346,6 +1346,48 @@ class HermesChatIntegrationTest {
     }
 
     @Test
+    fun idleRecoveryKeepsNonemptyResumeSegmentsOverStaleDurableRead() = runTest(dispatcher) {
+        assertIdleRecoveryTranscript(hasResumeRows = true)
+    }
+
+    @Test
+    fun idleRecoveryFallsBackToDurableHistoryWhenResumeIsEmpty() = runTest(dispatcher) {
+        assertIdleRecoveryTranscript(hasResumeRows = false)
+    }
+
+    private suspend fun kotlinx.coroutines.test.TestScope.assertIdleRecoveryTranscript(hasResumeRows: Boolean) {
+        val first = ReconnectingChatSession(
+            runtimeId = "runtime-first", running = false, inflightText = null,
+            submitFailure = HermesChatTransportException("socket closed before acknowledgement"),
+            onSubmit = { channel, _ -> channel.close() },
+        )
+        val segments = listOf("Synthetic first answer alpha.", "Synthetic first answer omega.")
+        val second = ReconnectingChatSession(
+            runtimeId = "runtime-recovered", running = false, inflightText = null,
+            resumeMessages = if (hasResumeRows) segments.map { text ->
+                buildJsonObject { put("role", "assistant"); put("content", text) }
+            } else emptyList(),
+        )
+        val sessions = ArrayDeque<HermesChatSession>().apply { add(first); add(second) }
+        val client = ChatConnectionClient()
+        val viewModel = HermesConnectionViewModel(
+            settingsStates = MutableStateFlow(ServerSettingsState.Ready(origin)),
+            client = client, tokenStore = MemoryTokenStore(tokens),
+            chatConnector = HermesChatConnector { _, _ -> sessions.removeFirst() },
+            nowEpochSeconds = { 1_900_000_000 },
+        )
+        advanceUntilIdle()
+        viewModel.sendMessage(durableId, "Synthetic first prompt")
+        advanceUntilIdle()
+        val chat = viewModel.snapshots.value.chatSessions.getValue(durableId)
+        assertEquals(if (hasResumeRows) segments else listOf("Earlier question", "Earlier answer"),
+            chat.messages.map { it.text })
+        assertTrue("Recovery must still perform the bounded durable read", client.transcriptLoads > 0)
+        assertTrue(second.closed)
+        assertFalse(chat.isSending)
+    }
+
+    @Test
     fun reconnectReplacesLocalPartialWithInflightSnapshot() = runTest(dispatcher) {
         val first = ReconnectingChatSession(
             runtimeId = "runtime-1",

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/connection/HermesConnectionClientTest.kt
@@ -38,6 +38,25 @@ import com.unsupportedpastels.hermesandroid.gateway.CronJobScope
 
 class HermesConnectionClientTest {
     @Test
+    fun officialTranscriptCarriesCompletionPresentationMetadataWithoutChangingContent() = runTest {
+        val engine = MockEngine { request ->
+            assertEquals("/api/sessions/session/messages", request.url.encodedPath)
+            respond(
+                """{"messages":[{"role":"user","content":"New envelope","display_kind":"async_delegation_complete"}]}""",
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val message = HttpHermesConnectionClient(HttpClient(engine)).loadTranscript(
+            ServerOrigin.parse("https://hermes.example"), null, DurableSessionId("session"),
+        ).single()
+        assertEquals(ChatMessageRole.User, message.role)
+        assertEquals("New envelope", message.text)
+        assertEquals("async_delegation_complete", message.displayKind)
+        assertTrue(com.unsupportedpastels.mercury.core.transcript.InternalCompletionNotice.isNotice(
+            message.role.name.lowercase(), message.text, message.displayKind))
+    }
+
+    @Test
     fun renamePinAndDeleteUseProfileScopedOfficialSessionContracts() = runTest {
         val requests = mutableListOf<String>()
         val engine = MockEngine { request ->

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/InternalCompletionNoticePresentationTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/InternalCompletionNoticePresentationTest.kt
@@ -1,0 +1,71 @@
+package com.unsupportedpastels.hermesandroid.ui
+
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import com.unsupportedpastels.hermesandroid.connection.chatMessageFromJson
+import com.unsupportedpastels.hermesandroid.connection.parseRelayTranscriptRows
+import com.unsupportedpastels.hermesandroid.connection.applyTranscriptEvent
+import com.unsupportedpastels.hermesandroid.gateway.*
+import com.unsupportedpastels.hermesandroid.theme.HermesAndroidTheme
+import kotlinx.serialization.json.*
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class InternalCompletionNoticePresentationTest {
+    @get:Rule val compose = createComposeRule()
+    private val notice = "[IMPORTANT: Background process proc_f05837cd4d75 completed normally (exit code 0).\nCommand: python check.py\nOutput:\nverified]"
+
+    @Test fun liveAndRestoredNoticeKeepBothAssistantSummariesOutsideActivity() {
+        for (active in listOf(false, true)) {
+            val messages = listOf(ChatMessage(ChatMessageRole.User, "run checks"),
+                ChatMessage(ChatMessageRole.Assistant, "Started checks."),
+                ChatMessage(ChatMessageRole.User, notice),
+                ChatMessage(ChatMessageRole.Assistant, "Checks passed.", isStreaming = active))
+            val entries = foldTranscriptTurns(messages, active)
+            assertEquals(listOf("run checks", "Started checks.", "Checks passed."),
+                entries.filterIsInstance<FoldedEntry.Single>().map { it.message.text })
+            assertSame(messages[2], entries.filterIsInstance<FoldedEntry.TurnActivity>().single().steps.single().message)
+        }
+    }
+
+    @Test fun officialResumeAndRelayMetadataReachSharedFoldingAndSurviveLiveReduction() {
+        val row = buildJsonObject { put("role", "user"); put("content", "New envelope"); put("display_kind", "async_delegation_complete") }
+        val direct = requireNotNull(chatMessageFromJson(row))
+        val relay = parseRelayTranscriptRows(buildJsonObject { put("messages", JsonArray(listOf(row))) }).single()
+        assertEquals(direct, relay)
+        for (message in listOf(direct, relay)) {
+            val snapshot = ChatSessionSnapshot(messages = listOf(message)).applyTranscriptEvent(
+                HermesChatEvent.MessageDelta(RuntimeSessionId("s"), "Summary"))
+            assertEquals("async_delegation_complete", snapshot.messages.first().displayKind)
+            assertTrue(foldTranscriptTurns(snapshot.messages, true).first() is FoldedEntry.TurnActivity)
+        }
+    }
+
+    @Test fun noticeDisclosureStartsCollapsedExpandsAndRestores() {
+        val entry = foldTranscriptTurns(listOf(ChatMessage(ChatMessageRole.User, notice)), true).single() as FoldedEntry.TurnActivity
+        val restoration = androidx.compose.ui.test.junit4.StateRestorationTester(compose)
+        restoration.setContent {
+            HermesAndroidTheme {
+                var expanded by rememberSaveable { mutableStateOf(false) }
+                TurnActivityGroup(entry, expanded, { expanded = !expanded }, "notice-session")
+            }
+        }
+        compose.onNodeWithContentDescription("Activity, 1 step, collapsed").assertIsDisplayed()
+        compose.onNodeWithText("verified", substring = true).assertDoesNotExist()
+        compose.onNodeWithTag("Turn activity").performClick()
+        compose.onNodeWithContentDescription("Activity, 1 step, expanded").assertIsDisplayed()
+        compose.onNodeWithText("verified", substring = true).assertIsDisplayed()
+        restoration.emulateSavedInstanceStateRestore()
+        compose.onNodeWithContentDescription("Activity, 1 step, expanded").assertIsDisplayed()
+        compose.onNodeWithTag("Turn activity").performClick()
+        compose.onNodeWithText("verified", substring = true).assertDoesNotExist()
+    }
+}

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/SessionActivitySheetTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/SessionActivitySheetTest.kt
@@ -2,6 +2,7 @@ package com.unsupportedpastels.hermesandroid.ui
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -46,6 +47,90 @@ class SessionActivitySheetTest {
         compose.onNodeWithContentDescription("Get progress update (read-only)").assertIsNotEnabled()
         compose.onNodeWithText("Reconnect").performClick()
         assertEquals(1, reconnects)
+    }
+
+    @Test fun expandedReportsAndMilestonesSurviveRefreshFailureAndRetry() {
+        val refreshing = mutableStateOf(false)
+        val error = mutableStateOf<String?>(null)
+        var updates = 0
+        var reconnects = 0
+        compose.setContent { MaterialTheme {
+            SessionActivitySheet(
+                summary = SessionProgressPolicy.summarize(RunEventState(todos = listOf(
+                    RunTodoItem("pending", "Review report", RunTodoStatus.Pending),
+                )), false),
+                connectionLost = true, lastObservedAt = 0, now = 12_000,
+                onDismiss = {}, restored = true,
+                onGetUpdate = { updates++; refreshing.value = true; error.value = null },
+                onRetryConnection = { reconnects++ },
+                refreshing = refreshing.value, refreshError = error.value,
+                evidence = listOf(SessionProgressItem("Build report", "Host reported exit 0")),
+            )
+        } }
+        val sheet = compose.onNodeWithTag("Session activity sheet")
+        fun reveal(text: String) {
+            sheet.performScrollToNode(hasText(text))
+            compose.onNodeWithText(text).assertIsDisplayed()
+        }
+        fun assertRetainedReport() {
+            reveal("Review report")
+            reveal("Tool reports")
+            compose.onNodeWithText("Tool reports").assert(
+                SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Expanded"))
+            reveal("Host reported exit 0")
+            // A successful tool report must not promote a pending milestone to Done.
+            compose.onAllNodesWithText("Done").assertCountEquals(0)
+        }
+        fun refreshButton() = compose.onNodeWithContentDescription("Get progress update (read-only)")
+        fun revealRefresh() {
+            sheet.performScrollToNode(hasContentDescription("Get progress update (read-only)"))
+        }
+
+        reveal("Tool reports")
+        compose.onNodeWithText("Tool reports").assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Collapsed"))
+        compose.onAllNodesWithText("Host reported exit 0").assertCountEquals(0)
+        compose.onNodeWithText("Tool reports").performClick()
+        assertRetainedReport()
+        revealRefresh()
+        refreshButton().performClick()
+        assertEquals(1, updates)
+        assertEquals(0, reconnects)
+        refreshButton().assertIsNotEnabled().assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Refreshing"))
+        refreshButton().performClick()
+        assertEquals(1, updates)
+        assertRetainedReport()
+
+        compose.runOnIdle {
+            refreshing.value = false
+            error.value = "Update unavailable; showing saved progress"
+        }
+        reveal("Couldn’t refresh")
+        revealRefresh()
+        refreshButton().assertIsEnabled()
+        assertRetainedReport()
+        revealRefresh()
+        refreshButton().performClick()
+        assertEquals(2, updates)
+        assertEquals(0, reconnects)
+        refreshButton().assertIsNotEnabled()
+        compose.onAllNodesWithText("Couldn’t refresh").assertCountEquals(0)
+        assertRetainedReport()
+
+        compose.runOnIdle { refreshing.value = false }
+        revealRefresh()
+        refreshButton().assertIsEnabled()
+        reveal("Reconnect")
+        compose.onNodeWithText("Reconnect").performClick()
+        assertEquals(1, reconnects)
+        assertEquals(2, updates)
+        assertRetainedReport()
+        reveal("Tool reports")
+        compose.onNodeWithText("Tool reports").performClick()
+        compose.onNodeWithText("Tool reports").assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Collapsed"))
+        compose.onAllNodesWithText("Host reported exit 0").assertCountEquals(0)
     }
 
     @Test fun idleStatusIsHiddenAndMilestoneSectionsRemain() {

--- a/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/UnifiedSessionActivityTest.kt
+++ b/app/src/test/java/com/unsupportedpastels/hermesandroid/ui/UnifiedSessionActivityTest.kt
@@ -4,11 +4,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.v2.createComposeRule
-import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.unsupportedpastels.hermesandroid.app.*
 import com.unsupportedpastels.hermesandroid.gateway.*
 import com.unsupportedpastels.hermesandroid.navigation.SessionDetailRoute
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -54,6 +54,136 @@ class UnifiedSessionActivityTest {
         compose.onAllNodesWithText("Only observed child events", substring = true).assertCountEquals(0)
         compose.onAllNodes(SemanticsMatcher.keyIsDefined(androidx.compose.ui.semantics.SemanticsProperties.ProgressBarRangeInfo) and
             (hasAnyAncestor(hasTestTag("Session activity sheet")) or hasAnyAncestor(hasTestTag("Session progress strip")))).assertCountEquals(0)
+    }
+
+    @Test fun savedProgressAgesInMountedDetailsWithoutRequestingRefresh() {
+        val chat = mutableStateOf(ChatSessionSnapshot(progress = DurableProgress(
+            hasMilestoneSnapshot = true, restored = true,
+            milestones = listOf(RunTodoItem("done", "Saved review", RunTodoStatus.Completed)),
+        )))
+        var updates = 0
+        var reconnects = 0
+        compose.setContent { MaterialTheme {
+            HermesApp(snapshot = snapshot(chat.value), initialRoute = SessionDetailRoute(id),
+                onGetSessionProgress = { updates++ }, onRetrySessionConnection = { reconnects++ })
+        } }
+        openSavedActivity()
+        compose.onNodeWithText("Saved").assertIsDisplayed()
+        // Install a receipt after navigation, so startup cost cannot consume the
+        // boundary. From here on the snapshot stays fixed: only the screen's
+        // production LaunchedEffect clock can update the mounted sheet's age.
+        compose.runOnIdle {
+            chat.value = chat.value.copy(progress = chat.value.progress.copy(
+                lastObservedAtEpochMillis = System.currentTimeMillis() - 58_000L))
+        }
+        compose.mainClock.advanceTimeBy(1_032)
+        compose.onNode(hasText("Saved · 58s ago") or hasText("Saved · 59s ago")).assertIsDisplayed()
+        val receipt = chat.value.progress.lastObservedAtEpochMillis
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.mainClock.advanceTimeBy(1_032)
+            compose.onAllNodesWithText("Saved · 1m ago").fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithTag("Session activity sheet").assertIsDisplayed()
+        compose.onNodeWithText("Saved review").assertIsDisplayed()
+        compose.onAllNodesWithTag("Composer activity line").assertCountEquals(0)
+        assertEquals(receipt, chat.value.progress.lastObservedAtEpochMillis)
+        assertEquals(0, updates)
+        assertEquals(0, reconnects)
+    }
+
+    @Test fun completedChildDismissalPersistsButNewEvidenceReappearsInCurrentSheet() {
+        val chat = mutableStateOf(ChatSessionSnapshot(backgroundTasks = BackgroundTasks(listOf(finished))))
+        compose.setContent { MaterialTheme {
+            HermesApp(snapshot = snapshot(chat.value), initialRoute = SessionDetailRoute(id))
+        } }
+        compose.onAllNodesWithTag("Composer activity line").assertCountEquals(0)
+        openSavedActivity()
+        compose.onNodeWithText("Review complete").assertIsDisplayed()
+        compose.onNodeWithTag("Session activity sheet").performScrollToNode(hasText("Dismiss completed"))
+        compose.onNodeWithText("Dismiss completed").performClick()
+        compose.onAllNodesWithText("Review complete").assertCountEquals(0)
+        compose.onAllNodesWithText("Dismiss completed").assertCountEquals(0)
+        compose.onAllNodesWithTag("Composer activity line").assertCountEquals(0)
+        dismissActivity()
+        // Unrelated snapshot changes and reopening must not clear dismissal.
+        compose.runOnIdle { chat.value = chat.value.copy(notice = "Snapshot refreshed") }
+        openSavedActivity()
+        compose.onAllNodesWithText("Review complete").assertCountEquals(0)
+        dismissActivity()
+        compose.runOnIdle {
+            chat.value = chat.value.copy(backgroundTasks = BackgroundTasks(listOf(finished.copy(
+                status = BackgroundTaskStatus.Active, available = true,
+                observedAtMillis = System.currentTimeMillis(), action = "Checking follow-up evidence",
+            ))))
+        }
+        compose.onNodeWithContentDescription("Activity: 1 background task").assertIsDisplayed().performClick()
+        compose.onNodeWithText("Review complete").assertIsDisplayed()
+        compose.onNodeWithText("Active · observed activity").assertIsDisplayed()
+        compose.onNodeWithText("Checking follow-up evidence").assertIsDisplayed()
+        compose.onAllNodesWithText("Dismiss completed").assertCountEquals(0)
+        assertNoLegacySurfaces()
+    }
+
+    @Test fun freshChildOutranksCompletedPlanThenAgesToQuietHistory() {
+        val child = finished.copy(status = BackgroundTaskStatus.Active, available = true,
+            observedAtMillis = System.currentTimeMillis())
+        val chat = mutableStateOf(ChatSessionSnapshot(
+            progress = DurableProgress(hasMilestoneSnapshot = true, restored = true,
+                milestones = listOf(RunTodoItem("done", "Completed plan", RunTodoStatus.Completed))),
+            backgroundTasks = BackgroundTasks(listOf(child)),
+        ))
+        var updates = 0
+        compose.setContent { MaterialTheme {
+            HermesApp(snapshot = snapshot(chat.value), initialRoute = SessionDetailRoute(id),
+                onGetSessionProgress = { updates++ })
+        } }
+        compose.onNodeWithContentDescription("Activity: 1 background task").assertIsDisplayed().performClick()
+        compose.onNodeWithText("Completed plan").assertIsDisplayed()
+        compose.onNodeWithText("Active · observed activity").assertIsDisplayed()
+        // Place this same child just inside its freshness window after mounting.
+        // Do not send a stale replacement snapshot: expiry must come from the
+        // production screen clock while both the plan and child remain supplied.
+        compose.runOnIdle {
+            chat.value = chat.value.copy(backgroundTasks = BackgroundTasks(listOf(child.copy(
+                observedAtMillis = System.currentTimeMillis() - 118_000L,
+            ))))
+        }
+        compose.onNodeWithText("Active · observed activity").assertIsDisplayed()
+        val suppliedTasks = chat.value.backgroundTasks
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.mainClock.advanceTimeBy(1_032)
+            compose.onAllNodesWithText("Last known active · no recent activity").fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithText("Completed plan").assertIsDisplayed()
+        compose.onNodeWithText("Done").assertIsDisplayed()
+        compose.onAllNodesWithText("Active · observed activity").assertCountEquals(0)
+        dismissActivity()
+        compose.onAllNodesWithTag("Composer activity line").assertCountEquals(0)
+        compose.onAllNodesWithTag("Session progress strip").assertCountEquals(0)
+        openSavedActivity()
+        compose.onNodeWithText("Completed plan").assertIsDisplayed()
+        compose.onNodeWithText("Last known active · no recent activity").assertIsDisplayed()
+        assertEquals(suppliedTasks, chat.value.backgroundTasks)
+        assertEquals(0, updates)
+        assertNoLegacySurfaces()
+    }
+
+    private fun snapshot(chat: ChatSessionSnapshot) = HermesGatewaySnapshot(
+        authenticationState = AuthenticationState.Authenticated,
+        durableSessions = listOf(SessionSummary(id, "Regression")),
+        chatSessions = mapOf(id to chat),
+    )
+
+    private fun openSavedActivity() {
+        compose.onNodeWithContentDescription("Open session details").performClick()
+        compose.onNodeWithContentDescription("Open activity details").performClick()
+        compose.onNodeWithTag("Session activity sheet").assertIsDisplayed()
+    }
+
+    private fun dismissActivity() {
+        compose.onNode(SemanticsMatcher.keyIsDefined(androidx.compose.ui.semantics.SemanticsActions.Dismiss))
+            .performSemanticsAction(androidx.compose.ui.semantics.SemanticsActions.Dismiss)
+        compose.onAllNodesWithTag("Session activity sheet").assertCountEquals(0)
     }
 
     @Test fun emptyScreenHasNoActivitySurfaceEvenDuringInitialHistoryRefresh() {

--- a/ios/Mercury/MercuryKit/Cache/OfflineCacheModels.swift
+++ b/ios/Mercury/MercuryKit/Cache/OfflineCacheModels.swift
@@ -47,11 +47,13 @@ struct OfflineCachedMessage: Codable, Equatable, Sendable {
     let role: OfflineCachedMessageRole
     let text: String
     let reasoningText: String
+    let displayKind: String?
 
-    init(role: OfflineCachedMessageRole, text: String, reasoningText: String = "") {
+    init(role: OfflineCachedMessageRole, text: String, reasoningText: String = "", displayKind: String? = nil) {
         self.role = role
         self.text = text
         self.reasoningText = reasoningText
+        self.displayKind = displayKind
     }
 }
 

--- a/ios/Mercury/MercuryKit/Cache/OfflineCacheStore.swift
+++ b/ios/Mercury/MercuryKit/Cache/OfflineCacheStore.swift
@@ -250,9 +250,11 @@ actor OfflineCacheStore {
             let bounded = OfflineCachedMessage(
                 role: message.role,
                 text: bound(message.text, bytes: OfflineCachePolicy.maxBodyBytes),
-                reasoningText: bound(message.reasoningText, bytes: OfflineCachePolicy.maxBodyBytes)
+                reasoningText: bound(message.reasoningText, bytes: OfflineCachePolicy.maxBodyBytes),
+                displayKind: message.displayKind.map { bound($0, bytes: 256) }
             )
             let size = bounded.text.utf8.count + bounded.reasoningText.utf8.count
+                + (bounded.displayKind?.utf8.count ?? 0)
             if selected.isEmpty || bytes + size <= budget {
                 selected.insert(bounded, at: 0)
                 bytes += size

--- a/ios/Mercury/MercuryKit/Chat/TranscriptReducer.swift
+++ b/ios/Mercury/MercuryKit/Chat/TranscriptReducer.swift
@@ -23,6 +23,7 @@ struct TranscriptState: Sendable, Equatable {
         var completed: Bool
         var toolName: String? = nil
         var reasoningText: String = ""
+        var displayKind: String? = nil
 
         /// Stable UUID derived from the engine identity, for SwiftUI.
         var id: UUID {
@@ -37,16 +38,18 @@ struct TranscriptState: Sendable, Equatable {
             lhs.role == rhs.role && lhs.text == rhs.text && lhs.completed == rhs.completed
                 && lhs.toolName == rhs.toolName
                 && lhs.reasoningText == rhs.reasoningText
+                && lhs.displayKind == rhs.displayKind
         }
 
         init(coreID: Int64 = 0, role: String, text: String, completed: Bool,
-             toolName: String? = nil, reasoningText: String = "") {
+             toolName: String? = nil, reasoningText: String = "", displayKind: String? = nil) {
             self.coreID = coreID
             self.role = role
             self.text = text
             self.completed = completed
             self.toolName = toolName
             self.reasoningText = reasoningText
+            self.displayKind = displayKind
         }
 
         init(_ core: MercuryCore.TranscriptRow) {
@@ -56,14 +59,14 @@ struct TranscriptState: Sendable, Equatable {
                 text: core.text,
                 completed: core.completed,
                 toolName: core.toolName,
-                reasoningText: core.reasoningText
+                reasoningText: core.reasoningText, displayKind: core.displayKind
             )
         }
 
         var core: MercuryCore.TranscriptRow {
             MercuryCore.TranscriptRow(
                 id: coreID, role: role, text: text, completed: completed,
-                toolName: toolName, reasoningText: reasoningText
+                toolName: toolName, reasoningText: reasoningText, displayKind: displayKind
             )
         }
     }
@@ -73,10 +76,12 @@ struct TranscriptState: Sendable, Equatable {
         var content: String
         var toolName: String? = nil
         var reasoningText: String = ""
+        var displayKind: String? = nil
 
         var core: MercuryCore.RestoredMessage {
             MercuryCore.RestoredMessage(
-                role: role, content: content, toolName: toolName, reasoningText: reasoningText
+                role: role, content: content, toolName: toolName, reasoningText: reasoningText,
+                displayKind: displayKind
             )
         }
     }

--- a/ios/Mercury/MercuryKit/Sessions/SessionsClient.swift
+++ b/ios/Mercury/MercuryKit/Sessions/SessionsClient.swift
@@ -23,6 +23,7 @@ struct TranscriptMessage: Equatable, Decodable {
     var content: String
     var toolName: String?
     var reasoningText: String
+    var displayKind: String?
 
     private enum CodingKeys: String, CodingKey {
         case role
@@ -33,23 +34,27 @@ struct TranscriptMessage: Equatable, Decodable {
         case reasoning
         case reasoningContent = "reasoning_content"
         case reasoningDetails = "reasoning_details"
+        case displayKind = "display_kind"
     }
 
     init(
         role: String = "",
         content: String = "",
         toolName: String? = nil,
-        reasoningText: String = ""
+        reasoningText: String = "",
+        displayKind: String? = nil
     ) {
         self.role = role
         self.content = content
         self.toolName = toolName
         self.reasoningText = reasoningText
+        self.displayKind = displayKind
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         role = (try? c.decode(String.self, forKey: .role)) ?? ""
+        displayKind = try? c.decode(String.self, forKey: .displayKind)
         content = (try? c.decode(String.self, forKey: .content))
             ?? (try? c.decode(String.self, forKey: .text))
             ?? ""

--- a/ios/Mercury/Views/ChatConnectionCoordinator.swift
+++ b/ios/Mercury/Views/ChatConnectionCoordinator.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import MercuryCore
 
 /// The user-action boundary for a chat connection attempt. Retries that are
 /// part of opening a session, or of tapping Retry, remain explicit even when
@@ -176,15 +177,17 @@ extension ChatView {
                         completed: false
                     )
                 } else {
-                    // The turn completed while we were away. Android performs
-                    // a second REST transcript load here because the first
-                    // load may have raced the tool phase and omitted the final
-                    // assistant response. Keep the resume snapshot visible if
-                    // that follow-up request is temporarily unavailable. The
+                    // Resume owns display rows when nonempty. The bounded
+                    // durable read still recovers progress/tool metadata and
+                    // history cursors; it is not an interchangeable display
+                    // projection. Empty resume retains full history fallback. The
                     // candidate is not published yet, so pass it explicitly:
                     // in relay mode a standalone read here would supersede
                     // this very connection and loop the reconnect.
-                    _ = await loadTranscript(durableSessionID: sessionID, using: candidate)
+                    _ = await loadTranscript(
+                        durableSessionID: state.durableID ?? sessionID, using: candidate,
+                        sourceAuthority: TranscriptReadPolicy.shared.afterResume(hasDisplayRows: !resumedRows.isEmpty)
+                    )
                     state.transcript.finishStreamingAssistant()
                 }
             }

--- a/ios/Mercury/Views/ChatConnectionCoordinator.swift
+++ b/ios/Mercury/Views/ChatConnectionCoordinator.swift
@@ -165,7 +165,7 @@ extension ChatView {
                     expectedVersion: state.progress.observationVersion)
                 let resumedRows = transcriptRows(from: resumed.messages)
                 if !resumedRows.isEmpty {
-                    state.transcript.loadTranscript(resumedRows)
+                    publishResumeDisplayRows(resumedRows)
                 }
                 if resumed.running || resumed.inflight != nil {
                     // A turn was already executing when we attached; reopen the
@@ -178,10 +178,10 @@ extension ChatView {
                     )
                 } else {
                     // Resume owns display rows when nonempty. The bounded
-                    // durable read still recovers progress/tool metadata and
-                    // history cursors; it is not an interchangeable display
-                    // projection. Empty resume retains full history fallback. The
-                    // candidate is not published yet, so pass it explicitly:
+                    // durable read still recovers progress/tool metadata, but
+                    // its cursor cannot paginate a different display projection.
+                    // Empty resume retains full history fallback. The candidate
+                    // is not published yet, so pass it explicitly:
                     // in relay mode a standalone read here would supersede
                     // this very connection and loop the reconnect.
                     _ = await loadTranscript(

--- a/ios/Mercury/Views/ChatSessionControls.swift
+++ b/ios/Mercury/Views/ChatSessionControls.swift
@@ -423,7 +423,7 @@ extension ChatView {
                 role: role,
                 content: content,
                 toolName: toolName,
-                reasoningText: reasoning
+                reasoningText: reasoning, displayKind: message["display_kind"] as? String
             )
         }
     }

--- a/ios/Mercury/Views/ChatSessionLoader.swift
+++ b/ios/Mercury/Views/ChatSessionLoader.swift
@@ -93,9 +93,11 @@ extension ChatView {
             }
             applyDurableDisplayRows(restored, sourceAuthority: sourceAuthority,
                                     preservingActiveTurn: preservingActiveTurn, turnWasActive: turnWasActive)
-            state.loadedTranscriptCount = relayPage?.nextOffset ?? history.count
-            state.hasMoreHistory = relayPage?.hasMore ?? TranscriptHistoryPolicy.hasMoreHistory(fetchedCount: history.count)
-            state.historyError = nil
+            applyHistoryPagination(
+                loadedCount: relayPage?.nextOffset ?? history.count,
+                hasMore: relayPage?.hasMore ?? TranscriptHistoryPolicy.hasMoreHistory(fetchedCount: history.count),
+                sourceAuthority: sourceAuthority
+            )
             if sourceAuthority.publishesTranscript { await cacheCurrentTranscript() }
             state.initialScrollDone = !state.transcript.rows.isEmpty
             state.loadError = nil
@@ -121,6 +123,28 @@ extension ChatView {
         } else {
             state.transcript.loadTranscript(restored)
         }
+    }
+
+    /// A durable cursor is valid only when the same read also published the
+    /// rows it indexes. Metadata-only post-resume reads cannot claim paging.
+    @MainActor
+    func applyHistoryPagination(
+        loadedCount: Int,
+        hasMore: Bool,
+        sourceAuthority: TranscriptReadAuthority
+    ) {
+        guard sourceAuthority.publishesTranscript else { return }
+        state.adoptHistoryPagination(loadedCount: loadedCount, hasMore: hasMore)
+    }
+
+    /// Resume rows are an authoritative display projection, but do not carry
+    /// a durable-history cursor. Disable backfill before a metadata read can
+    /// suspend or fail.
+    @MainActor
+    func publishResumeDisplayRows(_ rows: [TranscriptState.RestoredMessage]) {
+        guard !rows.isEmpty else { return }
+        state.invalidateTranscriptPagination()
+        state.transcript.loadTranscript(rows)
     }
 
     /// Fetches one transcript page over the relay's in-process read
@@ -182,10 +206,13 @@ extension ChatView {
     /// insertion.
     func loadEarlierHistory() async {
         guard !state.isLoadingHistory, !(state.hasMoreHistory == false && state.historyError == nil) else { return }
+        guard let paginationRequest = state.historyPaginationRequest() else { return }
         let isRelay = appModel.activeRelayTarget != nil
         guard isRelay || appModel.serverOrigin != nil else { return }
         let transcriptID = state.durableID ?? sessionID
         guard !transcriptID.isEmpty else { return }
+        let requestedScope = backgroundTaskScope
+        let requestedSelection = appModel.relaySelectionGeneration
         state.isLoadingHistory = true
         defer { state.isLoadingHistory = false }
         do {
@@ -198,7 +225,7 @@ extension ChatView {
                 let page = try await relayTranscriptMessages(
                     transcriptID: transcriptID,
                     limit: TranscriptHistoryPolicy.pageSize,
-                    offset: TranscriptHistoryPolicy.nextOffset(loadedCount: state.loadedTranscriptCount),
+                    offset: TranscriptHistoryPolicy.nextOffset(loadedCount: paginationRequest.loadedCount),
                     using: live
                 )
                 relayPage = page
@@ -209,9 +236,14 @@ extension ChatView {
                 let sessions = SessionsClient(client: client, profile: appModel.activeProfile)
                 fetchedOlder = try await sessions.olderTranscript(
                     sessionID: transcriptID,
-                    offset: TranscriptHistoryPolicy.nextOffset(loadedCount: state.loadedTranscriptCount)
+                    offset: TranscriptHistoryPolicy.nextOffset(loadedCount: paginationRequest.loadedCount)
                 )
             }
+            guard !Task.isCancelled,
+                  backgroundTaskScope == requestedScope,
+                  appModel.relaySelectionGeneration == requestedSelection,
+                  (state.durableID ?? sessionID) == transcriptID,
+                  state.acceptsHistoryPaginationResponse(generation: paginationRequest.generation) else { return }
             let older = TranscriptPageOrdering.forDisplay(fetchedOlder)
             if let page = relayPage {
                 state.loadedTranscriptCount = page.nextOffset
@@ -236,6 +268,7 @@ extension ChatView {
             }
             state.historyError = nil
         } catch {
+            guard state.acceptsHistoryPaginationResponse(generation: paginationRequest.generation) else { return }
             state.historyError = "Could not load earlier messages. Tap to retry."
         }
     }

--- a/ios/Mercury/Views/ChatSessionLoader.swift
+++ b/ios/Mercury/Views/ChatSessionLoader.swift
@@ -22,7 +22,8 @@ extension ChatView {
         durableSessionID requestedID: String? = nil,
         preservingActiveTurn: Bool = false,
         using liveConnection: ChatConnection? = nil,
-        allowStandaloneRelayRead: Bool = false
+        allowStandaloneRelayRead: Bool = false,
+        sourceAuthority: TranscriptReadAuthority = .history
     ) async -> Bool {
         let isRelay = appModel.activeRelayTarget != nil
         guard isRelay || appModel.serverOrigin != nil else {
@@ -35,7 +36,7 @@ extension ChatView {
         let requestedScope = backgroundTaskScope
         let requestedSelection = appModel.relaySelectionGeneration
         let turnWasActive = preservingActiveTurn && (state.isSending || state.transcript.hasStreamingAssistant)
-        if !preservingActiveTurn, let origin = appModel.serverOrigin {
+        if sourceAuthority.publishesTranscript, !preservingActiveTurn, let origin = appModel.serverOrigin {
             let cached = await appModel.cachedTranscript(
                 origin: origin,
                 profile: appModel.activeProfile,
@@ -46,7 +47,7 @@ extension ChatView {
                     TranscriptState.RestoredMessage(
                         role: $0.role.rawValue,
                         content: $0.text,
-                        reasoningText: $0.reasoningText
+                        reasoningText: $0.reasoningText, displayKind: $0.displayKind
                     )
                 })
                 state.initialScrollDone = true
@@ -87,21 +88,15 @@ extension ChatView {
                     role: message.role,
                     content: message.content,
                     toolName: message.toolName,
-                    reasoningText: message.reasoningText
+                    reasoningText: message.reasoningText, displayKind: message.displayKind
                 )
             }
-            if preservingActiveTurn {
-                state.isSending = state.transcript.reconcileForegroundTranscript(
-                    restored,
-                    turnWasActive: turnWasActive
-                )
-            } else {
-                state.transcript.loadTranscript(restored)
-            }
+            applyDurableDisplayRows(restored, sourceAuthority: sourceAuthority,
+                                    preservingActiveTurn: preservingActiveTurn, turnWasActive: turnWasActive)
             state.loadedTranscriptCount = relayPage?.nextOffset ?? history.count
             state.hasMoreHistory = relayPage?.hasMore ?? TranscriptHistoryPolicy.hasMoreHistory(fetchedCount: history.count)
             state.historyError = nil
-            await cacheCurrentTranscript()
+            if sourceAuthority.publishesTranscript { await cacheCurrentTranscript() }
             state.initialScrollDone = !state.transcript.rows.isEmpty
             state.loadError = nil
             return true
@@ -109,6 +104,22 @@ extension ChatView {
             // Keep whatever rendered; surface a banner. No secret material here.
             state.loadError = "Could not load transcript for this session."
             return false
+        }
+    }
+
+    /// Publication boundary shared by initial history and the post-resume read.
+    @MainActor
+    func applyDurableDisplayRows(
+        _ restored: [TranscriptState.RestoredMessage],
+        sourceAuthority: TranscriptReadAuthority = .history,
+        preservingActiveTurn: Bool = false,
+        turnWasActive: Bool = false
+    ) {
+        guard sourceAuthority.publishesTranscript else { return }
+        if preservingActiveTurn {
+            state.isSending = state.transcript.reconcileForegroundTranscript(restored, turnWasActive: turnWasActive)
+        } else {
+            state.transcript.loadTranscript(restored)
         }
     }
 
@@ -215,7 +226,7 @@ extension ChatView {
                     role: message.role,
                     content: message.content,
                     toolName: message.toolName,
-                    reasoningText: message.reasoningText
+                    reasoningText: message.reasoningText, displayKind: message.displayKind
                 )
             }
             state.transcript.prependHistory(restored)
@@ -242,7 +253,8 @@ extension ChatView {
             )
         let messages = state.transcript.rows.compactMap { row -> OfflineCachedMessage? in
             guard let role = OfflineCachedMessageRole(rawValue: row.role.lowercased()) else { return nil }
-            return OfflineCachedMessage(role: role, text: row.text, reasoningText: row.reasoningText)
+            return OfflineCachedMessage(role: role, text: row.text, reasoningText: row.reasoningText,
+                                        displayKind: row.displayKind)
         }
         await appModel.cacheTranscript(
             origin: origin,

--- a/ios/Mercury/Views/ChatSessionState.swift
+++ b/ios/Mercury/Views/ChatSessionState.swift
@@ -42,6 +42,11 @@ extension ChatView {
 @Observable
 @MainActor
 final class ChatSessionState {
+    enum TranscriptPaginationOwner {
+        case unavailable
+        case historyProjection
+    }
+
     // MARK: Transcript state
     //
     // Row modeling and event mutation live in TranscriptState (pure value
@@ -239,6 +244,34 @@ final class ChatSessionState {
     var hasMoreHistory = false
     var isLoadingHistory = false
     var historyError: String?
+    private(set) var transcriptPaginationOwner: TranscriptPaginationOwner = .unavailable
+    private(set) var transcriptPaginationGeneration = 0
+
+    func invalidateTranscriptPagination() {
+        transcriptPaginationGeneration &+= 1
+        transcriptPaginationOwner = .unavailable
+        loadedTranscriptCount = 0
+        hasMoreHistory = false
+        historyError = nil
+    }
+
+    func adoptHistoryPagination(loadedCount: Int, hasMore: Bool) {
+        transcriptPaginationGeneration &+= 1
+        transcriptPaginationOwner = .historyProjection
+        loadedTranscriptCount = max(0, loadedCount)
+        hasMoreHistory = hasMore
+        historyError = nil
+    }
+
+    func historyPaginationRequest() -> (generation: Int, loadedCount: Int)? {
+        guard transcriptPaginationOwner == .historyProjection else { return nil }
+        return (transcriptPaginationGeneration, loadedTranscriptCount)
+    }
+
+    func acceptsHistoryPaginationResponse(generation: Int) -> Bool {
+        transcriptPaginationOwner == .historyProjection
+            && transcriptPaginationGeneration == generation
+    }
 
     init(
         sessionID: String,

--- a/ios/Mercury/Views/TurnActivityView.swift
+++ b/ios/Mercury/Views/TurnActivityView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import MercuryCore
 
 /// Quiet per-turn disclosure below the settled answer, not a persistent work card.
 struct TurnActivityView: View {
@@ -61,7 +62,11 @@ struct ActivityTranscriptContent: View {
                         ReasoningDisclosure(reasoningText: row.reasoningText, streaming: !row.completed)
                     }
                     if !row.text.isEmpty {
-                        if row.role.lowercased() == "assistant", row.completed {
+                        if InternalCompletionNotice.shared.isNotice(row: row.core) {
+                            // Internal details are not a human chat bubble, even expanded.
+                            Text(row.text).font(.callout.monospaced()).textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        } else if row.role.lowercased() == "assistant", row.completed {
                             media(row.text)
                         } else {
                             MessageBubble(role: row.role, text: row.text, isStreaming: !row.completed)

--- a/ios/MercuryNotificationPreviewKit/PushPreviewKit.swift
+++ b/ios/MercuryNotificationPreviewKit/PushPreviewKit.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MercuryCore
 import CryptoKit
 import Security
 #if canImport(Darwin)
@@ -72,21 +73,21 @@ public struct PushPreviewPlaintext: Equatable {
               let expNumber = object["exp"] as? NSNumber, let exp = exactInt64(expNumber)
         else { throw PushPreviewFailure.malformedPlaintext }
         guard exp >= iat, exp - iat <= 300, iat <= now + 60, iat >= now - 300, now <= exp else { throw PushPreviewFailure.invalidTime }
-        func bounded(_ name: String, max: Int) throws -> String? {
+        // KMP owns byte bounds and the frozen scalar policy. Do not sanitize or
+        // normalize decrypted text: LF is accepted only by the body validator.
+        let fields = PushPreviewFieldPolicy.shared
+        func bounded(_ name: String, valid: (String) -> Bool) throws -> String? {
             guard let raw = object[name] else { return nil }
-            guard let value = raw as? String, !value.isEmpty, value.utf8.count <= max,
-                  !value.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) else { throw PushPreviewFailure.malformedPlaintext }
+            guard let value = raw as? String, valid(value) else { throw PushPreviewFailure.malformedPlaintext }
             return value
         }
-        let title = try bounded("title", max: PushPreviewConstants.maxTitleBytes)
-        let body = try bounded("body", max: PushPreviewConstants.maxBodyBytes)
+        let title = try bounded("title", valid: { fields.validTitle(value: $0) })
+        let body = try bounded("body", valid: { fields.validBody(value: $0) })
         var routeSessionID: String?, routeProfile: String?
         if let rawRoute = object["route"] {
             guard let r = rawRoute as? [String: Any], Set(r.keys) == ["sid", "profile"],
-                  let sid = r["sid"] as? String, (1...PushPreviewConstants.maxRouteSessionBytes).contains(sid.utf8.count),
-                  let profile = r["profile"] as? String, (1...PushPreviewConstants.maxRouteProfileBytes).contains(profile.utf8.count),
-                  !sid.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }),
-                  !profile.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) else { throw PushPreviewFailure.malformedPlaintext }
+                  let sid = r["sid"] as? String, fields.validSessionId(value: sid),
+                  let profile = r["profile"] as? String, fields.validProfile(value: profile) else { throw PushPreviewFailure.malformedPlaintext }
             routeSessionID = sid; routeProfile = profile
         }
         return Self(kind: kind, title: title, body: body, routeSessionID: routeSessionID, routeProfile: routeProfile, issuedAt: iat, expiresAt: exp)

--- a/ios/MercuryTests/FirstResponseReopenInvestigationTests.swift
+++ b/ios/MercuryTests/FirstResponseReopenInvestigationTests.swift
@@ -60,6 +60,47 @@ final class FirstResponseReopenInvestigationTests: XCTestCase {
         }
     }
 
+    func testAuthoritativeResumeInvalidatesDurablePaginationAndMetadataCannotRestoreIt() {
+        let reopened = ChatView(sessionID: "synthetic-durable", title: "Synthetic")
+        reopened.state.adoptHistoryPagination(loadedCount: 100, hasMore: true)
+        let resumeRows = (1...125).map {
+            TranscriptState.RestoredMessage(
+                role: $0.isMultiple(of: 2) ? "assistant" : "user",
+                content: "Resume row \($0)"
+            )
+        }
+
+        reopened.publishResumeDisplayRows(resumeRows)
+        XCTAssertNil(reopened.state.historyPaginationRequest())
+        XCTAssertEqual(reopened.state.loadedTranscriptCount, 0)
+        XCTAssertFalse(reopened.state.hasMoreHistory)
+
+        reopened.applyHistoryPagination(loadedCount: 100, hasMore: true, sourceAuthority: .resume)
+        XCTAssertNil(reopened.state.historyPaginationRequest(),
+                     "A metadata-only durable read must not restore a mismatched cursor")
+        XCTAssertFalse(reopened.state.hasMoreHistory)
+        XCTAssertEqual(reopened.state.transcript.rows.count, 125)
+    }
+
+    func testHistoryPublicationRestoresPaginationAndOwnershipChangeRejectsInflightPage() throws {
+        let reopened = ChatView(sessionID: "synthetic-durable", title: "Synthetic")
+        reopened.applyHistoryPagination(loadedCount: 100, hasMore: true, sourceAuthority: .history)
+        let request = try XCTUnwrap(reopened.state.historyPaginationRequest())
+        XCTAssertEqual(request.loadedCount, 100)
+
+        reopened.publishResumeDisplayRows([
+            TranscriptState.RestoredMessage(role: "assistant", content: "Authoritative resume")
+        ])
+        XCTAssertFalse(reopened.state.acceptsHistoryPaginationResponse(generation: request.generation))
+
+        reopened.applyDurableDisplayRows([
+            TranscriptState.RestoredMessage(role: "assistant", content: "History fallback")
+        ], sourceAuthority: .history)
+        reopened.applyHistoryPagination(loadedCount: 50, hasMore: true, sourceAuthority: .history)
+        XCTAssertEqual(reopened.state.historyPaginationRequest()?.loadedCount, 50)
+        XCTAssertTrue(reopened.state.hasMoreHistory)
+    }
+
     func testEmptyResumeFallsBackAndInitialExplicitHistoryCanReplaceOrRewind() {
         let reopened = ChatView(sessionID: "synthetic-durable", title: "Synthetic")
         let full = reopened.transcriptRows(from: wireRows(tools: true))

--- a/ios/MercuryTests/FirstResponseReopenInvestigationTests.swift
+++ b/ios/MercuryTests/FirstResponseReopenInvestigationTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+import MercuryCore
+@testable import Mercury
+
+/// Synthetic adapter/reducer lifecycle coverage; not a mounted navigation or live-server test.
+@MainActor
+final class FirstResponseReopenInvestigationTests: XCTestCase {
+    private let answer = "FIRST ANSWER BEGIN\n\nEvery synthetic paragraph survives.\n\nFIRST ANSWER END"
+    private let prompt = "Explain the synthetic result."
+
+    private func visibleAnswers(_ state: TranscriptState) -> [String] {
+        foldTranscriptTurns(state.rows, turnActive: false).compactMap {
+            if case .message(let row) = $0, row.role == "assistant" { return row.text }
+            return nil
+        }
+    }
+
+    private func completeFirstResponse(tools: Bool) -> TranscriptState {
+        var state = TranscriptState(isNewSession: true)
+        state.appendUserMessage(prompt)
+        if tools {
+            state.apply(.messageInterim(sessionID: "synthetic-runtime", text: "Checking synthetic data.", alreadyStreamed: false))
+            state.apply(.toolStart(sessionID: "synthetic-runtime", toolID: "t1", name: "fixture", context: "synthetic"))
+        }
+        state.apply(.messageStart(sessionID: "synthetic-runtime", text: nil))
+        state.apply(.messageDelta(sessionID: "synthetic-runtime", text: answer))
+        state.apply(.messageComplete(sessionID: "synthetic-runtime", text: answer, status: nil, error: nil, reasoning: nil,
+                                     warning: nil, failureReason: nil, recoverable: false, billing: nil))
+        XCTAssertFalse(state.hasStreamingAssistant)
+        XCTAssertEqual(visibleAnswers(state), [answer])
+        return state
+    }
+
+    private func wireRows(tools: Bool) -> [[String: Any]] {
+        var rows: [[String: Any]] = [["role": "user", "content": prompt]]
+        if tools {
+            rows.append(["role": "assistant", "content": "Checking synthetic data.", "tool_calls": [["id": "t1"]]])
+            rows.append(["role": "tool", "content": "synthetic result", "tool_name": "fixture", "tool_call_id": "t1"])
+        }
+        rows.append(["role": "assistant", "content": answer, "finish_reason": "stop"])
+        return rows
+    }
+
+    func testPostResumeDurablePublicationPreservesAllSegmentsAndRowIdentity() {
+        let reopened = ChatView(sessionID: "synthetic-durable", title: "Synthetic")
+        let rows = reopened.transcriptRows(from: [
+            ["role": "user", "content": prompt],
+            ["role": "assistant", "content": "Synthetic first answer alpha."],
+            ["role": "assistant", "content": "Synthetic first answer omega."]
+        ])
+        reopened.state.transcript.loadTranscript(rows)
+        let before = reopened.state.transcript.rows
+        let authority = TranscriptReadPolicy.shared.afterResume(hasDisplayRows: !rows.isEmpty)
+        XCTAssertFalse(authority.publishesTranscript)
+        let stale = reopened.transcriptRows(from: [["role": "user", "content": prompt]])
+        for fetched in [stale, rows, rows + rows] {
+            reopened.applyDurableDisplayRows(fetched, sourceAuthority: authority)
+            XCTAssertEqual(reopened.state.transcript.rows, before)
+            XCTAssertEqual(reopened.state.transcript.rows.map(\.coreID), before.map(\.coreID))
+        }
+    }
+
+    func testEmptyResumeFallsBackAndInitialExplicitHistoryCanReplaceOrRewind() {
+        let reopened = ChatView(sessionID: "synthetic-durable", title: "Synthetic")
+        let full = reopened.transcriptRows(from: wireRows(tools: true))
+        reopened.applyDurableDisplayRows(full)
+        XCTAssertEqual(visibleAnswers(reopened.state.transcript), [answer])
+        reopened.applyDurableDisplayRows([], sourceAuthority: .history)
+        XCTAssertTrue(reopened.state.transcript.rows.isEmpty)
+        reopened.applyDurableDisplayRows(full,
+            sourceAuthority: TranscriptReadPolicy.shared.afterResume(hasDisplayRows: false))
+        XCTAssertEqual(visibleAnswers(reopened.state.transcript), [answer])
+        reopened.applyDurableDisplayRows(Array(full.prefix(1)))
+        XCTAssertEqual(reopened.state.transcript.rows.map(\.text), [prompt])
+    }
+
+    func testCompletedFirstResponseLeaveReopenThroughRESTDecodeAndResumeMapping() throws {
+        for tools in [false, true] {
+            _ = completeFirstResponse(tools: tools)
+            // A different detail owner on reopen must not rely on retained live rows.
+            let reopened = ChatView(sessionID: "synthetic-durable", title: "Synthetic")
+            let wire = wireRows(tools: tools)
+            let page = try TranscriptProgressPage.decode(JSONSerialization.data(withJSONObject: ["messages": wire]))
+            reopened.state.transcript.loadTranscript(TranscriptPageOrdering.forDisplay(page.messages).map {
+                TranscriptState.RestoredMessage(role: $0.role, content: $0.content, toolName: $0.toolName,
+                                                reasoningText: $0.reasoningText, displayKind: $0.displayKind)
+            })
+            XCTAssertEqual(visibleAnswers(reopened.state.transcript), [answer], "REST restore must retain the entire first answer")
+            // Production resume mapping, then the idle post-resume durable refresh.
+            reopened.state.transcript.loadTranscript(reopened.transcriptRows(from: wire))
+            XCTAssertEqual(visibleAnswers(reopened.state.transcript), [answer], "Resume must not erase any paragraph")
+            reopened.state.transcript.loadTranscript(reopened.transcriptRows(from: wire))
+            reopened.state.transcript.finishStreamingAssistant()
+            XCTAssertEqual(visibleAnswers(reopened.state.transcript), [answer])
+        }
+    }
+
+    func testCompletedFirstToolResponseLeaveReopenThroughRelayPageAndPagination() throws {
+        _ = completeFirstResponse(tools: true)
+        let reopened = ChatView(sessionID: "synthetic-durable", title: "Synthetic")
+        let wire = wireRows(tools: true)
+        let newest = try RelayTranscriptPage.decode(["messages": [wire.last!], "raw_returned": 1,
+            "next_offset": 1, "has_more": true], offset: 0, limit: 1)
+        reopened.state.transcript.loadTranscript(newest.messages.map {
+            TranscriptState.RestoredMessage(role: $0.role, content: $0.content, toolName: $0.toolName)
+        })
+        XCTAssertEqual(newest.nextOffset, 1)
+        XCTAssertTrue(newest.hasMore)
+        XCTAssertEqual(visibleAnswers(reopened.state.transcript), [answer])
+        let older = try RelayTranscriptPage.decode(["messages": Array(wire.dropLast()), "raw_returned": 3,
+            "next_offset": 4, "has_more": false], offset: newest.nextOffset, limit: 100)
+        reopened.state.transcript.prependHistory(older.messages.map {
+            TranscriptState.RestoredMessage(role: $0.role, content: $0.content, toolName: $0.toolName)
+        })
+        XCTAssertFalse(older.hasMore)
+        XCTAssertEqual(visibleAnswers(reopened.state.transcript), [answer])
+        XCTAssertEqual(reopened.state.transcript.rows.map(\.text), [prompt, "Checking synthetic data.", "synthetic result", answer])
+    }
+}

--- a/ios/MercuryTests/InternalCompletionNoticeTests.swift
+++ b/ios/MercuryTests/InternalCompletionNoticeTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import MercuryCore
+@testable import Mercury
+
+final class InternalCompletionNoticeTests: XCTestCase {
+    private let notice = "[IMPORTANT: Background process proc_f05837cd4d75 completed normally (exit code 0).\nCommand: python check.py\nOutput:\nverified]"
+
+    func testLiveAndRestoredFoldingPreservesSummariesAndOriginalNotice() {
+        for active in [false, true] {
+            let rows = [
+                TranscriptState.Row(coreID: 1, role: "user", text: "run checks", completed: true),
+                TranscriptState.Row(coreID: 2, role: "assistant", text: "Started checks.", completed: true),
+                TranscriptState.Row(coreID: 3, role: "user", text: notice, completed: true),
+                TranscriptState.Row(coreID: 4, role: "assistant", text: "Checks passed.", completed: !active)
+            ]
+            let folded = foldTranscriptTurns(rows, turnActive: active)
+            let messages = folded.compactMap { entry -> String? in
+                if case .message(let row) = entry { return row.text }
+                return nil
+            }
+            XCTAssertEqual(messages, ["run checks", "Started checks.", "Checks passed."])
+            guard case .activity(_, let steps, _, let count) = folded[2] else {
+                return XCTFail("Expected collapsed activity entry rather than user bubble")
+            }
+            XCTAssertEqual(count, 1)
+            XCTAssertEqual(steps, [rows[2]])
+            XCTAssertEqual(steps[0].role, "user")
+            XCTAssertEqual(steps[0].text, notice)
+        }
+    }
+
+    func testOfficialMetadataDecodeRestorePaginationAndCoreRoundTrip() throws {
+        let decoded = try JSONDecoder().decode(TranscriptMessage.self, from: Data(
+            #"{"role":"user","content":"New envelope","display_kind":"async_delegation_complete"}"#.utf8))
+        var state = TranscriptState()
+        state.prependHistory([TranscriptState.RestoredMessage(role: decoded.role, content: decoded.content,
+            displayKind: decoded.displayKind)])
+        let row = try XCTUnwrap(state.rows.first)
+        XCTAssertEqual(row.displayKind, "async_delegation_complete")
+        XCTAssertTrue(InternalCompletionNotice.shared.isNotice(row: row.core))
+        XCTAssertEqual(TranscriptState.Row(row.core), row)
+        guard case .activity = foldTranscriptTurns(state.rows, turnActive: true).first else {
+            return XCTFail("Typed notification was rendered as chat")
+        }
+    }
+
+    func testOrdinaryUserQuotesAndAssistantTextRemainMessages() {
+        for text in ["IMPORTANT: run checks", "Please explain \(notice)", "> \(notice)", "```\n\(notice)\n```"] {
+            let row = TranscriptState.Row(role: "user", text: text, completed: true)
+            guard case .message = foldTranscriptTurns([row], turnActive: false).first else {
+                return XCTFail("Ordinary user text was folded")
+            }
+        }
+        XCTAssertFalse(InternalCompletionNotice.shared.isNotice(role: "assistant", text: notice,
+            displayKind: "async_delegation_complete"))
+    }
+
+    func testOfflineMetadataRoundTripAndOlderCacheCompatibility() throws {
+        let message = OfflineCachedMessage(role: .user, text: "New envelope", displayKind: "async_delegation_complete")
+        XCTAssertEqual(try JSONDecoder().decode(OfflineCachedMessage.self,
+            from: JSONEncoder().encode(message)), message)
+        let old = try JSONDecoder().decode(OfflineCachedMessage.self,
+            from: Data(#"{"role":"user","text":"old text","reasoningText":""}"#.utf8))
+        XCTAssertNil(old.displayKind)
+    }
+}

--- a/ios/MercuryTests/PushPreviewKitTests.swift
+++ b/ios/MercuryTests/PushPreviewKitTests.swift
@@ -22,6 +22,106 @@ final class PushPreviewKitTests: XCTestCase {
         let preview = try PushPreviewProcessor.decrypt(userInfo: info, environment: "sandbox", now: 2_000_000_010, keys: Keys(record), replay: Replay())
         XCTAssertEqual(preview.title, "Mercury test"); XCTAssertEqual(preview.body, "Preview ready")
     }
+    func testBundledHostMultilineCiphertextsOpenThroughNativeProcessor() throws {
+        let url = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "host-multiline", withExtension: "json"))
+        let rows = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [[String: String]])
+        XCTAssertEqual(rows.count, 4)
+        XCTAssertEqual(Set(rows.compactMap { $0["name"] }), Set(["single", "lf", "crlf", "three"]))
+        for row in rows {
+            func field(_ name: String) throws -> String { try XCTUnwrap(row[name]) }
+            let keyID = try field("kid"), wake = try field("wake")
+            let envelope: [AnyHashable: Any] = [
+                "mercury_wake": wake, "mercury_event": try field("event"),
+                "mercury_preview": ["v": 1, "alg": "C20P", "kid": keyID,
+                                    "nonce": try field("nonce"), "ct": try field("ct")]
+            ]
+            let key = try XCTUnwrap(PushPreviewEnvelope.decode(try field("key")))
+            let record = PreviewKeyRecord(key: key, keyID: keyID, wake: wake, environment: "sandbox", createdAt: 0)
+            let replay = Replay()
+            let preview = try PushPreviewProcessor.decrypt(
+                userInfo: envelope, environment: "sandbox", now: 2_000_000_010, keys: Keys(record), replay: replay
+            )
+            XCTAssertEqual(preview.body, try field("expected_body"), row["name"] ?? "")
+            XCTAssertEqual(preview.title, "Synthetic preview")
+            XCTAssertEqual(preview.routeSessionID, "synthetic-session")
+            XCTAssertEqual(preview.routeProfile, "default")
+            XCTAssertEqual(replay.seen.count, 1)
+        }
+    }
+
+    // These negative cases use authenticated ciphertext too, exercising the exact
+    // native opener rather than a standalone text validator or an emulated parser.
+    private func encryptedField(_ name: String, value: String) throws -> [AnyHashable: Any] {
+        var plain: [String: Any] = [
+            "v": 1, "kind": "completion", "iat": 2_000_000_000, "exp": 2_000_000_120,
+            "title": "Synthetic preview", "body": "Alpha\nBeta",
+            "route": ["sid": "synthetic-session", "profile": "default"]
+        ]
+        if name == "sid" || name == "profile" {
+            var route = plain["route"] as! [String: String]
+            route[name] = value
+            plain["route"] = route
+        } else {
+            plain[name] = value
+        }
+        let key = SymmetricKey(data: Data(0..<32))
+        let envelope = try PushPreviewEnvelope(userInfo: info)
+        let sealed = try ChaChaPoly.seal(
+            JSONSerialization.data(withJSONObject: plain), using: key,
+            nonce: ChaChaPoly.Nonce(data: XCTUnwrap(PushPreviewEnvelope.decode(nonce))),
+            authenticating: PushPreviewProcessor.aad(environment: "sandbox", envelope: envelope)
+        )
+        var result = info
+        var metadata = result["mercury_preview"] as! [String: Any]
+        metadata["ct"] = PushPreviewEnvelope.encode(sealed.ciphertext + sealed.tag)
+        result["mercury_preview"] = metadata
+        return result
+    }
+
+    func testNativeOpenerStillRejectsControlsAndLFOutsideBody() throws {
+        let record = PreviewKeyRecord(key: Data(0..<32), keyID: kid, wake: wake, environment: "sandbox", createdAt: 0)
+        let controls = ["\u{0}", "\t", "\r", "\u{b}", "\u{c}", "\u{1f}", "\u{7f}",
+                        "\u{85}", "\u{200b}", "\u{202e}", "\u{feff}", "\u{1d173}"]
+        for field in ["title", "body", "sid", "profile"] {
+            let rejected = controls + ["\r\n"] + (field == "body" ? [] : ["\n"])
+            for control in rejected {
+                let replay = Replay()
+                let envelope = try encryptedField(field, value: "A" + control + "B")
+                XCTAssertThrowsError(try PushPreviewProcessor.decrypt(
+                    userInfo: envelope, environment: "sandbox", now: 2_000_000_010, keys: Keys(record), replay: replay
+                ), field) { error in
+                    XCTAssertEqual(error as? PushPreviewFailure, .malformedPlaintext)
+                }
+                XCTAssertTrue(replay.seen.isEmpty)
+            }
+        }
+    }
+
+    func testNativeOpenerPreservesUTF8FieldBoundsIncludingLF() throws {
+        let record = PreviewKeyRecord(key: Data(0..<32), keyID: kid, wake: wake, environment: "sandbox", createdAt: 0)
+        for (field, limit) in [("title", 160), ("body", 640), ("sid", 128), ("profile", 64)] {
+            let boundary = field == "body"
+                ? String(repeating: "é", count: 319) + "\na"
+                : String(repeating: "é", count: limit / 2)
+            for (value, accepted) in [(boundary, true), (boundary + "a", false), ("", false)] {
+                let envelope = try encryptedField(field, value: value)
+                let open = { try PushPreviewProcessor.decrypt(
+                    userInfo: envelope, environment: "sandbox", now: 2_000_000_010, keys: Keys(record), replay: Replay()
+                ) }
+                if accepted {
+                    let preview = try open()
+                    let actual = ["title": preview.title, "body": preview.body,
+                                  "sid": preview.routeSessionID, "profile": preview.routeProfile]
+                    XCTAssertEqual(actual[field] ?? nil, value, field)
+                } else {
+                    XCTAssertThrowsError(try open(), field) { error in
+                        XCTAssertEqual(error as? PushPreviewFailure, .malformedPlaintext)
+                    }
+                }
+            }
+        }
+    }
+
     func testHostGeneratedCiphertextOpensThroughNativeProcessor() throws {
         let environmentPath = ProcessInfo.processInfo.environment["MERCURY_HOST_PREVIEW_VECTOR"]
         let appSupportPath = FileManager.default.urls(

--- a/ios/MercuryUITests/FirstResponseNavigationBoundaryUITests.swift
+++ b/ios/MercuryUITests/FirstResponseNavigationBoundaryUITests.swift
@@ -42,6 +42,14 @@ final class FirstResponseNavigationBoundaryUITests: XCTestCase {
         try navigate(mode: "stale")
     }
 
+    func testLongAuthoritativeResumeDoesNotOfferMismatchedDurablePagination() throws {
+        try navigate(mode: "long")
+    }
+
+    func testEmptyResumeHistoryFallbackStillPaginates() throws {
+        try navigate(mode: "history")
+    }
+
     private func navigate(mode: String) throws {
         _ = try control(["action": "reset", "mode": mode])
         defer { _ = try? control(["action": "release"]) }
@@ -117,6 +125,27 @@ final class FirstResponseNavigationBoundaryUITests: XCTestCase {
         add(attachment)
         capture("reopened-after-followup-\(mode)", app)
         assertAnswer(app)
+        if mode == "long" {
+            let loadEarlier = app.buttons["Load earlier messages"]
+            XCTAssertTrue(loadEarlier.waitForExistence(timeout: 10),
+                          "The resume's first 25 local rows should be revealable")
+            loadEarlier.tap()
+            XCTAssertFalse(loadEarlier.waitForExistence(timeout: 2),
+                           "Resume-owned rows must not expose the durable page's offset")
+            let afterReveal = try control()
+            let reads = afterReveal["reads"] as? [[String: Any]] ?? []
+            XCTAssertFalse(reads.contains { ($0["offset"] as? Int ?? 0) > 0 },
+                           "No mismatched earlier-page request may be made")
+        } else if mode == "history" {
+            let loadEarlier = app.buttons["Load earlier messages"]
+            XCTAssertTrue(loadEarlier.waitForExistence(timeout: 10))
+            loadEarlier.tap()
+            XCTAssertTrue(app.staticTexts["Long synthetic row 001."].waitForExistence(timeout: 10))
+            let afterPage = try control()
+            let reads = afterPage["reads"] as? [[String: Any]] ?? []
+            XCTAssertTrue(reads.contains { ($0["offset"] as? Int) == 100 },
+                          "History-owned rows must retain ordinary durable pagination")
+        }
     }
 
     private func assertAnswer(_ app: XCUIApplication) {

--- a/ios/MercuryUITests/FirstResponseNavigationBoundaryUITests.swift
+++ b/ios/MercuryUITests/FirstResponseNavigationBoundaryUITests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import XCTest
+
+/// SYNTHETIC network experiment, not a reproduction on the user's host.
+/// Mounts release ChatView by tapping its real session NavigationLink; performs
+/// live completion -> native Back -> same session -> REST/resume/REST.
+/// Run ONLY on a disposable simulator with first_response_navigation_fake.py.
+final class FirstResponseNavigationBoundaryUITests: XCTestCase {
+    private let answerParts = ["Synthetic first answer alpha.", "Synthetic first answer omega."]
+    private var origin = ""
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        #if !targetEnvironment(simulator)
+        throw XCTSkip("Disposable simulator only; never navigate physical/private chats")
+        #endif
+        let args = ProcessInfo.processInfo.arguments
+        if let index = args.firstIndex(of: "-first-response-fake-origin"), args.indices.contains(index + 1) {
+            origin = args[index + 1]
+        } else {
+            origin = ProcessInfo.processInfo.environment["FIRST_RESPONSE_FAKE_ORIGIN"] ?? ""
+        }
+        guard let url = URL(string: origin), url.scheme == "http",
+              url.host == "127.0.0.1", url.port != nil else {
+            throw XCTSkip("Set FIRST_RESPONSE_FAKE_ORIGIN to the loopback synthetic server, with explicit port")
+        }
+        XCTAssertEqual(try control()["synthetic"] as? Bool, true)
+    }
+
+    func testFreshMultisegmentFirstAnswerSurvivesActualNavigation() throws {
+        try navigate(mode: "fresh")
+    }
+
+    func testDuplicateDurableAssistantRowsRetainFirstAnswerAfterNavigation() throws {
+        try navigate(mode: "duplicate")
+    }
+
+    /// Deliberately asserts the desired preservation invariant. Expected RED
+    /// on the current loader if the synthetic stale response replaces resume.
+    /// Do not convert this to an expected failure or call it a real-host race.
+    func testSyntheticStalePostResumeReadMustNotEraseFirstAnswer() throws {
+        try navigate(mode: "stale")
+    }
+
+    private func navigate(mode: String) throws {
+        _ = try control(["action": "reset", "mode": mode])
+        defer { _ = try? control(["action": "release"]) }
+        let app = XCUIApplication()
+        app.launchArguments = ["-uitest-reset-local-state", "-uitest-probe", origin]
+        app.launch()
+        let session = app.staticTexts["E2E Session"]
+        if !session.waitForExistence(timeout: 3) {
+            let login = app.buttons["Sign in with username and password"]
+            XCTAssertTrue(login.waitForExistence(timeout: 30))
+            login.tap()
+            let username = app.textFields["Username"]
+            XCTAssertTrue(username.waitForExistence(timeout: 10))
+            username.tap()
+            username.typeText("admin")
+            let password = app.secureTextFields["Password"]
+            password.tap()
+            password.typeText("e2epass") // public, disposable fake credential
+            app.buttons["Sign in"].tap()
+        }
+        XCTAssertTrue(session.waitForExistence(timeout: 30))
+        session.tap()
+        try awaitState { state in
+            let counts = state["rpc_counts"] as? [String: Int] ?? [:]
+            return counts["model.options", default: 0] >= 1
+        }
+        let composer = app.textFields["Message Hermes"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 15))
+        composer.tap()
+        composer.typeText("synthetic first navigation turn")
+        let send = app.buttons["Send message"]
+        let ready = XCTNSPredicateExpectation(predicate: NSPredicate(format: "enabled == true"), object: send)
+        XCTAssertEqual(XCTWaiter.wait(for: [ready], timeout: 15), .completed)
+        send.tap()
+        assertAnswer(app)
+        let stopped = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"),
+                                               object: app.buttons["Stop Hermes response"])
+        XCTAssertEqual(XCTWaiter.wait(for: [stopped], timeout: 10), .completed)
+        XCTAssertTrue(app.buttons["Send message"].waitForExistence(timeout: 10))
+        try awaitState { $0["completed"] as? Bool == true }
+        capture("first-completed", app)
+
+        // Native Back actually destroys the idle route; do not relaunch or
+        // reconstruct TranscriptState in place of this boundary.
+        let back = app.navigationBars.buttons.element(boundBy: 0)
+        XCTAssertTrue(back.exists)
+        XCTAssertTrue(back.label == "Back" || back.label == "Mercury",
+                      "Unexpected navigation control; refusing to tap another action")
+        back.tap()
+        XCTAssertTrue(app.navigationBars["Mercury"].waitForExistence(timeout: 15))
+        XCTAssertTrue(session.waitForExistence(timeout: 15))
+        _ = try control(["action": "arm"])
+        let before = try control()["rpc_counts"] as? [String: Int] ?? [:]
+        session.tap()
+        try awaitState { $0["held"] as? Bool == true }
+        assertAnswer(app) // full initial REST + resume visible before final read returns
+        capture("reopened-before-followup-\(mode)", app)
+        _ = try control(["action": "release"])
+        try awaitState { state in
+            let counts = state["rpc_counts"] as? [String: Int] ?? [:]
+            return state["released"] as? Bool == true
+                && counts["model.options", default: 0] > before["model.options", default: 0]
+        }
+        // model.options is requested only after loadTranscript returns and the
+        // connection is published. This is a network fence, not a guessed sleep.
+        let receipt = try control()
+        XCTAssertEqual((receipt["rpc_counts"] as? [String: Int])?["prompt.submit"], 1)
+        XCTAssertEqual((receipt["rpc_counts"] as? [String: Int])?["session.resume"], 2)
+        let attachment = XCTAttachment(data: try JSONSerialization.data(withJSONObject: receipt, options: [.prettyPrinted]),
+                                       uniformTypeIdentifier: "public.json")
+        attachment.name = "synthetic-network-order-\(mode)"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+        capture("reopened-after-followup-\(mode)", app)
+        assertAnswer(app)
+    }
+
+    private func assertAnswer(_ app: XCUIApplication) {
+        // Both paragraphs must survive, not just an assistant role/row count.
+        for part in answerParts {
+            XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", part))
+                .firstMatch.waitForExistence(timeout: 10), "Missing exact synthetic answer paragraph: \(part)")
+        }
+    }
+
+    private func capture(_ name: String, _ app: XCUIApplication) {
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = name
+        shot.lifetime = .keepAlways
+        add(shot)
+    }
+
+    private func awaitState(_ predicate: @escaping ([String: Any]) -> Bool) throws {
+        let deadline = Date().addingTimeInterval(30)
+        while Date() < deadline {
+            if predicate(try control()) { return }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        XCTFail("Synthetic network boundary not reached")
+        throw NSError(domain: "FirstResponseNavigationBoundary", code: 1)
+    }
+
+    private func control(_ body: [String: String]? = nil) throws -> [String: Any] {
+        var request = URLRequest(url: URL(string: origin + "/__test__/first-response-navigation")!)
+        request.timeoutInterval = 5
+        if let body {
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        }
+        let done = expectation(description: "synthetic-only control")
+        var output: Result<[String: Any], Error>?
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            defer { done.fulfill() }
+            do {
+                if let error { throw error }
+                guard (response as? HTTPURLResponse)?.statusCode == 200, let data,
+                      let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    throw NSError(domain: "FirstResponseNavigationBoundary", code: 2)
+                }
+                output = .success(object)
+            } catch { output = .failure(error) }
+        }.resume()
+        guard XCTWaiter.wait(for: [done], timeout: 6) == .completed, let output else {
+            throw NSError(domain: "FirstResponseNavigationBoundary", code: 3)
+        }
+        return try output.get()
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -18,14 +18,58 @@ settings:
     MARKETING_VERSION: "0.2.5"
     CURRENT_PROJECT_VERSION: 3
 
+# One producer shared by app, PreviewKit and extension. Never depend on the
+# app's build phases: the app itself depends on both notification targets.
+aggregateTargets:
+  MercuryCoreBuild:
+    targets: []
+    settings:
+      base:
+        SDKROOT: iphoneos
+        SUPPORTED_PLATFORMS: iphoneos iphonesimulator
+        IPHONEOS_DEPLOYMENT_TARGET: "17.0"
+        USER_SCRIPT_SANDBOXING: NO
+    buildScripts:
+      - name: Build MercuryCore KMP framework
+        basedOnDependencyAnalysis: false
+        outputFiles:
+          - $(BUILT_PRODUCTS_DIR)/MercuryCore.framework/MercuryCore
+          - $(BUILT_PRODUCTS_DIR)/MercuryCore.framework/Headers/MercuryCore.h
+          - $(BUILT_PRODUCTS_DIR)/MercuryCore.framework/Modules/module.modulemap
+        script: |
+          set -eu
+          # Static KMP frameworks must be linked, not embedded or signed.
+          if ! command -v java >/dev/null 2>&1 && [ -z "${JAVA_HOME:-}" ]; then
+            echo "error: building MercuryCore requires a JDK (brew install openjdk@17)"
+            exit 1
+          fi
+          case "$SDK_NAME" in
+            iphonesimulator*) KT_TARGET=IosSimulatorArm64; KT_DIR=iosSimulatorArm64 ;;
+            iphoneos*)        KT_TARGET=IosArm64;          KT_DIR=iosArm64 ;;
+            *) echo "error: unsupported SDK_NAME=$SDK_NAME for MercuryCore"; exit 1 ;;
+          esac
+          CONF_LC=$(printf %s "$CONFIGURATION" | tr '[:upper:]' '[:lower:]')
+          cd "$SRCROOT/.."
+          ./gradlew ":shared:mercury-core:link${CONFIGURATION}Framework${KT_TARGET}"
+          # Stage into this Xcode build's products, never a previous app build.
+          mkdir -p "$BUILT_PRODUCTS_DIR"
+          rsync -a --delete "$SRCROOT/../shared/mercury-core/build/bin/$KT_DIR/${CONF_LC}Framework/MercuryCore.framework" "$BUILT_PRODUCTS_DIR/"
+
 targets:
   MercuryNotificationPreviewKit:
-    type: framework
+    type: framework.static
     platform: iOS
     sources:
       - MercuryNotificationPreviewKit
+    dependencies:
+      - target: MercuryCoreBuild
     settings:
       base:
+        # A static adapter avoids a second Kotlin runtime inside a dynamic
+        # PreviewKit alongside the app's own static MercuryCore linkage.
+        MACH_O_TYPE: staticlib
+        APPLICATION_EXTENSION_API_ONLY: YES
+        FRAMEWORK_SEARCH_PATHS: $(inherited) $(BUILT_PRODUCTS_DIR)
         GENERATE_INFOPLIST_FILE: YES
         PRODUCT_BUNDLE_IDENTIFIER: com.unsupportedpastels.mercury.notificationpreviewkit
 
@@ -47,6 +91,9 @@ targets:
       - Resources
     dependencies:
       - target: MercuryNotificationPreviewKit
+        embed: false
+      - sdk: MercuryCore.framework
+        embed: false
       - target: MercuryNotificationService
         embed: true
       - target: MercuryShareKit
@@ -57,42 +104,13 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.unsupportedpastels.mercury
         CODE_SIGN_ENTITLEMENTS: Mercury/Mercury.entitlements
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        # Where Gradle drops the static MercuryCore KMP framework for Xcode
-        # consumption (see AGENTS.md, cross-platform rule).
-        FRAMEWORK_SEARCH_PATHS: $(inherited) $(SRCROOT)/../shared/mercury-core/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)
+        # Produced by MercuryCoreBuild before PreviewKit or app compilation.
+        FRAMEWORK_SEARCH_PATHS: $(inherited) $(BUILT_PRODUCTS_DIR)
       configs:
         Debug:
           MERCURY_APNS_ENVIRONMENT: development
         Release:
           MERCURY_APNS_ENVIRONMENT: production
-    # Builds the KMP framework before compiling Swift. MercuryCore is a hard
-    # dependency (AttachmentPolicy is a facade over it), so a JDK is required
-    # to build the iOS app — fail here with a clear message instead of a
-    # confusing "no such module MercuryCore" later.
-    preBuildScripts:
-      - name: Build MercuryCore KMP framework
-        basedOnDependencyAnalysis: false
-        script: |
-          set -eu
-          # Not embedAndSignAppleFrameworkForXcode: that task disables itself
-          # for a static framework with signing disallowed. Link the flavor
-          # Xcode asked for and copy it to the FRAMEWORK_SEARCH_PATHS dir.
-          if command -v java >/dev/null 2>&1 || [ -n "${JAVA_HOME:-}" ]; then
-            case "$SDK_NAME" in
-              iphonesimulator*) KT_TARGET=IosSimulatorArm64; KT_DIR=iosSimulatorArm64 ;;
-              iphoneos*)        KT_TARGET=IosArm64;          KT_DIR=iosArm64 ;;
-              *) echo "warning: unsupported SDK_NAME=$SDK_NAME for MercuryCore"; exit 0 ;;
-            esac
-            CONF_LC=$(printf %s "$CONFIGURATION" | tr '[:upper:]' '[:lower:]')
-            cd "$SRCROOT/.."
-            ./gradlew ":shared:mercury-core:link${CONFIGURATION}Framework${KT_TARGET}"
-            OUT="$SRCROOT/../shared/mercury-core/build/xcode-frameworks/$CONFIGURATION/$SDK_NAME"
-            mkdir -p "$OUT"
-            rsync -a --delete "$SRCROOT/../shared/mercury-core/build/bin/$KT_DIR/${CONF_LC}Framework/MercuryCore.framework" "$OUT/"
-          else
-            echo "error: building Mercury requires a JDK (brew install openjdk@17) to compile the MercuryCore KMP framework"
-            exit 1
-          fi
     info:
       path: Mercury/Info.plist
       properties:
@@ -160,8 +178,13 @@ targets:
       - MercuryNotificationService
     dependencies:
       - target: MercuryNotificationPreviewKit
+        embed: false
+      - sdk: MercuryCore.framework
+        embed: false
     settings:
       base:
+        APPLICATION_EXTENSION_API_ONLY: YES
+        FRAMEWORK_SEARCH_PATHS: $(inherited) $(BUILT_PRODUCTS_DIR)
         PRODUCT_BUNDLE_IDENTIFIER: com.unsupportedpastels.mercury.notification-service
         CODE_SIGN_ENTITLEMENTS: MercuryNotificationService/MercuryNotificationService.entitlements
       configs:
@@ -198,16 +221,19 @@ targets:
         buildPhase: resources
       - path: ../shared/mercury-core/src/commonTest/resources/push-preview/v1-vector.json
         buildPhase: resources
+      - path: ../shared/mercury-core/src/commonTest/resources/push-preview/host-multiline.json
+        buildPhase: resources
     settings:
       base:
         GENERATE_INFOPLIST_FILE: YES
         # @testable import Mercury exposes public signatures backed by the
         # static KMP module, so the test compiler must resolve MercuryCore too.
-        FRAMEWORK_SEARCH_PATHS: $(inherited) $(SRCROOT)/../shared/mercury-core/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)
+        FRAMEWORK_SEARCH_PATHS: $(inherited) $(BUILT_PRODUCTS_DIR)
     dependencies:
       - target: Mercury
       - target: MercuryShareKit
       - target: MercuryNotificationPreviewKit
+        embed: false
 
   # Live integration tests: hit an operator-supplied Hermes origin and Nous Portal.
   # Kept in a separate target so the default MercuryTests suite stays hermetic

--- a/shared/mercury-core/src/androidHostTest/kotlin/com/unsupportedpastels/mercury/core/notifications/PushPreviewCorpusTest.kt
+++ b/shared/mercury-core/src/androidHostTest/kotlin/com/unsupportedpastels/mercury/core/notifications/PushPreviewCorpusTest.kt
@@ -10,6 +10,25 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class PushPreviewCorpusTest {
+    @Test fun hostProducedMultilineFieldsUseSharedWirePolicy() {
+        val text = checkNotNull(javaClass.classLoader!!.getResourceAsStream("push-preview/host-multiline.json"))
+            .bufferedReader().use { it.readText() }
+        val rows = Json.parseToJsonElement(text).jsonArray
+        assertEquals(setOf("single", "lf", "crlf", "three"), rows.map { it.jsonObject["name"]!!.jsonPrimitive.content }.toSet())
+        assertEquals(4, rows.size)
+        for (rowElement in rows) {
+            val row = rowElement.jsonObject
+            val plain = Json.parseToJsonElement(row["plaintext"]!!.jsonPrimitive.content).jsonObject
+            val body = plain["body"]!!.jsonPrimitive.content
+            assertEquals(row["expected_body"]!!.jsonPrimitive.content, body)
+            assertEquals(true, PushPreviewFieldPolicy.validBody(body))
+            assertEquals(true, PushPreviewFieldPolicy.validTitle(plain["title"]!!.jsonPrimitive.content))
+            val route = plain["route"]!!.jsonObject
+            assertEquals(true, PushPreviewFieldPolicy.validSessionId(route["sid"]!!.jsonPrimitive.content))
+            assertEquals(true, PushPreviewFieldPolicy.validProfile(route["profile"]!!.jsonPrimitive.content))
+        }
+    }
+
     @Test fun canonicalPolicyCorpus() {
         val text = checkNotNull(javaClass.classLoader!!.getResourceAsStream("push-preview/policy-corpus.json")).bufferedReader().use { it.readText() }
         val rows = Json.parseToJsonElement(text).jsonObject["cases"]!!.jsonArray

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/notifications/PushPreviewFieldPolicy.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/notifications/PushPreviewFieldPolicy.kt
@@ -1,0 +1,46 @@
+package com.unsupportedpastels.mercury.core.notifications
+
+/**
+ * Wire validation, not display sanitization: preserve accepted text exactly.
+ * Only preview bodies allow LF, matching the host's normalized multiline excerpts.
+ * Titles and routing fields retain the frozen Foundation control-scalar contract.
+ */
+object PushPreviewFieldPolicy {
+    fun validTitle(value: String): Boolean = validField(value, PushPreviewContract.MAX_TITLE_UTF8_BYTES)
+
+    fun validBody(value: String): Boolean =
+        validField(value, PushPreviewContract.MAX_BODY_UTF8_BYTES, allowLineFeed = true)
+
+    fun validSessionId(value: String): Boolean = validField(value, PushPreviewContract.MAX_ROUTE_SESSION_UTF8_BYTES)
+
+    fun validProfile(value: String): Boolean = validField(value, PushPreviewContract.MAX_ROUTE_PROFILE_UTF8_BYTES)
+
+    private fun validField(value: String, maxBytes: Int, allowLineFeed: Boolean = false): Boolean {
+        if (value.encodeToByteArray().size !in 1..maxBytes) return false
+        var index = 0
+        while (index < value.length) {
+            val first = value[index++].code
+            val scalar = if (first in 0xd800..0xdbff && index < value.length && value[index].code in 0xdc00..0xdfff) {
+                0x10000 + ((first - 0xd800) shl 10) + (value[index++].code - 0xdc00)
+            } else first
+            if (legacyControlScalar(scalar) && !(allowLineFeed && scalar == 0x000a)) return false
+        }
+        return true
+    }
+
+    // Frozen from the existing Foundation CharacterSet.controlCharacters contract,
+    // characterized through the production Swift adapter for every Unicode scalar.
+    // Do not substitute Char.isISOControl or platform Unicode categories: those
+    // omit format characters, differ by Unicode version, and lose Foundation's
+    // plane-14 low-byte membership behavior. Changing that behavior is not this move.
+    private fun legacyControlScalar(value: Int): Boolean = when (value) {
+        in 0x0000..0x001f, in 0x007f..0x009f, 0x00ad,
+        in 0x0600..0x0605, 0x061c, 0x06dd, 0x070f, in 0x0890..0x0891, 0x08e2,
+        0x180e, in 0x200b..0x200f, in 0x202a..0x202e, in 0x2060..0x2064,
+        in 0x2066..0x206f, 0xfeff, in 0xfff9..0xfffb,
+        0x110bd, 0x110cd, in 0x13430..0x1343f, in 0x1bca0..0x1bca3,
+        in 0x1d173..0x1d17a -> true
+        in 0xe0000..0xeffff -> (value and 0xff) == 1 || (value and 0xff) in 0x20..0x7f
+        else -> false
+    }
+}

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/notifications/RelayPushRoutePolicy.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/notifications/RelayPushRoutePolicy.kt
@@ -25,36 +25,7 @@ object RelayPushRoutePolicy {
         if (result?.get("resolved") as? Boolean != true) return null
         val session = result["durable_session_id"] as? String ?: return null
         val profile = result["profile"] as? String ?: return null
-        if (!validField(session, MAX_SESSION_UTF8_BYTES) || !validField(profile, MAX_PROFILE_UTF8_BYTES)) return null
+        if (!PushPreviewFieldPolicy.validSessionId(session) || !PushPreviewFieldPolicy.validProfile(profile)) return null
         return RelayPushSessionRoute(session, profile)
-    }
-
-    private fun validField(value: String, maxBytes: Int): Boolean {
-        if (value.encodeToByteArray().size !in 1..maxBytes) return false
-        var index = 0
-        while (index < value.length) {
-            val first = value[index++].code
-            val scalar = if (first in 0xd800..0xdbff && index < value.length && value[index].code in 0xdc00..0xdfff) {
-                0x10000 + ((first - 0xd800) shl 10) + (value[index++].code - 0xdc00)
-            } else first
-            if (legacyControlScalar(scalar)) return false
-        }
-        return true
-    }
-
-    // Frozen from the existing Foundation CharacterSet.controlCharacters contract,
-    // characterized through the production Swift adapter for every Unicode scalar.
-    // Do not substitute Char.isISOControl or platform Unicode categories: those
-    // omit format characters, differ by Unicode version, and lose Foundation's
-    // plane-14 low-byte membership behavior. Changing that behavior is not this move.
-    private fun legacyControlScalar(value: Int): Boolean = when (value) {
-        in 0x0000..0x001f, in 0x007f..0x009f, 0x00ad,
-        in 0x0600..0x0605, 0x061c, 0x06dd, 0x070f, in 0x0890..0x0891, 0x08e2,
-        0x180e, in 0x200b..0x200f, in 0x202a..0x202e, in 0x2060..0x2064,
-        in 0x2066..0x206f, 0xfeff, in 0xfff9..0xfffb,
-        0x110bd, 0x110cd, in 0x13430..0x1343f, in 0x1bca0..0x1bca3,
-        in 0x1d173..0x1d17a -> true
-        in 0xe0000..0xeffff -> (value and 0xff) == 1 || (value and 0xff) in 0x20..0x7f
-        else -> false
     }
 }

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/InternalCompletionNotice.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/InternalCompletionNotice.kt
@@ -1,0 +1,46 @@
+package com.unsupportedpastels.mercury.core.transcript
+
+/**
+ * Presentation only. Verified against official tools/process_registry.py
+ * format_process_notification/_format_async_delegation and tui_gateway/server.py.
+ * Delegations carry display_kind=async_delegation_complete; process notices and
+ * older history have only text. Do not infer from generic IMPORTANT/delegate prose.
+ * Exact pasted envelopes are indistinguishable on older servers; retain every byte
+ * in the disclosure, and prefer explicit metadata (including unknown kinds).
+ */
+object InternalCompletionNotice {
+    fun isNotice(row: TranscriptRow): Boolean = isNotice(row.role, row.text, row.displayKind)
+
+    fun isNotice(role: String, text: String, displayKind: String?): Boolean {
+        if (role.lowercase() != "user") return false
+        if (!displayKind.isNullOrEmpty()) return displayKind == "async_delegation_complete"
+        if (processHeader.containsMatchIn(text) && text.endsWith("]")) {
+            val body = text.substringAfter('\n')
+            val command = if (body.startsWith("Started by subagent sa-")) {
+                body.substringAfter("\nCommand: ", "")
+            } else if (body.startsWith("Command: ")) body.removePrefix("Command: ") else return false
+            return command.contains("\nOutput:\n")
+        }
+        if (singleHeader.containsMatchIn(text)) {
+            return text.contains("\nOriginal goal: ") && text.contains("\nRole: ") &&
+                text.contains("\nStatus: ") && text.contains("   API calls: ") &&
+                text.contains("\n--- RESULT ---\n")
+        }
+        if (batchHeader.containsMatchIn(text)) {
+            return text.contains("\nRole: ") && text.contains("   Total duration: ") &&
+                (batchTask.containsMatchIn(text) || text.contains("\n--- ERROR ---\nThe batch did not complete successfully: "))
+        }
+        return false
+    }
+
+    private val processHeader = Regex(
+        """^\[IMPORTANT: Background process proc_[A-Za-z0-9]+ (?:completed normally|exited|failed to start|marked lost because the process backend disappeared|terminated by [^\n]+) \(exit code (?:-?\d+|\?)(?:, SIGTERM)?\)\.\n"""
+    )
+    private val singleHeader = Regex(
+        """^\[ASYNC DELEGATION COMPLETE — [A-Za-z0-9_-]+\]\nA background subagent you dispatched earlier has finished\. """
+    )
+    private val batchHeader = Regex(
+        """^\[ASYNC DELEGATION BATCH COMPLETE — [A-Za-z0-9_-]+\]\nA background fan-out of \d+ subagent\(s\) you dispatched earlier has finished\. """
+    )
+    private val batchTask = Regex("""\n--- [✓✗⚠] TASK \d+/\d+[^\n]* \(status=[^\n]+\) ---\n""")
+}

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/TranscriptEngine.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/TranscriptEngine.kt
@@ -37,6 +37,8 @@ data class TranscriptRow(
     val toolName: String? = null,
     /** Accumulated chain-of-thought for this assistant segment. */
     val reasoningText: String = "",
+    /** Official Hermes presentation metadata; never changes the wire role/content. */
+    val displayKind: String? = null,
 )
 
 enum class ToolRowState { Running, Completed }
@@ -62,6 +64,7 @@ data class RestoredMessage(
     val content: String,
     val toolName: String? = null,
     val reasoningText: String = "",
+    val displayKind: String? = null,
 )
 
 data class TranscriptSnapshot(
@@ -447,6 +450,7 @@ object TranscriptEngine {
             completed = true,
             toolName = message.toolName,
             reasoningText = message.reasoningText,
+            displayKind = message.displayKind,
         )
     }
 

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/TranscriptReadAuthority.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/TranscriptReadAuthority.kt
@@ -1,0 +1,14 @@
+package com.unsupportedpastels.mercury.core.transcript
+
+/** Authority for one durable read, not a sticky preference for a session's longest transcript. */
+enum class TranscriptReadAuthority(val publishesTranscript: Boolean) {
+    /** Initial history, explicit refresh/rewind, or fallback after an empty resume. */
+    History(true),
+    /** Official resume already supplied display rows; read only progress and pagination metadata. */
+    Resume(false),
+}
+
+object TranscriptReadPolicy {
+    fun afterResume(hasDisplayRows: Boolean): TranscriptReadAuthority =
+        if (hasDisplayRows) TranscriptReadAuthority.Resume else TranscriptReadAuthority.History
+}

--- a/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/TurnFolding.kt
+++ b/shared/mercury-core/src/commonMain/kotlin/com/unsupportedpastels/mercury/core/transcript/TurnFolding.kt
@@ -20,6 +20,14 @@ fun foldTranscriptTurns(rows: List<TranscriptRow>, turnActive: Boolean): List<Fo
     }
     val result = mutableListOf<FoldedTranscriptEntry>()
     fun emitTurn(turn: List<TranscriptRow>, active: Boolean) {
+        // A completion starts its own server turn, but is not a human prompt.
+        // Keep its disclosure separate from both the preceding and following
+        // assistant summary, including while the new summary is streaming.
+        if (turn.firstOrNull()?.let(InternalCompletionNotice::isNotice) == true) {
+            result += FoldedTranscriptEntry.TurnActivity(listOf(turn.first()), null)
+            emitTurn(turn.drop(1), active)
+            return
+        }
         if (active) {
             turn.forEach { row ->
                 val role = row.role.lowercase()

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/notifications/PushPreviewFieldPolicyTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/notifications/PushPreviewFieldPolicyTest.kt
@@ -1,0 +1,55 @@
+package com.unsupportedpastels.mercury.core.notifications
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PushPreviewFieldPolicyTest {
+    private val fields = listOf(
+        Triple("title", 160, PushPreviewFieldPolicy::validTitle),
+        Triple("body", 640, PushPreviewFieldPolicy::validBody),
+        Triple("sid", 128, PushPreviewFieldPolicy::validSessionId),
+        Triple("profile", 64, PushPreviewFieldPolicy::validProfile),
+    )
+
+    @Test fun hostNormalizedMultilineBodyIsAcceptedWithoutRelaxingOtherFields() {
+        for (value in listOf("Alpha", "Alpha\nBeta", "Alpha\nBeta\nGamma")) {
+            assertTrue(PushPreviewFieldPolicy.validBody(value))
+        }
+        for ((name, _, valid) in fields) {
+            assertEquals(name == "body", valid("Alpha\nBeta"), name)
+            assertFalse(valid("Alpha\r\nBeta"), name) // Host normalizes CRLF; wire CR remains invalid.
+        }
+    }
+
+    @Test fun onlyLFIsExemptFromFrozenFoundationControlScalars() {
+        val controls = listOf(
+            "\u0000", "\t", "\r", "\u000b", "\u000c", "\u001f", "\u007f", "\u0085",
+            "\u00ad", "\u061c", "\u0890", "\u200b", "\u200d", "\u202e", "\ufeff",
+            "\ud804\udcbd", "\ud80d\udc3f", "\ud834\udd73", "\udb40\udc01", "\udb40\udd01",
+        )
+        for ((name, _, valid) in fields) {
+            for (control in controls) assertFalse(valid("A${control}B"), name)
+            // Existing Foundation exceptions must not be replaced by Unicode categories.
+            for (value in listOf("\u2065", "\u2028", "\u2029", "\udb40\udd00", "\udb40\udd80")) {
+                assertTrue(valid(value), name)
+            }
+        }
+    }
+
+    @Test fun nonEmptyUTF8ByteBoundsRemainUnchanged() {
+        for ((name, limit, valid) in fields) {
+            assertFalse(valid(""), name)
+            assertTrue(valid("a".repeat(limit)), name)
+            assertFalse(valid("a".repeat(limit + 1)), name)
+            assertTrue(valid("é".repeat(limit / 2)), name)
+            assertFalse(valid("é".repeat(limit / 2) + "a"), name)
+            assertTrue(valid("\ud83d\ude00".repeat(limit / 4)), name)
+            assertFalse(valid("\ud83d\ude00".repeat(limit / 4) + "a"), name)
+            assertTrue(valid(" ../ spaced : name "), name)
+        }
+        assertTrue(PushPreviewFieldPolicy.validBody("é".repeat(319) + "\na"))
+        assertFalse(PushPreviewFieldPolicy.validBody("é".repeat(319) + "\naa"))
+    }
+}

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/FirstResponseReopenInvestigationTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/FirstResponseReopenInvestigationTest.kt
@@ -1,0 +1,96 @@
+package com.unsupportedpastels.mercury.core.transcript
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Synthetic lifecycle characterization, not a claim of device reproduction. */
+class FirstResponseReopenInvestigationTest {
+    private val sid = "first-response-synthetic"
+    private val prompt = "Explain the synthetic result."
+    private val answer = "FIRST ANSWER BEGIN\n\nThe synthetic result includes every paragraph.\n\nFIRST ANSWER END"
+
+    private fun completedFirstTurn(tools: Boolean = false): TranscriptSnapshot {
+        var state = TranscriptEngine.appendUserMessage(TranscriptEngine.initial(isNewSession = true), prompt)
+        if (tools) {
+            state = TranscriptEngine.apply(state, ChatEvent.MessageInterim(sid, "Checking the synthetic input.", false))
+            state = TranscriptEngine.apply(state, ChatEvent.ToolStart(sid, "tool-1", "fixture", "synthetic input"))
+            state = TranscriptEngine.apply(state, ChatEvent.ToolComplete(sid, "tool-1", "fixture", "synthetic result"))
+        }
+        state = TranscriptEngine.apply(state, ChatEvent.MessageStart(sid, null))
+        state = TranscriptEngine.apply(state, ChatEvent.MessageDelta(sid, answer))
+        state = TranscriptEngine.apply(state, ChatEvent.MessageComplete(sid, text = answer))
+        assertFalse(state.hasStreamingAssistant)
+        assertVisibleAnswer(state)
+        return state
+    }
+
+    private fun history(tools: Boolean = false): List<RestoredMessage> = buildList {
+        add(RestoredMessage("user", prompt))
+        if (tools) {
+            add(RestoredMessage("assistant", "Checking the synthetic input."))
+            add(RestoredMessage("tool", "synthetic result", toolName = "fixture"))
+        }
+        add(RestoredMessage("assistant", answer))
+    }
+
+    private fun assertVisibleAnswer(state: TranscriptSnapshot) {
+        val visibleAnswers = foldTranscriptTurns(state.rows, turnActive = false)
+            .filterIsInstance<FoldedTranscriptEntry.Message>()
+            .map { it.row }.filter { it.role == "assistant" }.map { it.text }
+        assertTrue(answer in visibleAnswers, "Full first answer must be a visible message, not merely an assistant row or hidden step")
+        assertEquals(1, visibleAnswers.count { it == answer })
+    }
+
+    @Test fun completedFirstResponseSurvivesLeaveAndFreshRestore() {
+        completedFirstTurn()
+        // Leaving releases the detail owner; reopening creates a fresh snapshot.
+        val reopened = TranscriptEngine.loadTranscript(TranscriptEngine.initial(), history())
+        assertVisibleAnswer(reopened)
+        assertFalse(reopened.hasStreamingAssistant)
+    }
+
+    @Test fun completedFirstToolTurnSurvivesLeaveAndFreshRestore() {
+        completedFirstTurn(tools = true)
+        val reopened = TranscriptEngine.loadTranscript(TranscriptEngine.initial(), history(tools = true))
+        assertVisibleAnswer(reopened)
+        assertEquals(listOf("Checking the synthetic input.", "synthetic result"),
+            foldTranscriptTurns(reopened.rows, false).filterIsInstance<FoldedTranscriptEntry.TurnActivity>()
+                .flatMap { it.steps }.map { it.text })
+    }
+
+    @Test fun completedFirstResponseSurvivesForegroundReconciliation() {
+        val live = completedFirstTurn(tools = true)
+        val result = TranscriptEngine.reconcileForegroundTranscript(live, history(tools = true), turnWasActive = false)
+        assertVisibleAnswer(result.state)
+        assertFalse(result.keptLocalSuffix)
+    }
+
+    @Test fun firstResponseSurvivesResumeThenSecondDurableLoad() {
+        completedFirstTurn(tools = true)
+        var reopened = TranscriptEngine.loadTranscript(TranscriptEngine.initial(), history(tools = true))
+        reopened = TranscriptEngine.loadTranscript(reopened, history(tools = true))
+        reopened = TranscriptEngine.finishStreamingAssistant(reopened)
+        assertVisibleAnswer(reopened)
+    }
+
+    @Test fun firstResponseSurvivesNoticeAndFollowupSummaryOnReopen() {
+        completedFirstTurn(tools = true)
+        val persisted = history(tools = true) + listOf(
+            RestoredMessage("user", "Synthetic completion envelope", displayKind = "async_delegation_complete"),
+            RestoredMessage("assistant", "Later synthetic summary.")
+        )
+        assertVisibleAnswer(TranscriptEngine.loadTranscript(TranscriptEngine.initial(), persisted))
+    }
+
+    @Test fun firstResponseSurvivesOlderPagePrepend() {
+        completedFirstTurn(tools = true)
+        val persisted = history(tools = true)
+        var reopened = TranscriptEngine.loadTranscript(TranscriptEngine.initial(), persisted.takeLast(1))
+        assertVisibleAnswer(reopened)
+        reopened = TranscriptEngine.prependHistory(reopened, persisted.dropLast(1))
+        assertVisibleAnswer(reopened)
+        assertEquals(persisted.map { it.content }, reopened.rows.map { it.text })
+    }
+}

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/InternalCompletionNoticeTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/InternalCompletionNoticeTest.kt
@@ -1,0 +1,88 @@
+package com.unsupportedpastels.mercury.core.transcript
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class InternalCompletionNoticeTest {
+    @Test fun officialMetadataWinsAndSurvivesRestoreAndReconcile() {
+        val message = RestoredMessage("user", "Future formatted result", displayKind = "async_delegation_complete")
+        val state = TranscriptEngine.loadTranscript(TranscriptEngine.initial(), listOf(message))
+        assertTrue(InternalCompletionNotice.isNotice(state.rows.single()))
+        assertEquals("async_delegation_complete", state.rows.single().displayKind)
+        val reconciled = TranscriptEngine.reconcileForegroundTranscript(state, listOf(message), false).state
+        assertTrue(foldTranscriptTurns(reconciled.rows, false).single() is FoldedTranscriptEntry.TurnActivity)
+        assertFalse(InternalCompletionNotice.isNotice("assistant", process, "async_delegation_complete"))
+        assertFalse(InternalCompletionNotice.isNotice("user", process, "future_other_kind"))
+    }
+
+    @Test fun processTerminalVariantsAndDelegatedAttributionAreRecognized() {
+        for (status in listOf("completed normally", "exited", "terminated by Hermes", "failed to start",
+            "marked lost because the process backend disappeared")) {
+            val notice = process.replace("completed normally", status).replace("exit code 0", "exit code -15, SIGTERM")
+                .replace("\nCommand:", "\nStarted by subagent sa-123 of delegation deleg_123. Task: \"Checks\"\nCommand:")
+            assertTrue(InternalCompletionNotice.isNotice("user", notice, null), status)
+        }
+        assertFalse(InternalCompletionNotice.isNotice("user", process.removeSuffix("]"), null))
+        assertFalse(InternalCompletionNotice.isNotice("user", process + " explain this", null))
+        assertFalse(InternalCompletionNotice.isNotice("user", "[IMPORTANT: Background process proc_123 matched watch pattern \"ready\".\nCommand: run\nMatched output:\nready]", null))
+    }
+
+    @Test fun officialSingleBatchAndErrorDelegationsUseNarrowEnvelopeFallback() {
+        val single = "[ASYNC DELEGATION COMPLETE — deleg_123]\nA background subagent you dispatched earlier has finished. You may have moved on since dispatching it; the full task source is below so you can act on the result or re-dispatch if things have changed.\n\nOriginal goal: checks\nRole: leaf   Model: model\nStatus: completed   API calls: 2   Duration: 3s\n--- RESULT ---\nPassed"
+        val batch = "[ASYNC DELEGATION BATCH COMPLETE — deleg_123]\nA background fan-out of 1 subagent(s) you dispatched earlier has finished. All ran in parallel and waited on each other; their consolidated results are below. You may have moved on since dispatching — act on these or re-dispatch if things have changed.\n\nRole: leaf   Model: model   Total duration: 3s\n"
+        for (notice in listOf(single, batch + "\n--- ✓ TASK 1/1: checks  (status=completed, 3s) ---\nPassed",
+            batch + "--- ERROR ---\nThe batch did not complete successfully: stopped")) {
+            assertTrue(InternalCompletionNotice.isNotice("user", notice, null))
+            assertFalse(InternalCompletionNotice.isNotice("user", "Explain $notice", null))
+            assertFalse(InternalCompletionNotice.isNotice("assistant", notice, null))
+            assertFalse(InternalCompletionNotice.isNotice("user", notice.substringBefore('\n'), null))
+        }
+    }
+
+    @Test fun actualLiveAppendAndAssistantDeltasKeepNoticeCollapsed() {
+        val state = TranscriptEngine.appendUserMessage(TranscriptEngine.initial(), process)
+        val live = TranscriptEngine.apply(state, ChatEvent.MessageDelta("s", "Checks passed."))
+        val folded = foldTranscriptTurns(live.rows, true)
+        assertTrue(folded.first() is FoldedTranscriptEntry.TurnActivity)
+        assertEquals("Checks passed.", (folded.last() as FoldedTranscriptEntry.Message).row.text)
+        assertEquals(process, live.rows.first().text)
+    }
+
+    private val process = "[IMPORTANT: Background process proc_f05837cd4d75 completed normally (exit code 0).\nCommand: python check.py\nOutput:\nverified]"
+    private fun row(id: Long, role: String, text: String) = TranscriptRow(id, role, text, true)
+
+    @Test fun completionIsActivityWhileLiveAndAfterHistoryRestoreWithoutLosingSummaries() {
+        for (active in listOf(false, true)) {
+            val messages = listOf(RestoredMessage("user", "run checks"), RestoredMessage("assistant", "Started checks."),
+                RestoredMessage("user", process), RestoredMessage("assistant", "Checks passed."))
+            val state = TranscriptEngine.loadTranscript(TranscriptEngine.initial(), messages)
+            val folded = foldTranscriptTurns(state.rows, active)
+            assertEquals(listOf("run checks", "Started checks.", "Checks passed."),
+                folded.filterIsInstance<FoldedTranscriptEntry.Message>().map { it.row.text })
+            val notice = folded.filterIsInstance<FoldedTranscriptEntry.TurnActivity>().single().steps.single()
+            assertSame(state.rows[2], notice)
+            assertEquals(process, notice.text)
+            assertEquals("user", notice.role)
+        }
+    }
+
+    @Test fun ordinaryUserTextQuotesAndAssistantNotificationsStayVisible() {
+        for (text in listOf("IMPORTANT: run checks", "Please explain $process", "> $process", "```\n$process\n```",
+            "\"$process\"", "[IMPORTANT: Background process proc_f05837cd4d75 completed normally (exit code 0).]")) {
+            val source = row(1, "user", text)
+            assertEquals(listOf(FoldedTranscriptEntry.Message(source)), foldTranscriptTurns(listOf(source), false))
+        }
+        val assistant = row(1, "assistant", process)
+        assertEquals(listOf(FoldedTranscriptEntry.Message(assistant)), foldTranscriptTurns(listOf(assistant), false))
+    }
+
+    @Test fun noticeOnlyHistoryAndPaginationStillOfferDisclosure() {
+        val state = TranscriptEngine.prependHistory(TranscriptEngine.initial(), listOf(RestoredMessage("user", process)))
+        for (active in listOf(false, true)) {
+            assertTrue(foldTranscriptTurns(state.rows, active).single() is FoldedTranscriptEntry.TurnActivity)
+        }
+    }
+}

--- a/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/TranscriptReadAuthorityTest.kt
+++ b/shared/mercury-core/src/commonTest/kotlin/com/unsupportedpastels/mercury/core/transcript/TranscriptReadAuthorityTest.kt
@@ -1,0 +1,40 @@
+package com.unsupportedpastels.mercury.core.transcript
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TranscriptReadAuthorityTest {
+    @Test fun nonemptyResumeOwnsDisplayAndEmptyResumeFallsBack() {
+        assertEquals(TranscriptReadAuthority.Resume, TranscriptReadPolicy.afterResume(true))
+        assertFalse(TranscriptReadPolicy.afterResume(true).publishesTranscript)
+        assertEquals(TranscriptReadAuthority.History, TranscriptReadPolicy.afterResume(false))
+        assertTrue(TranscriptReadPolicy.afterResume(false).publishesTranscript)
+    }
+
+    @Test fun historyAuthorityIsNotStickyAndAllowsInitialReplacementAndRewind() {
+        val initial = listOf(RestoredMessage("user", "Question"), RestoredMessage("assistant", "Alpha"),
+            RestoredMessage("assistant", "Omega"))
+        var state = TranscriptEngine.initial()
+        if (TranscriptReadAuthority.History.publishesTranscript) {
+            state = TranscriptEngine.loadTranscript(state, initial)
+        }
+        val authoritative = state
+        for (durable in listOf(initial.take(1), initial, initial + initial)) {
+            if (TranscriptReadPolicy.afterResume(true).publishesTranscript) {
+                state = TranscriptEngine.loadTranscript(state, durable)
+            }
+            assertEquals(authoritative, state)
+        }
+        // A subsequent explicit history operation is free to replace even with zero rows.
+        if (TranscriptReadAuthority.History.publishesTranscript) {
+            state = TranscriptEngine.loadTranscript(state, emptyList())
+        }
+        assertTrue(state.rows.isEmpty())
+        if (TranscriptReadPolicy.afterResume(false).publishesTranscript) {
+            state = TranscriptEngine.loadTranscript(state, initial)
+        }
+        assertEquals(initial.map { it.content }, state.rows.map { it.text })
+    }
+}

--- a/shared/mercury-core/src/commonTest/resources/push-preview/host-multiline.README.md
+++ b/shared/mercury-core/src/commonTest/resources/push-preview/host-multiline.README.md
@@ -1,0 +1,22 @@
+# Host-produced multiline preview regression fixture
+
+`host-multiline.json` is the unmodified synthetic corpus produced by the installed
+Mercury Relay host plugin's `build_preview_plaintext` and `encrypt_preview`, not
+by a client reimplementation. Producer source SHA-256:
+`152256b8b1cf669f1ad8a98be0fc2baeb112faea5b13ddbe0d21f3afc4264169`.
+Fixture SHA-256: `ed85fd2d9c2dca7978ec82bc585e6f930cab425b695757e6a1671ca83edf3814`.
+
+All inputs and keys are synthetic public test material. Environment is `sandbox`,
+issued time is `2000000000`, TTL is 120 seconds, opener time is `2000000010`.
+The producer was called with completion kind, title `Synthetic preview`, both
+preview fields enabled, and route `synthetic-session` / `default`. Keys/wake/event/
+key ID are the sequential byte values encoded in each row; nonce is the row
+index as 12 big-endian bytes. Never use these deterministic values for real pushes.
+
+Inputs cover a single line, LF, CRLF, and three lines. The host normalizes CRLF to
+LF; the client must accept that authenticated LF body without accepting a raw
+CR, or LF in title/session/profile. Swift tests bundle the fixture and open its
+actual ciphertext through `PushPreviewProcessor.decrypt` without an optional
+external fixture or skip. Shared host tests consume the same plaintext fields.
+The original native RED accepted single-line and rejected the other three with
+`malformedPlaintext`; its independent field/control negatives remained rejected.

--- a/shared/mercury-core/src/commonTest/resources/push-preview/host-multiline.json
+++ b/shared/mercury-core/src/commonTest/resources/push-preview/host-multiline.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": "single",
+    "input": "Alpha",
+    "plaintext": "{\"v\":1,\"kind\":\"completion\",\"title\":\"Synthetic preview\",\"body\":\"Alpha\",\"route\":{\"sid\":\"synthetic-session\",\"profile\":\"default\"},\"iat\":2000000000,\"exp\":2000000120}",
+    "expected_body": "Alpha",
+    "key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+    "wake": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+    "event": "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8",
+    "kid": "AAECAwQFBgcICQoLDA0ODw",
+    "nonce": "AAAAAAAAAAAAAAAA",
+    "ct": "Y5o0E5fXivN4CDIFjXlsRJfcg5mE2TIzgtrQMF5cATAXKjJPgpdSKfXkLE0HLnBO_tafO6l_dexvRS4GE694jC6CRb2FZrCnA9L-igu0CRkTShsUfcjNzp2U9FW66YDP981xaOMzZQa470z_NHU5EqLFmlopkcWDn-0W8Bzpv0qG3zP6xQwLToCoCWCD0uiC6vxNi2WFzIPBBGaxWmOH__VQLDX3x1NIi67urYMSwAU"
+  },
+  {
+    "name": "lf",
+    "input": "Alpha\nBeta",
+    "plaintext": "{\"v\":1,\"kind\":\"completion\",\"title\":\"Synthetic preview\",\"body\":\"Alpha\\nBeta\",\"route\":{\"sid\":\"synthetic-session\",\"profile\":\"default\"},\"iat\":2000000000,\"exp\":2000000120}",
+    "expected_body": "Alpha\nBeta",
+    "key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+    "wake": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+    "event": "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8",
+    "kid": "AAECAwQFBgcICQoLDA0ODw",
+    "nonce": "AAAAAAAAAAAAAAAB",
+    "ct": "En4K-ws7lFhGGBBLkS41cX-cTyyrxZUaKxiZCl2H62a2D9Yo4ILA90ktn03Fw9q8oIgsFv5JeBcGVHQ3TS0NOHOiCNueVMtICREH4ZP1OGP8ZVqMS7TVoI2Tgl3iT-7eXqRlyyRMOCwQmetm9W9ibWz1ju1bQyE2SB-TRHFkhdDwPP-ljhcxe8r1B6eU5yQnj_Fej8PZTi6pWBfQsYYg7JUF1PQnLpiPgfvoYFZZokwhLszWS8c"
+  },
+  {
+    "name": "crlf",
+    "input": "Alpha\r\nBeta",
+    "plaintext": "{\"v\":1,\"kind\":\"completion\",\"title\":\"Synthetic preview\",\"body\":\"Alpha\\nBeta\",\"route\":{\"sid\":\"synthetic-session\",\"profile\":\"default\"},\"iat\":2000000000,\"exp\":2000000120}",
+    "expected_body": "Alpha\nBeta",
+    "key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+    "wake": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+    "event": "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8",
+    "kid": "AAECAwQFBgcICQoLDA0ODw",
+    "nonce": "AAAAAAAAAAAAAAAC",
+    "ct": "NujG1TBMS3amV9ap78pre0ieaqJ08ICC6h39EQEJyLKNSASxt77JC9G7yoX-Xf8L_e8rlwHKJ0hYQ_yu1AAMgjf7-Q5R-P1sZfar9yC7ONNDD4RuhbxYJddI2kzjAyQSG9ZcdAUGGhOYVUSxZoGsMdPq41KptGuxmeSm47wOSceIwOzqmTNAK9dVxtKFHb31xnNTUCV020VPCLGgr3ZOAnEqXEAXuGzVCMPp5t-ytG03Jg5VO5w"
+  },
+  {
+    "name": "three",
+    "input": "Alpha\nBeta\nGamma",
+    "plaintext": "{\"v\":1,\"kind\":\"completion\",\"title\":\"Synthetic preview\",\"body\":\"Alpha\\nBeta\\nGamma\",\"route\":{\"sid\":\"synthetic-session\",\"profile\":\"default\"},\"iat\":2000000000,\"exp\":2000000120}",
+    "expected_body": "Alpha\nBeta\nGamma",
+    "key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+    "wake": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+    "event": "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8",
+    "kid": "AAECAwQFBgcICQoLDA0ODw",
+    "nonce": "AAAAAAAAAAAAAAAD",
+    "ct": "-2dqmQh7iFPjJpJumd20IAixPKulqTYoZSgqStXc9a4c_4EGUBphm-cIhIO-HdicEnYiYN-VAYUzl7arlH2T1FkCnXe0LqcW2H2n6lpuIJHhMgH_moMfmvl8jVksSl2EFale8ONu0t8mZ5T1BfpYrhHmLYqrVOsTJzC1JqH1YEmzYgnwmApUcIIfjwUKkVwhWVx4Fk3heHPG1qNwqScPXq8ovcN_ud6RmLGy-__gHl6ARlyTNPplsnQe532y"
+  }
+]

--- a/tools/fake-hermes/first_response_navigation_fake.py
+++ b/tools/fake-hermes/first_response_navigation_fake.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""SYNTHETIC first-answer navigation lab; not evidence of a real host race.
+
+Run on the disposable simulator's Mac: python3 first_response_navigation_fake.py 8793
+Uses existing fake authentication/WS framing; never connects to real Hermes.
+Loopback-only test controls hold the *post-resume* REST read until UI inspection.
+Fresh and stale modes differ only in that held response's final assistant rows.
+"""
+import json
+import sys
+import threading
+from urllib.parse import parse_qs, urlsplit
+
+import fake_hermes as base
+
+ANSWER = "Synthetic first answer alpha.\n\nSynthetic first answer omega."
+PROMPT = "synthetic first navigation turn"
+CONTROL = "/__test__/first-response-navigation"
+LOCK = threading.RLock()
+RELEASE = threading.Event()
+STATE = {}
+
+
+def reset(mode="fresh"):
+    with LOCK:
+        STATE.clear()
+        STATE.update(mode=mode, armed=False, resumed=False, held=False,
+                     released=False, completed=False, reads=[], rpc_counts={})
+        RELEASE.clear()
+        base.reset_synthetic_state()
+
+
+def rows():
+    if not STATE["completed"]:
+        return []
+    result = [
+        {"id": 1, "role": "user", "content": PROMPT},
+        {"id": 2, "role": "assistant", "content": "Synthetic intermediate commentary.",
+         "tool_calls": [{"id": "synthetic-tool", "type": "function", "function": {
+             "name": "terminal", "arguments": "{}"}}]},
+        {"id": 3, "role": "tool", "tool_name": "terminal", "tool_call_id": "synthetic-tool",
+         "content": "Synthetic tool result."},
+        {"id": 4, "role": "assistant", "content": ANSWER},
+    ]
+    if STATE["mode"] == "duplicate":
+        result.append(dict(result[-1], id=5))
+    return result
+
+
+def snapshot():
+    with LOCK:
+        return json.loads(json.dumps(dict(STATE, synthetic=True)))
+
+
+class NavigationHandler(base.Handler):
+    def do_GET(self):
+        parts = urlsplit(self.path)
+        if parts.path == CONTROL:
+            self.send_json(snapshot())
+            return
+        if parts.path == f"/api/sessions/{base.DURABLE_SESSION_ID}/messages":
+            if not self.require_auth():
+                return
+            query = parse_qs(parts.query)
+            limit = min(500, max(1, int(query.get("limit", [100])[0])))
+            offset = max(0, int(query.get("offset", [0])[0]))
+            latest = query.get("order", ["latest"])[0] == "latest"
+            with LOCK:
+                hold = STATE["armed"] and STATE["resumed"] and not STATE["held"]
+                if hold:
+                    STATE["held"] = True
+                source = rows()
+                if hold and STATE["mode"] == "stale":
+                    source = source[:3]  # deliberately old successful durable snapshot
+                selected = list(reversed(source)) if latest else source
+                selected = selected[offset:offset + limit]
+                if latest:
+                    selected.reverse()
+                receipt = dict(phase="post-resume" if hold else "initial-or-other",
+                               offset=offset, limit=limit, order="latest" if latest else "oldest",
+                               ids=[r["id"] for r in selected], roles=[r["role"] for r in selected])
+                STATE["reads"].append(receipt)
+            if hold and not RELEASE.wait(45):
+                self.send_json({"error": "synthetic gate timed out"}, status=504)
+                return
+            self.send_json({"session_id": base.DURABLE_SESSION_ID, "messages": selected,
+                            "pagination": {"limit": limit, "offset": offset,
+                                           "order": receipt["order"], "returned": len(selected)}})
+            if hold:
+                with LOCK:
+                    STATE["released"] = True
+            return
+        super().do_GET()
+
+    def do_POST(self):
+        if urlsplit(self.path).path != CONTROL:
+            return super().do_POST()
+        body = self.read_body_json()
+        action = body.get("action")
+        if action == "reset" and body.get("mode") in {"fresh", "stale", "duplicate"}:
+            reset(body["mode"])
+        elif action == "arm":
+            with LOCK:
+                STATE["armed"] = True
+                STATE["resumed"] = False
+        elif action == "release":
+            RELEASE.set()
+        else:
+            self.send_json({"error": "invalid synthetic control"}, status=400)
+            return
+        self.send_json(snapshot())
+
+
+class NavigationSession(base.WsSession):
+    def handle_rpc(self, text):
+        message = json.loads(text)
+        method = message.get("method")
+        with LOCK:
+            counts = STATE["rpc_counts"]
+            counts[method] = counts.get(method, 0) + 1
+        if method == "session.resume":
+            with LOCK:
+                history = rows()
+                if STATE["armed"]:
+                    STATE["resumed"] = True
+            # Official resume projects assistant/user to text, tool to name/context.
+            projected = [{"role": r["role"], **(
+                {"name": r["tool_name"], "context": "synthetic"} if r["role"] == "tool"
+                else {"text": r["content"]})} for r in history]
+            self.respond(message["id"], {"session_id": base.RUNTIME_SESSION_ID,
+                         "session_key": base.DURABLE_SESSION_ID, "messages": projected,
+                         "running": False, "resumed": True,
+                         "info": {"provider": "fake", "model": "fake-model"}})
+            return
+        if method == "prompt.submit":
+            self.respond(message["id"], {"status": "streaming"})
+            self.push_event("message.start", {})
+            self.push_event("message.delta", {"text": ANSWER})
+            with LOCK:
+                STATE["completed"] = True
+            self.push_event("message.complete", {"text": ANSWER, "status": "completed"})
+            return
+        super().handle_rpc(text)
+
+
+def main():
+    reset()
+    base.WsSession = NavigationSession
+    server = base.SafeThreadingHTTPServer(("127.0.0.1", int(sys.argv[1]) if len(sys.argv) > 1 else 8793), NavigationHandler)
+    try:
+        server.serve_forever()
+    finally:
+        RELEASE.set()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/fake-hermes/first_response_navigation_fake.py
+++ b/tools/fake-hermes/first_response_navigation_fake.py
@@ -33,6 +33,18 @@ def reset(mode="fresh"):
 def rows():
     if not STATE["completed"]:
         return []
+    if STATE["mode"] in {"long", "history"}:
+        result = [
+            {
+                "id": index,
+                "role": "user" if index % 2 else "assistant",
+                "content": f"Long synthetic row {index:03d}.",
+            }
+            for index in range(1, 124)
+        ]
+        result.append({"id": 124, "role": "user", "content": PROMPT})
+        result.append({"id": 125, "role": "assistant", "content": ANSWER})
+        return result
     result = [
         {"id": 1, "role": "user", "content": PROMPT},
         {"id": 2, "role": "assistant", "content": "Synthetic intermediate commentary.",
@@ -97,7 +109,7 @@ class NavigationHandler(base.Handler):
             return super().do_POST()
         body = self.read_body_json()
         action = body.get("action")
-        if action == "reset" and body.get("mode") in {"fresh", "stale", "duplicate"}:
+        if action == "reset" and body.get("mode") in {"fresh", "stale", "duplicate", "long", "history"}:
             reset(body["mode"])
         elif action == "arm":
             with LOCK:
@@ -121,6 +133,8 @@ class NavigationSession(base.WsSession):
         if method == "session.resume":
             with LOCK:
                 history = rows()
+                if STATE["mode"] == "history" and STATE["armed"]:
+                    history = []
                 if STATE["armed"]:
                     STATE["resumed"] = True
             # Official resume projects assistant/user to text, tool to name/context.

--- a/tools/fake-hermes/first_response_persisted_contract_probe.py
+++ b/tools/fake-hermes/first_response_persisted_contract_probe.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Synthetic disposable SessionDB contract probe; no host session/network access.
+
+Exercise installed Mercury read adapter against real official SessionDB APIs.
+This does NOT execute session.resume or a mounted client; it compares that
+RPC's documented source reader with the adapter's actual dispatched payload.
+Run with Hermes' venv and explicit source locations (see navigation report).
+Only roles, fixture IDs, counts and source hashes are printed.
+"""
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hermes-source", type=Path, required=True)
+    parser.add_argument("--relay-source", type=Path, required=True)
+    args = parser.parse_args()
+    with tempfile.TemporaryDirectory(prefix="first-response-contract-") as directory:
+        os.environ["HERMES_HOME"] = directory
+        sys.path[:0] = [str(args.hermes_source), str(args.relay_source / "src")]
+        from hermes_state import SessionDB
+        from mercury_relay_plugin.session_reads import SessionReads
+
+        class UnusedFolders:
+            def list_folders(self, *args):
+                raise AssertionError("not a folder probe")
+
+            def create_folder(self, *args):
+                raise AssertionError("not a folder probe")
+
+        path = Path(directory) / "state.db"
+        db = SessionDB(path)
+        db.create_session("synthetic-root", "cli")
+        for role, content in [("user", "synthetic first ask"),
+                              ("assistant", "synthetic first answer")]:
+            db.append_message("synthetic-root", role, content)
+        db.end_session("synthetic-root", "compression")
+        db.create_session("synthetic-tip", "cli", parent_session_id="synthetic-root")
+        db.append_message("synthetic-tip", "user", "synthetic second ask")
+        db.append_message("synthetic-tip", "assistant", "synthetic second answer")
+        db.close()
+        reader = SessionDB(path, read_only=True)
+        resolved = reader.resolve_resume_session_id(reader.resolve_session_id("synthetic-root"))
+        lineage = reader.get_messages_as_conversation(resolved, include_ancestors=True, include_row_ids=True)
+        official_page = reader.get_messages(resolved, limit=100, offset=0, latest=True)
+        reader.close()
+        adapter = SessionReads(db_opener=lambda _: SessionDB(path, read_only=True),
+                               folder_service=UnusedFolders())
+        relay = asyncio.run(adapter.dispatch("relay.session.transcript", {
+            "profile": "default", "session_id": "synthetic-root",
+            "limit": 100, "offset": 0, "order": "latest"}))
+        assert relay["messages"] == official_page
+        summary = lambda rows: {"count": len(rows), "roles": [r["role"] for r in rows],
+                                "ids": [r.get("id", r.get("_row_id")) for r in rows]}
+        print(json.dumps({
+            "synthetic": True, "real_host_data_read": False, "resolved_id": resolved,
+            "resume_source_reader_not_rpc": summary(lineage),
+            "official_latest_page_reader": summary(official_page),
+            "installed_relay_dispatch": summary(relay["messages"]),
+            "pagination": relay["pagination"],
+            "sources": {str(p): hashlib.sha256(p.read_bytes()).hexdigest() for p in [
+                args.hermes_source / "hermes_state.py",
+                args.relay_source / "src/mercury_relay_plugin/session_reads.py"]},
+        }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/fake-hermes/test_first_response_navigation_fake.py
+++ b/tools/fake-hermes/test_first_response_navigation_fake.py
@@ -57,7 +57,10 @@ class FirstResponseNavigationFakeWireTests(unittest.TestCase):
         initial = self.history()["messages"]
         self.assertEqual(initial[-1]["content"], lab.ANSWER)
         _, resumed = self.resume()
-        self.assertEqual(resumed["messages"][-1]["text"], lab.ANSWER)
+        if mode == "history":
+            self.assertEqual(resumed["messages"], [])
+        else:
+            self.assertEqual(resumed["messages"][-1]["text"], lab.ANSWER)
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
             pending = pool.submit(self.history)
             deadline = time.monotonic() + 1
@@ -94,6 +97,24 @@ class FirstResponseNavigationFakeWireTests(unittest.TestCase):
         older = self.history(limit=2, offset=2)["messages"]
         oldest = self.history(limit=2, offset=4)["messages"]
         self.assertEqual([r["id"] for r in oldest + older + newest], [1, 2, 3, 4, 5])
+
+    def test_long_resume_overlaps_bounded_durable_window(self):
+        initial, followup = self.drive("long")
+        self.assertEqual(len(initial), 100)
+        self.assertEqual(initial, followup)
+        self.assertEqual(initial[0]["id"], 26)
+        self.assertEqual(initial[-1]["id"], 125)
+        _, resumed = self.resume()
+        self.assertEqual(len(resumed["messages"]), 125)
+        self.assertEqual(resumed["messages"][0]["text"], "Long synthetic row 001.")
+
+    def test_empty_resume_leaves_durable_history_paginatable(self):
+        initial, followup = self.drive("history")
+        self.assertEqual(len(initial), 100)
+        self.assertEqual(initial, followup)
+        oldest = self.history(limit=50, offset=100)["messages"]
+        self.assertEqual(len(oldest), 25)
+        self.assertEqual(oldest[0]["id"], 1)
 
 
 if __name__ == "__main__":

--- a/tools/fake-hermes/test_first_response_navigation_fake.py
+++ b/tools/fake-hermes/test_first_response_navigation_fake.py
@@ -1,0 +1,100 @@
+"""Verify the synthetic network lab itself, NOT Mercury behavior or real data."""
+import concurrent.futures
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+import first_response_navigation_fake as lab
+from test_fake_hermes import _json_request, _open_websocket, _prompt_completion, _rpc
+
+
+class FirstResponseNavigationFakeWireTests(unittest.TestCase):
+    def setUp(self):
+        lab.reset()
+        self.ws_patch = patch.object(lab.base, "WsSession", lab.NavigationSession)
+        self.ws_patch.start()
+        self.server = lab.base.SafeThreadingHTTPServer(("127.0.0.1", 0), lab.NavigationHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.origin = f"http://127.0.0.1:{self.server.server_port}"
+        self.token = lab.base.mint_session_token()
+        self.sockets = []
+
+    def tearDown(self):
+        lab.RELEASE.set()
+        for sock in self.sockets:
+            sock.close()
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(2)
+        self.ws_patch.stop()
+
+    def control(self, body=None):
+        return _json_request(self.origin, "POST" if body else "GET", lab.CONTROL, body=body)[1]
+
+    def history(self, limit=100, offset=0):
+        return _json_request(self.origin, "GET",
+                             f"/api/sessions/e2e-session-1/messages?order=latest&limit={limit}&offset={offset}",
+                             token=self.token)[1]
+
+    def resume(self):
+        ticket = _json_request(self.origin, "POST", "/api/auth/ws-ticket", token=self.token)[1]["ticket"]
+        sock = _open_websocket(self.origin, ticket)
+        self.sockets.append(sock)
+        result = _rpc(sock, 1, "session.resume", {"session_id": "e2e-session-1"})
+        return sock, result
+
+    def drive(self, mode):
+        self.control({"action": "reset", "mode": mode})
+        self.assertEqual(self.history()["messages"], [])
+        first, _ = self.resume()
+        self.assertEqual(self.history()["messages"], [])
+        _, completion = _prompt_completion(first, 2, lab.PROMPT)
+        self.assertEqual(completion["text"], lab.ANSWER)
+        first.close()  # true socket leave; next socket is a new attachment
+        self.control({"action": "arm"})
+        initial = self.history()["messages"]
+        self.assertEqual(initial[-1]["content"], lab.ANSWER)
+        _, resumed = self.resume()
+        self.assertEqual(resumed["messages"][-1]["text"], lab.ANSWER)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            pending = pool.submit(self.history)
+            deadline = time.monotonic() + 1
+            while not self.control()["held"] and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertTrue(self.control()["held"])
+            self.assertFalse(pending.done())
+            self.control({"action": "release"})
+            followup = pending.result(timeout=2)["messages"]
+        state = self.control()
+        self.assertEqual(state["rpc_counts"]["session.resume"], 2)
+        self.assertEqual(state["rpc_counts"]["prompt.submit"], 1)
+        self.assertEqual([r["phase"] for r in state["reads"]],
+                         ["initial-or-other"] * 3 + ["post-resume"])
+        self.assertEqual(state["reads"][-1]["offset"], 0)
+        return initial, followup
+
+    def test_fresh_network_order_keeps_both_assistant_segments(self):
+        initial, followup = self.drive("fresh")
+        self.assertEqual(initial, followup)
+        self.assertEqual([r["role"] for r in followup], ["user", "assistant", "tool", "assistant"])
+
+    def test_stale_network_order_is_explicitly_synthetic(self):
+        initial, followup = self.drive("stale")
+        self.assertEqual(followup, initial[:3])
+        self.assertTrue(self.control()["synthetic"])
+
+    def test_duplicate_rows_and_latest_offsets_are_not_deduped_by_fake(self):
+        initial, followup = self.drive("duplicate")
+        self.assertEqual(initial, followup)
+        self.assertEqual(followup[-1]["content"], followup[-2]["content"])
+        self.assertNotEqual(followup[-1]["id"], followup[-2]["id"])
+        newest = self.history(limit=2)["messages"]
+        older = self.history(limit=2, offset=2)["messages"]
+        oldest = self.history(limit=2, offset=4)["messages"]
+        self.assertEqual([r["id"] for r in oldest + older + newest], [1, 2, 3, 4, 5])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Render internal background-process/delegation completion notices as collapsed, expandable Activity instead of user chat bubbles on Android and iOS. Preserve original message content, role, identity, assistant summaries, and presentation metadata through history, resume, relay adapters, and offline caches.
- Prevent a post-resume durable-history read from replacing a nonempty authoritative resume transcript. Continue refreshing progress and history cursors; retain full history fallback when resume has no display rows. Apply the same source-authority policy to iOS and Android's analogous idle direct recovery.
- Accept host-produced multiline encrypted push-preview bodies using shared field validation. Keep title/route control restrictions, byte bounds, key accessibility, crypto, replay, and privacy behavior unchanged.
- Recover Activity UI regression coverage for refresh/retry, saved-progress aging, and child dismissal/reappearance.

## Reproduction and regression evidence

### Reply disappears after leaving and reopening
The real navigation regression drives a synthetic server through initial response, native Back, reopening, resume, and a controlled follow-up history response. Before the fix, the full reply was visible after resume and then disappeared when the shorter durable response arrived. After the fix, all three unchanged navigation scenarios pass: fresh multisegment response, duplicate durable assistant rows, and the controlled stale post-resume read.

A disposable official SessionDB/installed relay-adapter probe also demonstrated that ancestor-inclusive resume and tip-only history can legitimately return different projections. This is contract evidence, not a claim that the reported live session used that exact compression lineage.

### Generic multiline push preview
Actual host-produced encrypted single-line previews passed while LF, host-normalized CRLF, and three-line previews failed the native opener with `malformedPlaintext`. The bundled ciphertext fixtures now pass through the native opener. Negative controls and title/route LF rejection remain covered.

PreviewKit now consumes the shared validator. An independent MercuryCore build producer and static PreviewKit linkage ensure the app and notification extension build cleanly without depending on a framework produced by an earlier app build.

## Verification

- `./gradlew testDebugUnitTest lintDebug assembleDebug :shared:mercury-core:check` — passed; **1,095 Android tests and 328 shared-core tests**, no failures or skips.
- Full Mercury iOS simulator build/test — **784 passed, 3 opt-in integration tests skipped, 0 failures**.
- Actual `FirstResponseNavigationBoundaryUITests` on iOS 18.4 — **3 passed, 0 skipped**, including the previously failing preservation assertion. Earlier iOS 26.5 UI-runner attempts failed accessibility initialization before test execution; the full main suite passed on iPhone 17 Pro/iOS 26.5.
- Independent clean PreviewKit and NotificationService builds — passed; focused native push suite **46 passed, 1 existing optional-vector skip**. New bundled multiline fixtures executed without skips.
- Synthetic HTTP/WebSocket fixture tests — **3 passed**.
- Signed physical-device build and in-place installation — verified. Final launch attempt was blocked by the phone being locked; no device-data reset. Real APNs arrival was not exercised as part of this gate.
- `git diff --check` — passed.

## Compatibility and scope

No changes to Hermes, custom server routes, relay requirement for direct mode, or history deletion. Locked-device/disabled-excerpt privacy fallback can still intentionally produce a generic notification. An exact user-pasted legacy completion envelope is indistinguishable without provenance metadata; its full text remains accessible in Activity.

The post-resume metadata-only read deliberately does not replace or augment authoritative display rows with durable-only tool rows. Initial loads, empty-resume fallback, explicit history replacement, and existing older-page behavior remain intact. No content-based merging or length-based freshness heuristic is introduced.

Private execution evidence, signing configuration, device identifiers, build output, and preserved local stashes are excluded from this PR.
